### PR TITLE
Implement SectigoClient using HttpClient

### DIFF
--- a/SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj
+++ b/SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj
@@ -23,4 +23,8 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
 </Project>

--- a/SectigoCertificateManager.Tests/UnitTest1.cs
+++ b/SectigoCertificateManager.Tests/UnitTest1.cs
@@ -1,4 +1,6 @@
 using SectigoCertificateManager;
+using System.Linq;
+using System.Net.Http;
 using Xunit;
 
 namespace SectigoCertificateManager.Tests;
@@ -10,5 +12,21 @@ public class UnitTest1
     {
         var obj = new Class1();
         Assert.Equal("Class1", obj.Name);
+    }
+
+    [Fact]
+    public void SectigoClientAddsDefaultHeaders()
+    {
+        var config = new ApiConfig("https://example.com", "user", "pass", "cst1", ApiVersion.V25_4);
+        var httpClient = new HttpClient();
+        var client = new SectigoClient(config, httpClient);
+
+        Assert.True(httpClient.DefaultRequestHeaders.Contains("login"));
+        Assert.True(httpClient.DefaultRequestHeaders.Contains("password"));
+        Assert.True(httpClient.DefaultRequestHeaders.Contains("customerUri"));
+
+        Assert.Equal("user", httpClient.DefaultRequestHeaders.GetValues("login").Single());
+        Assert.Equal("pass", httpClient.DefaultRequestHeaders.GetValues("password").Single());
+        Assert.Equal("cst1", httpClient.DefaultRequestHeaders.GetValues("customerUri").Single());
     }
 }

--- a/SectigoCertificateManager/ApiConfig.cs
+++ b/SectigoCertificateManager/ApiConfig.cs
@@ -6,8 +6,9 @@ namespace SectigoCertificateManager;
 /// <param name="baseUrl">Base URL of the API endpoint.</param>
 /// <param name="username">User account used for authentication.</param>
 /// <param name="password">Password associated with <paramref name="username"/>.</param>
+/// <param name="customerUri">Value for the <c>customerUri</c> HTTP header.</param>
 /// <param name="apiVersion">Version of the API to use.</param>
-public sealed class ApiConfig(string baseUrl, string username, string password, ApiVersion apiVersion)
+public sealed class ApiConfig(string baseUrl, string username, string password, string customerUri, ApiVersion apiVersion)
 {
     /// <summary>
     /// Gets the base URL of the API endpoint.
@@ -22,7 +23,13 @@ public sealed class ApiConfig(string baseUrl, string username, string password, 
     /// <summary>
     /// Gets the password associated with the <see cref="Username"/> property.
     /// </summary>
+
     public string Password { get; } = password;
+
+    /// <summary>
+    /// Gets the customer URI part used for API calls.
+    /// </summary>
+    public string CustomerUri { get; } = customerUri;
 
     /// <summary>
     /// Gets the API version that should be used.

--- a/SectigoCertificateManager/ISectigoClient.cs
+++ b/SectigoCertificateManager/ISectigoClient.cs
@@ -1,0 +1,17 @@
+namespace SectigoCertificateManager;
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+public interface ISectigoClient
+{
+    HttpClient HttpClient { get; }
+    Task<HttpResponseMessage> GetAsync(string requestUri, CancellationToken cancellationToken = default);
+
+    Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default);
+
+    Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default);
+
+    Task<HttpResponseMessage> DeleteAsync(string requestUri, CancellationToken cancellationToken = default);
+}

--- a/SectigoCertificateManager/SectigoCertificateManager.csproj
+++ b/SectigoCertificateManager/SectigoCertificateManager.csproj
@@ -7,4 +7,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
 </Project>

--- a/SectigoCertificateManager/SectigoClient.cs
+++ b/SectigoCertificateManager/SectigoClient.cs
@@ -1,0 +1,42 @@
+namespace SectigoCertificateManager;
+
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+public sealed class SectigoClient : ISectigoClient
+{
+    private readonly HttpClient _client;
+
+    public HttpClient HttpClient => _client;
+
+    public SectigoClient(ApiConfig config, HttpClient? httpClient = null)
+    {
+        _client = httpClient ?? new HttpClient();
+        _client.BaseAddress = new Uri(config.BaseUrl);
+        ConfigureHeaders(config);
+    }
+
+    public Task<HttpResponseMessage> GetAsync(string requestUri, CancellationToken cancellationToken = default)
+        => _client.GetAsync(requestUri, cancellationToken);
+
+    public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default)
+        => _client.PostAsync(requestUri, content, cancellationToken);
+
+    public Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default)
+        => _client.PutAsync(requestUri, content, cancellationToken);
+
+    public Task<HttpResponseMessage> DeleteAsync(string requestUri, CancellationToken cancellationToken = default)
+        => _client.DeleteAsync(requestUri, cancellationToken);
+
+    private void ConfigureHeaders(ApiConfig cfg)
+    {
+        _client.DefaultRequestHeaders.Clear();
+        _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        _client.DefaultRequestHeaders.Add("login", cfg.Username);
+        _client.DefaultRequestHeaders.Add("password", cfg.Password);
+        _client.DefaultRequestHeaders.Add("customerUri", cfg.CustomerUri);
+    }
+}


### PR DESCRIPTION
## Summary
- define `ISectigoClient` with simple HTTP methods
- implement `SectigoClient` that sets default headers (`login`, `password`, `customerUri`)
- extend `ApiConfig` to include `CustomerUri`
- update tests to verify header configuration

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6866382b26dc832e8d998209c4972cc9