### PR TITLE
Add fluent configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# SectigoCertificateManager
+
+
+
+This library provides a simple client for the Sectigo Certificate Manager API.
+
+
+
+## Fluent API
+
+
+
+Create an `ApiConfig` using the fluent builder:
+
+
+
+```csharp
+
+var config = new ApiConfigBuilder()
+
+    .WithBaseUrl("https://example.com")
+
+    .WithCredentials("user", "pass")
+
+    .WithCustomerUri("cst1")
+
+    .WithApiVersion(ApiVersion.V25_5)
+
+    .Build();
+
+```
+
+
+
+Use the resulting `ApiConfig` to instantiate `SectigoClient`.
+

--- a/SectigoCertificateManager.Tests/UnitTest1.cs
+++ b/SectigoCertificateManager.Tests/UnitTest1.cs
@@ -29,4 +29,21 @@ public class UnitTest1
         Assert.Equal("pass", httpClient.DefaultRequestHeaders.GetValues("password").Single());
         Assert.Equal("cst1", httpClient.DefaultRequestHeaders.GetValues("customerUri").Single());
     }
+
+    [Fact]
+    public void ApiConfigBuilderCreatesValidConfig()
+    {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://example.com")
+            .WithCredentials("user", "pass")
+            .WithCustomerUri("cst1")
+            .WithApiVersion(ApiVersion.V25_5)
+            .Build();
+
+        Assert.Equal("https://example.com", config.BaseUrl);
+        Assert.Equal("user", config.Username);
+        Assert.Equal("pass", config.Password);
+        Assert.Equal("cst1", config.CustomerUri);
+        Assert.Equal(ApiVersion.V25_5, config.ApiVersion);
+    }
 }

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -1,0 +1,132 @@
+namespace SectigoCertificateManager;
+
+
+
+/// <summary>
+
+/// Provides a builder for creating instances of <see cref="ApiConfig"/> using a fluent API.
+
+/// </summary>
+
+public sealed class ApiConfigBuilder
+
+{
+
+    private string _baseUrl = string.Empty;
+
+    private string _username = string.Empty;
+
+    private string _password = string.Empty;
+
+    private string _customerUri = string.Empty;
+
+    private ApiVersion _apiVersion = ApiVersion.V25_4;
+
+
+
+    /// <summary>
+
+    /// Sets the base URL for the API endpoint.
+
+    /// </summary>
+
+    /// <param name="baseUrl">Base URL of the API.</param>
+
+    /// <returns>The builder instance.</returns>
+
+    public ApiConfigBuilder WithBaseUrl(string baseUrl)
+
+    {
+
+        _baseUrl = baseUrl;
+
+        return this;
+
+    }
+
+
+
+    /// <summary>
+
+    /// Sets the credentials used for authentication.
+
+    /// </summary>
+
+    /// <param name="username">User name.</param>
+
+    /// <param name="password">Password.</param>
+
+    /// <returns>The builder instance.</returns>
+
+    public ApiConfigBuilder WithCredentials(string username, string password)
+
+    {
+
+        _username = username;
+
+        _password = password;
+
+        return this;
+
+    }
+
+
+
+    /// <summary>
+
+    /// Sets the customer URI header value.
+
+    /// </summary>
+
+    /// <param name="customerUri">Customer URI value.</param>
+
+    /// <returns>The builder instance.</returns>
+
+    public ApiConfigBuilder WithCustomerUri(string customerUri)
+
+    {
+
+        _customerUri = customerUri;
+
+        return this;
+
+    }
+
+
+
+    /// <summary>
+
+    /// Sets the API version.
+
+    /// </summary>
+
+    /// <param name="version">Version of the API.</param>
+
+    /// <returns>The builder instance.</returns>
+
+    public ApiConfigBuilder WithApiVersion(ApiVersion version)
+
+    {
+
+        _apiVersion = version;
+
+        return this;
+
+    }
+
+
+
+    /// <summary>
+
+    /// Builds a new <see cref="ApiConfig"/> instance using configured values.
+
+    /// </summary>
+
+    /// <returns>An <see cref="ApiConfig"/>.</returns>
+
+    public ApiConfig Build()
+
+        => new ApiConfig(_baseUrl, _username, _password, _customerUri, _apiVersion);
+
+}
+


### PR DESCRIPTION
## Summary
- add `ApiConfigBuilder` for building configuration with a fluent API
- document fluent API usage in README
- cover builder usage with unit tests

## Testing
- `dotnet build SectigoCertificateManager.sln --no-restore --configuration Debug`
- `dotnet test SectigoCertificateManager.sln --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68663fabc2b4832e92c9307425300a57