### PR TITLE
Add dedicated example class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,3 +410,7 @@ FodyWeavers.xsd
 # Additional files built by Visual Studio
 
 # End of https://www.toptal.com/developers/gitignore/api/powershell,visualstudio
+
+# Local build and packaging artifacts
+dotnet-install.sh
+packages-microsoft-prod.deb

--- a/SectigoCertificateManager.Examples/Examples/BasicApiExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/BasicApiExample.cs
@@ -1,0 +1,31 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Requests;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates configuring the API client and retrieving a certificate.
+/// Credentials are generated in the Sectigo Certificate Manager portal.
+/// Navigate to <strong>Administration</strong> \u2192 <strong>Users</strong>, edit your user
+/// and create API credentials. Use the generated login and password below.
+/// </summary>
+public static class BasicApiExample
+{
+    public static async Task RunAsync()
+    {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_5)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+
+        Console.WriteLine("Requesting certificate details...");
+        var certificate = await certificates.GetAsync(12345);
+        Console.WriteLine($"Common name: {certificate?.CommonName}");
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -1,4 +1,3 @@
-using SectigoCertificateManager;
-// See https://aka.ms/new-console-template for more information
-var obj = new Class1();
-Console.WriteLine($"Example using {obj.Name}");
+using SectigoCertificateManager.Examples.Examples;
+
+await BasicApiExample.RunAsync();


### PR DESCRIPTION
## Summary
- ignore local packaging scripts
- place example code in a separate `BasicApiExample` class
- call example from `Program.cs`

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_686654e8bc60832eb37eda617c84dd86