### PR TITLE
Refactor ApiVersion enum

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
@@ -43,4 +43,21 @@ public sealed class ApiConfigLoaderTests
         Environment.SetEnvironmentVariable("SECTIGO_CUSTOMER_URI", null);
         Environment.SetEnvironmentVariable("SECTIGO_API_VERSION", null);
     }
+
+    [Fact]
+    public void Load_UsesDefaultPathFromEnvironment()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var path = Path.Combine(tempDir, "cred.json");
+        File.WriteAllText(path, "{\"baseUrl\":\"https://example.com\",\"username\":\"user\",\"password\":\"pass\",\"customerUri\":\"cst1\"}");
+        Environment.SetEnvironmentVariable("SECTIGO_CREDENTIALS_PATH", path);
+
+        var config = ApiConfigLoader.Load();
+
+        Assert.Equal("https://example.com", config.BaseUrl);
+
+        Environment.SetEnvironmentVariable("SECTIGO_CREDENTIALS_PATH", null);
+        Directory.Delete(tempDir, true);
+    }
 }

--- a/SectigoCertificateManager/ApiConfig.cs
+++ b/SectigoCertificateManager/ApiConfig.cs
@@ -37,18 +37,3 @@ public sealed class ApiConfig(string baseUrl, string username, string password, 
     public ApiVersion ApiVersion { get; } = apiVersion;
 }
 
-/// <summary>
-/// Enumerates available Sectigo Certificate Manager API versions.
-/// </summary>
-public enum ApiVersion
-{
-    /// <summary>
-    /// Version 25.4 of the API.
-    /// </summary>
-    V25_4,
-
-    /// <summary>
-    /// Version 25.5 of the API.
-    /// </summary>
-    V25_5,
-}

--- a/SectigoCertificateManager/ApiVersion.cs
+++ b/SectigoCertificateManager/ApiVersion.cs
@@ -1,0 +1,17 @@
+namespace SectigoCertificateManager;
+
+/// <summary>
+/// Enumerates available Sectigo Certificate Manager API versions.
+/// </summary>
+public enum ApiVersion
+{
+    /// <summary>
+    /// Version 25.4 of the API.
+    /// </summary>
+    V25_4,
+
+    /// <summary>
+    /// Version 25.5 of the API.
+    /// </summary>
+    V25_5,
+}


### PR DESCRIPTION
## Summary
- extract `ApiVersion` enum to its own file
- test that the config loader resolves default credential path from environment

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6866b86a0148832eb6b39246418cd9d9