### PR TITLE
Add required value validation for ApiConfigBuilder

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
@@ -1,0 +1,38 @@
+using SectigoCertificateManager;
+using System;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+public sealed class ApiConfigBuilderTests
+{
+    [Fact]
+    public void BuildThrowsWithoutBaseUrl()
+    {
+        var builder = new ApiConfigBuilder()
+            .WithCredentials("user", "pass")
+            .WithCustomerUri("cst1");
+
+        Assert.Throws<ArgumentException>(() => builder.Build());
+    }
+
+    [Fact]
+    public void BuildThrowsWithoutCredentials()
+    {
+        var builder = new ApiConfigBuilder()
+            .WithBaseUrl("https://example.com")
+            .WithCustomerUri("cst1");
+
+        Assert.Throws<ArgumentException>(() => builder.Build());
+    }
+
+    [Fact]
+    public void BuildThrowsWithoutCustomerUri()
+    {
+        var builder = new ApiConfigBuilder()
+            .WithBaseUrl("https://example.com")
+            .WithCredentials("user", "pass");
+
+        Assert.Throws<ArgumentException>(() => builder.Build());
+    }
+}

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -62,5 +62,27 @@ public sealed class ApiConfigBuilder
 
     /// <summary>Builds a new <see cref="ApiConfig"/> instance using configured values.</summary>
     public ApiConfig Build()
-        => new ApiConfig(_baseUrl, _username, _password, _customerUri, _apiVersion, _clientCertificate, _configureHandler);
+    {
+        if (string.IsNullOrWhiteSpace(_baseUrl))
+        {
+            throw new ArgumentException("Base URL is required.", nameof(_baseUrl));
+        }
+
+        if (string.IsNullOrWhiteSpace(_username))
+        {
+            throw new ArgumentException("User name is required.", nameof(_username));
+        }
+
+        if (string.IsNullOrWhiteSpace(_password))
+        {
+            throw new ArgumentException("Password is required.", nameof(_password));
+        }
+
+        if (string.IsNullOrWhiteSpace(_customerUri))
+        {
+            throw new ArgumentException("Customer URI is required.", nameof(_customerUri));
+        }
+
+        return new ApiConfig(_baseUrl, _username, _password, _customerUri, _apiVersion, _clientCertificate, _configureHandler);
+    }
 }


### PR DESCRIPTION
## Summary
- add null/empty checks in `ApiConfigBuilder.Build`
- add unit tests ensuring `ApiConfigBuilder` throws when required data is missing

## Testing
- `dotnet test`
- `dotnet build -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_68676b84799c832e9cab01c8b130ba8e