### PR TITLE
Add typed API clients

### DIFF
--- a/SectigoCertificateManager/CertificateStatus.cs
+++ b/SectigoCertificateManager/CertificateStatus.cs
@@ -1,0 +1,28 @@
+namespace SectigoCertificateManager;
+
+/// <summary>
+/// Enumerates statuses for certificates.
+/// </summary>
+public enum CertificateStatus
+{
+    /// <summary>Any status.</summary>
+    Any = 0,
+
+    /// <summary>Request for certificate has been submitted.</summary>
+    Requested = 1,
+
+    /// <summary>The certificate has been approved.</summary>
+    Approved = 8,
+
+    /// <summary>The certificate request was applied.</summary>
+    Applied = 9,
+
+    /// <summary>The certificate has been issued.</summary>
+    Issued = 2,
+
+    /// <summary>The certificate has been revoked.</summary>
+    Revoked = 3,
+
+    /// <summary>The certificate has expired.</summary>
+    Expired = 4
+}

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -1,0 +1,40 @@
+namespace SectigoCertificateManager.Clients;
+
+using System.Net.Http.Json;
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Requests;
+using SectigoCertificateManager.Responses;
+
+/// <summary>
+/// Provides access to certificate related endpoints.
+/// </summary>
+public sealed class CertificatesClient
+{
+    private readonly ISectigoClient _client;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CertificatesClient"/> class.
+    /// </summary>
+    /// <param name="client">HTTP client wrapper.</param>
+    public CertificatesClient(ISectigoClient client) => _client = client;
+
+    /// <summary>
+    /// Retrieves a certificate by identifier.
+    /// </summary>
+    public async Task<Certificate?> GetAsync(int certificateId, CancellationToken cancellationToken = default)
+    {
+        var response = await _client.GetAsync($"v1/certificate/{certificateId}", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<Certificate>(cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Issues a new certificate.
+    /// </summary>
+    public async Task<Certificate?> IssueAsync(IssueCertificateRequest request, CancellationToken cancellationToken = default)
+    {
+        var response = await _client.PostAsync("v1/certificate/issue", JsonContent.Create(request), cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<Certificate>(cancellationToken: cancellationToken);
+    }
+}

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -1,0 +1,29 @@
+namespace SectigoCertificateManager.Clients;
+
+using System.Net.Http.Json;
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Responses;
+
+/// <summary>
+/// Provides access to order related endpoints.
+/// </summary>
+public sealed class OrdersClient
+{
+    private readonly ISectigoClient _client;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrdersClient"/> class.
+    /// </summary>
+    /// <param name="client">HTTP client wrapper.</param>
+    public OrdersClient(ISectigoClient client) => _client = client;
+
+    /// <summary>
+    /// Retrieves an order by identifier.
+    /// </summary>
+    public async Task<Order?> GetAsync(int orderId, CancellationToken cancellationToken = default)
+    {
+        var response = await _client.GetAsync($"v1/order/{orderId}", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<Order>(cancellationToken: cancellationToken);
+    }
+}

--- a/SectigoCertificateManager/Clients/ProfilesClient.cs
+++ b/SectigoCertificateManager/Clients/ProfilesClient.cs
@@ -1,0 +1,28 @@
+namespace SectigoCertificateManager.Clients;
+
+using System.Net.Http.Json;
+using SectigoCertificateManager.Models;
+
+/// <summary>
+/// Provides access to profile related endpoints.
+/// </summary>
+public sealed class ProfilesClient
+{
+    private readonly ISectigoClient _client;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProfilesClient"/> class.
+    /// </summary>
+    /// <param name="client">HTTP client wrapper.</param>
+    public ProfilesClient(ISectigoClient client) => _client = client;
+
+    /// <summary>
+    /// Retrieves a profile by identifier.
+    /// </summary>
+    public async Task<Profile?> GetAsync(int profileId, CancellationToken cancellationToken = default)
+    {
+        var response = await _client.GetAsync($"v1/profile/{profileId}", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<Profile>(cancellationToken: cancellationToken);
+    }
+}

--- a/SectigoCertificateManager/Models/Certificate.cs
+++ b/SectigoCertificateManager/Models/Certificate.cs
@@ -1,6 +1,7 @@
 namespace SectigoCertificateManager.Models;
 
 using System.Collections.Generic;
+using SectigoCertificateManager;
 
 public sealed class Certificate
 {
@@ -10,7 +11,7 @@ public sealed class Certificate
 
     public int OrgId { get; set; }
 
-    public string Status { get; set; } = string.Empty;
+    public CertificateStatus Status { get; set; } = CertificateStatus.Any;
 
     public long OrderNumber { get; set; }
 

--- a/SectigoCertificateManager/Models/Order.cs
+++ b/SectigoCertificateManager/Models/Order.cs
@@ -1,9 +1,11 @@
 namespace SectigoCertificateManager.Models;
 
+using SectigoCertificateManager;
+
 public sealed class Order
 {
     public int Id { get; set; }
-    public string Status { get; set; } = string.Empty;
+    public OrderStatus Status { get; set; }
     public string BackendCertId { get; set; } = string.Empty;
     public int OrderNumber { get; set; }
 }

--- a/SectigoCertificateManager/OrderStatus.cs
+++ b/SectigoCertificateManager/OrderStatus.cs
@@ -1,0 +1,19 @@
+namespace SectigoCertificateManager;
+
+/// <summary>
+/// Enumerates statuses for certificate orders.
+/// </summary>
+public enum OrderStatus
+{
+    /// <summary>Order is not initiated.</summary>
+    NotInitiated,
+
+    /// <summary>Order was submitted.</summary>
+    Submitted,
+
+    /// <summary>Order was completed.</summary>
+    Completed,
+
+    /// <summary>Order was cancelled.</summary>
+    Cancelled
+}

--- a/SectigoCertificateManager/Requests/IssueCertificateRequest.cs
+++ b/SectigoCertificateManager/Requests/IssueCertificateRequest.cs
@@ -1,0 +1,29 @@
+namespace SectigoCertificateManager.Requests;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Request payload used when issuing a new certificate.
+/// </summary>
+public sealed class IssueCertificateRequest
+{
+    /// <summary>
+    /// Gets or sets the common name of the certificate.
+    /// </summary>
+    public string CommonName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the identifier of the profile to use.
+    /// </summary>
+    public int ProfileId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the term of the certificate.
+    /// </summary>
+    public int Term { get; set; }
+
+    /// <summary>
+    /// Gets or sets subject alternative names.
+    /// </summary>
+    public IReadOnlyList<string> SubjectAlternativeNames { get; set; } = [];
+}

--- a/SectigoCertificateManager/Responses/CertificateResponse.cs
+++ b/SectigoCertificateManager/Responses/CertificateResponse.cs
@@ -1,0 +1,15 @@
+namespace SectigoCertificateManager.Responses;
+
+using SectigoCertificateManager.Models;
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents a response containing certificates.
+/// </summary>
+public sealed class CertificateResponse
+{
+    /// <summary>
+    /// Gets or sets certificates returned by the API.
+    /// </summary>
+    public IReadOnlyList<Certificate> Certificates { get; set; } = [];
+}

--- a/SectigoCertificateManager/Responses/OrderResponse.cs
+++ b/SectigoCertificateManager/Responses/OrderResponse.cs
@@ -1,0 +1,14 @@
+namespace SectigoCertificateManager.Responses;
+
+using SectigoCertificateManager.Models;
+
+/// <summary>
+/// Represents a response containing a certificate order.
+/// </summary>
+public sealed class OrderResponse
+{
+    /// <summary>
+    /// Gets or sets the order information.
+    /// </summary>
+    public Order? Order { get; set; }
+}

--- a/SectigoCertificateManager/Responses/ProfileResponse.cs
+++ b/SectigoCertificateManager/Responses/ProfileResponse.cs
@@ -1,0 +1,14 @@
+namespace SectigoCertificateManager.Responses;
+
+using SectigoCertificateManager.Models;
+
+/// <summary>
+/// Represents a response containing profile information.
+/// </summary>
+public sealed class ProfileResponse
+{
+    /// <summary>
+    /// Gets or sets the profile.
+    /// </summary>
+    public Profile? Profile { get; set; }
+}

--- a/SectigoCertificateManager/SectigoCertificateManager.csproj
+++ b/SectigoCertificateManager/SectigoCertificateManager.csproj
@@ -11,4 +11,8 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add status enums for orders and certificates
- create typed requests and responses
- implement CertificatesClient, OrdersClient, and ProfilesClient
- integrate System.Net.Http.Json for net472/netstandard

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6866511647e4832e9fc7dccf6bbee400