### PR TITLE
Update README with API version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 This library provides a simple client for the Sectigo Certificate Manager API.
 
+The library defaults to **API version 25.4** as defined in `ApiConfigBuilder`.
+Support for version 25.5 is also available via `ApiVersion.V25_5`.
+
+## Documentation
+
+HTML copies of the official API reference are included in the repository:
+
+- [certmgr-api-doc-25.4.html](Documentation/certmgr-api-doc-25.4.html)
+- [certmgr-api-doc-25.5.html](Documentation/certmgr-api-doc-25.5.html)
+
+
 
 
 ## Fluent API


### PR DESCRIPTION
## Summary
- note default API version 25.4
- link to included API documentation

## Testing
- `dotnet build SectigoCertificateManager.sln --no-restore`
- `dotnet test SectigoCertificateManager.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_686654f57efc832e84dcb568c58930df