### PR TITLE
Use ConfigureAwait in client methods

### DIFF
--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -23,9 +23,9 @@ public sealed class CertificatesClient
     /// </summary>
     public async Task<Certificate?> GetAsync(int certificateId, CancellationToken cancellationToken = default)
     {
-        var response = await _client.GetAsync($"v1/certificate/{certificateId}", cancellationToken);
+        var response = await _client.GetAsync($"v1/certificate/{certificateId}", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<Certificate>(cancellationToken: cancellationToken);
+        return await response.Content.ReadFromJsonAsync<Certificate>(cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -33,8 +33,8 @@ public sealed class CertificatesClient
     /// </summary>
     public async Task<Certificate?> IssueAsync(IssueCertificateRequest request, CancellationToken cancellationToken = default)
     {
-        var response = await _client.PostAsync("v1/certificate/issue", JsonContent.Create(request), cancellationToken);
+        var response = await _client.PostAsync("v1/certificate/issue", JsonContent.Create(request), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<Certificate>(cancellationToken: cancellationToken);
+        return await response.Content.ReadFromJsonAsync<Certificate>(cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -22,8 +22,8 @@ public sealed class OrdersClient
     /// </summary>
     public async Task<Order?> GetAsync(int orderId, CancellationToken cancellationToken = default)
     {
-        var response = await _client.GetAsync($"v1/order/{orderId}", cancellationToken);
+        var response = await _client.GetAsync($"v1/order/{orderId}", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<Order>(cancellationToken: cancellationToken);
+        return await response.Content.ReadFromJsonAsync<Order>(cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/SectigoCertificateManager/Clients/ProfilesClient.cs
+++ b/SectigoCertificateManager/Clients/ProfilesClient.cs
@@ -21,8 +21,8 @@ public sealed class ProfilesClient
     /// </summary>
     public async Task<Profile?> GetAsync(int profileId, CancellationToken cancellationToken = default)
     {
-        var response = await _client.GetAsync($"v1/profile/{profileId}", cancellationToken);
+        var response = await _client.GetAsync($"v1/profile/{profileId}", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<Profile>(cancellationToken: cancellationToken);
+        return await response.Content.ReadFromJsonAsync<Profile>(cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary
- avoid context capturing in `CertificatesClient`, `OrdersClient`, and `ProfilesClient`
- confirm tests pass

## Testing
- `dotnet test`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68676b8b3394832e8b54a621aa90d65b