### PR TITLE
Add XML docs for API

### DIFF
--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -18,6 +18,7 @@ public sealed class ApiConfigBuilder
     private Action<HttpClientHandler>? _configureHandler;
 
     /// <summary>Sets the base URL for the API endpoint.</summary>
+    /// <param name="baseUrl">The root URL of the Sectigo API.</param>
     public ApiConfigBuilder WithBaseUrl(string baseUrl)
     {
         _baseUrl = baseUrl;
@@ -25,6 +26,8 @@ public sealed class ApiConfigBuilder
     }
 
     /// <summary>Sets the credentials used for authentication.</summary>
+    /// <param name="username">User name for API authentication.</param>
+    /// <param name="password">Password associated with <paramref name="username"/>.</param>
     public ApiConfigBuilder WithCredentials(string username, string password)
     {
         _username = username;
@@ -33,6 +36,7 @@ public sealed class ApiConfigBuilder
     }
 
     /// <summary>Sets the customer URI header value.</summary>
+    /// <param name="customerUri">Value of the <c>customerUri</c> header.</param>
     public ApiConfigBuilder WithCustomerUri(string customerUri)
     {
         _customerUri = customerUri;
@@ -40,6 +44,7 @@ public sealed class ApiConfigBuilder
     }
 
     /// <summary>Sets the API version.</summary>
+    /// <param name="version">Desired API version.</param>
     public ApiConfigBuilder WithApiVersion(ApiVersion version)
     {
         _apiVersion = version;
@@ -47,6 +52,7 @@ public sealed class ApiConfigBuilder
     }
 
     /// <summary>Attaches a client certificate for mutual TLS authentication.</summary>
+    /// <param name="certificate">The certificate used for client authentication.</param>
     public ApiConfigBuilder WithClientCertificate(X509Certificate2 certificate)
     {
         _clientCertificate = certificate;
@@ -54,6 +60,7 @@ public sealed class ApiConfigBuilder
     }
 
     /// <summary>Allows configuration of the <see cref="HttpClientHandler"/> used by <see cref="SectigoClient"/>.</summary>
+    /// <param name="configure">Delegate used to configure the handler.</param>
     public ApiConfigBuilder WithHttpClientHandler(Action<HttpClientHandler> configure)
     {
         _configureHandler = configure;

--- a/SectigoCertificateManager/ApiConfigLoader.cs
+++ b/SectigoCertificateManager/ApiConfigLoader.cs
@@ -11,10 +11,19 @@ public static class ApiConfigLoader
 {
     private sealed class FileModel
     {
+        /// <summary>Gets or sets the base URL.</summary>
         public string BaseUrl { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the username.</summary>
         public string Username { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the password.</summary>
         public string Password { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the customer URI.</summary>
         public string CustomerUri { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the API version string.</summary>
         public string ApiVersion { get; set; } = "V25_4";
     }
 

--- a/SectigoCertificateManager/ApiErrorHandler.cs
+++ b/SectigoCertificateManager/ApiErrorHandler.cs
@@ -5,8 +5,15 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Handles API error responses.
+/// </summary>
 internal static class ApiErrorHandler
 {
+    /// <summary>
+    /// Throws an exception if the response indicates an error.
+    /// </summary>
+    /// <param name="response">HTTP response message.</param>
     public static async Task ThrowIfErrorAsync(HttpResponseMessage response)
     {
         if (response.IsSuccessStatusCode)

--- a/SectigoCertificateManager/Class1.cs
+++ b/SectigoCertificateManager/Class1.cs
@@ -1,6 +1,10 @@
 ﻿namespace SectigoCertificateManager;
 
+/// <summary>
+/// Example class used for testing purposes.
+/// </summary>
 public class Class1
 {
+    /// <summary>Gets the name of the class.</summary>
     public string Name => nameof(Class1);
 }

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -21,6 +21,8 @@ public sealed class CertificatesClient
     /// <summary>
     /// Retrieves a certificate by identifier.
     /// </summary>
+    /// <param name="certificateId">Identifier of the certificate to retrieve.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Certificate?> GetAsync(int certificateId, CancellationToken cancellationToken = default)
     {
         var response = await _client.GetAsync($"v1/certificate/{certificateId}", cancellationToken);
@@ -31,6 +33,8 @@ public sealed class CertificatesClient
     /// <summary>
     /// Issues a new certificate.
     /// </summary>
+    /// <param name="request">Payload describing the certificate to issue.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Certificate?> IssueAsync(IssueCertificateRequest request, CancellationToken cancellationToken = default)
     {
         var response = await _client.PostAsync("v1/certificate/issue", JsonContent.Create(request), cancellationToken);

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -20,6 +20,8 @@ public sealed class OrdersClient
     /// <summary>
     /// Retrieves an order by identifier.
     /// </summary>
+    /// <param name="orderId">Identifier of the order to retrieve.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Order?> GetAsync(int orderId, CancellationToken cancellationToken = default)
     {
         var response = await _client.GetAsync($"v1/order/{orderId}", cancellationToken);

--- a/SectigoCertificateManager/Clients/ProfilesClient.cs
+++ b/SectigoCertificateManager/Clients/ProfilesClient.cs
@@ -19,6 +19,8 @@ public sealed class ProfilesClient
     /// <summary>
     /// Retrieves a profile by identifier.
     /// </summary>
+    /// <param name="profileId">Identifier of the profile to retrieve.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Profile?> GetAsync(int profileId, CancellationToken cancellationToken = default)
     {
         var response = await _client.GetAsync($"v1/profile/{profileId}", cancellationToken);

--- a/SectigoCertificateManager/ISectigoClient.cs
+++ b/SectigoCertificateManager/ISectigoClient.cs
@@ -4,14 +4,42 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Defines a minimal wrapper around <see cref="HttpClient"/> used by this library.
+/// </summary>
 public interface ISectigoClient
 {
+    /// <summary>
+    /// Gets the underlying <see cref="HttpClient"/> instance.
+    /// </summary>
     HttpClient HttpClient { get; }
+    /// <summary>
+    /// Sends a GET request.
+    /// </summary>
+    /// <param name="requestUri">Relative request URI.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task<HttpResponseMessage> GetAsync(string requestUri, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Sends a POST request.
+    /// </summary>
+    /// <param name="requestUri">Relative request URI.</param>
+    /// <param name="content">HTTP content to send.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Sends a PUT request.
+    /// </summary>
+    /// <param name="requestUri">Relative request URI.</param>
+    /// <param name="content">HTTP content to send.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Sends a DELETE request.
+    /// </summary>
+    /// <param name="requestUri">Relative request URI.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     Task<HttpResponseMessage> DeleteAsync(string requestUri, CancellationToken cancellationToken = default);
 }

--- a/SectigoCertificateManager/Models/Certificate.cs
+++ b/SectigoCertificateManager/Models/Certificate.cs
@@ -3,45 +3,68 @@ namespace SectigoCertificateManager.Models;
 using System.Collections.Generic;
 using SectigoCertificateManager;
 
+/// <summary>
+/// Represents a certificate returned by the Sectigo API.
+/// </summary>
 public sealed class Certificate
 {
+    /// <summary>Gets or sets the identifier of the certificate.</summary>
     public int Id { get; set; }
 
+    /// <summary>Gets or sets the common name of the certificate.</summary>
     public string? CommonName { get; set; }
 
+    /// <summary>Gets or sets the organization identifier.</summary>
     public int OrgId { get; set; }
 
+    /// <summary>Gets or sets the certificate status.</summary>
     public CertificateStatus Status { get; set; } = CertificateStatus.Any;
 
+    /// <summary>Gets or sets the associated order number.</summary>
     public long OrderNumber { get; set; }
 
+    /// <summary>Gets or sets the backend certificate identifier.</summary>
     public string BackendCertId { get; set; } = string.Empty;
 
+    /// <summary>Gets or sets the certificate vendor.</summary>
     public string? Vendor { get; set; }
 
+    /// <summary>Gets or sets the certificate profile.</summary>
     public Profile? CertType { get; set; }
 
+    /// <summary>Gets or sets the certificate term.</summary>
     public int Term { get; set; }
 
+    /// <summary>Gets or sets the owner of the certificate.</summary>
     public string? Owner { get; set; }
 
+    /// <summary>Gets or sets the requester of the certificate.</summary>
     public string? Requester { get; set; }
 
+    /// <summary>Gets or sets additional comments.</summary>
     public string? Comments { get; set; }
 
+    /// <summary>Gets or sets the request date.</summary>
     public string? Requested { get; set; }
 
+    /// <summary>Gets or sets the expiry date.</summary>
     public string? Expires { get; set; }
 
+    /// <summary>Gets or sets the serial number.</summary>
     public string? SerialNumber { get; set; }
 
+    /// <summary>Gets or sets the key algorithm.</summary>
     public string? KeyAlgorithm { get; set; }
 
+    /// <summary>Gets or sets the key size.</summary>
     public int? KeySize { get; set; }
 
+    /// <summary>Gets or sets the key type.</summary>
     public string? KeyType { get; set; }
 
+    /// <summary>Gets or sets subject alternative names.</summary>
     public IReadOnlyList<string> SubjectAlternativeNames { get; set; } = [];
 
+    /// <summary>Gets or sets a value indicating whether notifications are suspended.</summary>
     public bool SuspendNotifications { get; set; }
 }

--- a/SectigoCertificateManager/Models/Order.cs
+++ b/SectigoCertificateManager/Models/Order.cs
@@ -2,10 +2,20 @@ namespace SectigoCertificateManager.Models;
 
 using SectigoCertificateManager;
 
+/// <summary>
+/// Represents a certificate order.
+/// </summary>
 public sealed class Order
 {
+    /// <summary>Gets or sets the order identifier.</summary>
     public int Id { get; set; }
+
+    /// <summary>Gets or sets the status of the order.</summary>
     public OrderStatus Status { get; set; }
+
+    /// <summary>Gets or sets the backend certificate identifier.</summary>
     public string BackendCertId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the order number.</summary>
     public int OrderNumber { get; set; }
 }

--- a/SectigoCertificateManager/Models/Profile.cs
+++ b/SectigoCertificateManager/Models/Profile.cs
@@ -1,12 +1,26 @@
 namespace SectigoCertificateManager.Models;
 
 using System.Collections.Generic;
+/// <summary>
+/// Represents a certificate profile.
+/// </summary>
 public sealed class Profile
 {
+    /// <summary>Gets or sets the profile identifier.</summary>
     public int Id { get; set; }
+
+    /// <summary>Gets or sets the profile name.</summary>
     public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the description.</summary>
     public string Description { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets allowed certificate terms.</summary>
     public IReadOnlyList<int> Terms { get; set; } = [];
+
+    /// <summary>Gets or sets supported key types.</summary>
     public IReadOnlyDictionary<string, IReadOnlyList<string>> KeyTypes { get; set; } = new Dictionary<string, IReadOnlyList<string>>();
+
+    /// <summary>Gets or sets a value indicating whether secondary organization names can be used.</summary>
     public bool UseSecondaryOrgName { get; set; }
 }

--- a/SectigoCertificateManager/SectigoClient.cs
+++ b/SectigoCertificateManager/SectigoClient.cs
@@ -7,12 +7,23 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Provides a basic HTTP client wrapper for communicating with the Sectigo API.
+/// </summary>
 public sealed class SectigoClient : ISectigoClient
 {
     private readonly HttpClient _client;
 
+    /// <summary>
+    /// Gets the underlying <see cref="HttpClient"/> instance used for requests.
+    /// </summary>
     public HttpClient HttpClient => _client;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SectigoClient"/> class.
+    /// </summary>
+    /// <param name="config">API configuration settings.</param>
+    /// <param name="httpClient">Optional pre-configured HTTP client.</param>
     public SectigoClient(ApiConfig config, HttpClient? httpClient = null)
     {
         if (httpClient is null)
@@ -32,6 +43,11 @@ public sealed class SectigoClient : ISectigoClient
         ConfigureHeaders(config);
     }
 
+    /// <summary>
+    /// Sends a GET request to the specified endpoint.
+    /// </summary>
+    /// <param name="requestUri">Relative request URI.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<HttpResponseMessage> GetAsync(string requestUri, CancellationToken cancellationToken = default)
     {
         var response = await _client.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
@@ -39,6 +55,12 @@ public sealed class SectigoClient : ISectigoClient
         return response;
     }
 
+    /// <summary>
+    /// Sends a POST request with the provided content.
+    /// </summary>
+    /// <param name="requestUri">Relative request URI.</param>
+    /// <param name="content">HTTP content to send.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default)
     {
         var response = await _client.PostAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
@@ -46,6 +68,12 @@ public sealed class SectigoClient : ISectigoClient
         return response;
     }
 
+    /// <summary>
+    /// Sends a PUT request with the provided content.
+    /// </summary>
+    /// <param name="requestUri">Relative request URI.</param>
+    /// <param name="content">HTTP content to send.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default)
     {
         var response = await _client.PutAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
@@ -53,6 +81,11 @@ public sealed class SectigoClient : ISectigoClient
         return response;
     }
 
+    /// <summary>
+    /// Sends a DELETE request to the specified endpoint.
+    /// </summary>
+    /// <param name="requestUri">Relative request URI.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<HttpResponseMessage> DeleteAsync(string requestUri, CancellationToken cancellationToken = default)
     {
         var response = await _client.DeleteAsync(requestUri, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- document public interface `ISectigoClient`
- add missing `<summary>` and `<param>` docs in clients and builders
- document error handler, models, and client wrapper classes

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68676b7d551c832e9df998d719a19a8e