### PR TITLE
Add multi-targeted projects and example CLI

### DIFF
--- a/SectigoCertificateManager.CLI/Program.cs
+++ b/SectigoCertificateManager.CLI/Program.cs
@@ -1,0 +1,4 @@
+using SectigoCertificateManager;
+// See https://aka.ms/new-console-template for more information
+var obj = new Class1();
+Console.WriteLine($"CLI using {obj.Name}");

--- a/SectigoCertificateManager.CLI/SectigoCertificateManager.CLI.csproj
+++ b/SectigoCertificateManager.CLI/SectigoCertificateManager.CLI.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SectigoCertificateManager\SectigoCertificateManager.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -1,0 +1,4 @@
+using SectigoCertificateManager;
+// See https://aka.ms/new-console-template for more information
+var obj = new Class1();
+Console.WriteLine($"Example using {obj.Name}");

--- a/SectigoCertificateManager.Examples/SectigoCertificateManager.Examples.csproj
+++ b/SectigoCertificateManager.Examples/SectigoCertificateManager.Examples.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SectigoCertificateManager\SectigoCertificateManager.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SectigoCertificateManager.PowerShell/Class1.cs
+++ b/SectigoCertificateManager.PowerShell/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace SectigoCertificateManager.PowerShell;
+
+public class Class1
+{
+
+}

--- a/SectigoCertificateManager.PowerShell/SectigoCertificateManager.PowerShell.csproj
+++ b/SectigoCertificateManager.PowerShell/SectigoCertificateManager.PowerShell.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SectigoCertificateManager\SectigoCertificateManager.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj
+++ b/SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SectigoCertificateManager\SectigoCertificateManager.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/SectigoCertificateManager.Tests/UnitTest1.cs
+++ b/SectigoCertificateManager.Tests/UnitTest1.cs
@@ -1,0 +1,14 @@
+using SectigoCertificateManager;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+        var obj = new Class1();
+        Assert.Equal("Class1", obj.Name);
+    }
+}

--- a/SectigoCertificateManager.sln
+++ b/SectigoCertificateManager.sln
@@ -3,10 +3,86 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SectigoCertificateManager", "SectigoCertificateManager\SectigoCertificateManager.csproj", "{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SectigoCertificateManager.Tests", "SectigoCertificateManager.Tests\SectigoCertificateManager.Tests.csproj", "{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SectigoCertificateManager.PowerShell", "SectigoCertificateManager.PowerShell\SectigoCertificateManager.PowerShell.csproj", "{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SectigoCertificateManager.CLI", "SectigoCertificateManager.CLI\SectigoCertificateManager.CLI.csproj", "{B310FE0F-D82F-43B1-9FF3-E9199431EE71}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SectigoCertificateManager.Examples", "SectigoCertificateManager.Examples\SectigoCertificateManager.Examples.csproj", "{3B853C6C-B03F-4B62-8DD0-819119A61BEC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}.Debug|x64.Build.0 = Debug|Any CPU
+		{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}.Debug|x86.Build.0 = Debug|Any CPU
+		{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}.Release|x64.ActiveCfg = Release|Any CPU
+		{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}.Release|x64.Build.0 = Release|Any CPU
+		{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}.Release|x86.ActiveCfg = Release|Any CPU
+		{C077DE37-EB7D-45FE-97E7-D64EDB82BCA7}.Release|x86.Build.0 = Release|Any CPU
+		{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}.Debug|x64.Build.0 = Debug|Any CPU
+		{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}.Debug|x86.Build.0 = Debug|Any CPU
+		{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}.Release|x64.ActiveCfg = Release|Any CPU
+		{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}.Release|x64.Build.0 = Release|Any CPU
+		{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}.Release|x86.ActiveCfg = Release|Any CPU
+		{B6C6AF18-3A90-49D9-9FCC-5D2C0E3E383C}.Release|x86.Build.0 = Release|Any CPU
+		{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}.Debug|x64.Build.0 = Debug|Any CPU
+		{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}.Debug|x86.Build.0 = Debug|Any CPU
+		{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}.Release|x64.ActiveCfg = Release|Any CPU
+		{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}.Release|x64.Build.0 = Release|Any CPU
+		{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}.Release|x86.ActiveCfg = Release|Any CPU
+		{E6E0B4AC-2A93-4514-940B-1FCA37265E3C}.Release|x86.Build.0 = Release|Any CPU
+		{B310FE0F-D82F-43B1-9FF3-E9199431EE71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B310FE0F-D82F-43B1-9FF3-E9199431EE71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B310FE0F-D82F-43B1-9FF3-E9199431EE71}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B310FE0F-D82F-43B1-9FF3-E9199431EE71}.Debug|x64.Build.0 = Debug|Any CPU
+		{B310FE0F-D82F-43B1-9FF3-E9199431EE71}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B310FE0F-D82F-43B1-9FF3-E9199431EE71}.Debug|x86.Build.0 = Debug|Any CPU
+		{B310FE0F-D82F-43B1-9FF3-E9199431EE71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B310FE0F-D82F-43B1-9FF3-E9199431EE71}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B310FE0F-D82F-43B1-9FF3-E9199431EE71}.Release|x64.ActiveCfg = Release|Any CPU
+		{B310FE0F-D82F-43B1-9FF3-E9199431EE71}.Release|x64.Build.0 = Release|Any CPU
+		{B310FE0F-D82F-43B1-9FF3-E9199431EE71}.Release|x86.ActiveCfg = Release|Any CPU
+		{B310FE0F-D82F-43B1-9FF3-E9199431EE71}.Release|x86.Build.0 = Release|Any CPU
+		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Debug|x64.Build.0 = Debug|Any CPU
+		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Debug|x86.Build.0 = Debug|Any CPU
+		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Release|x64.ActiveCfg = Release|Any CPU
+		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Release|x64.Build.0 = Release|Any CPU
+		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Release|x86.ActiveCfg = Release|Any CPU
+		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SectigoCertificateManager/Class1.cs
+++ b/SectigoCertificateManager/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace SectigoCertificateManager;
+
+public class Class1
+{
+    public string Name => nameof(Class1);
+}

--- a/SectigoCertificateManager/SectigoCertificateManager.csproj
+++ b/SectigoCertificateManager/SectigoCertificateManager.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- create SectigoCertificateManager class library and multi-target for net472, netstandard2.0, net8.0 and net9.0
- add xUnit test project targeting net472, net8.0 and net9.0
- add PowerShell, CLI and Examples projects
- wire up project references and add simple example code

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68662935508c832e9de6f9d45e97ac78