### PR TITLE
Enable analyzer config and warnings as errors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <ItemGroup>
+    <AnalyzerConfigFiles Include="$(MSBuildThisFileDirectory).editorconfig" />
+  </ItemGroup>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- enable nullable and treat warnings as errors project-wide
- reference `.editorconfig` for style rules

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68662f40885c832e94511a66418e351d