### PR TITLE
Add API version 25.6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 This library provides a simple client for the Sectigo Certificate Manager API.
 
-The library defaults to **API version 25.4** as defined in `ApiConfigBuilder`.
-Support for version 25.5 is also available via `ApiVersion.V25_5`.
+The library defaults to **API version 25.6** as defined in `ApiConfigBuilder`.
+Support for version 25.5 remains available via `ApiVersion.V25_5`. To target
+version 25.6 explicitly, use `ApiVersion.V25_6`.
 
 ## Documentation
 
@@ -35,7 +36,7 @@ var config = new ApiConfigBuilder()
 
     .WithCustomerUri("cst1")
 
-    .WithApiVersion(ApiVersion.V25_5)
+    .WithApiVersion(ApiVersion.V25_6)
 
     // configure handler or attach a client certificate if needed
     .WithHttpClientHandler(h => h.AllowAutoRedirect = false)

--- a/SectigoCertificateManager.Examples/Examples/BasicApiExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/BasicApiExample.cs
@@ -18,7 +18,7 @@ public static class BasicApiExample
             .WithBaseUrl("https://cert-manager.com/api")
             .WithCredentials("<username>", "<password>")
             .WithCustomerUri("<customer uri>")
-            .WithApiVersion(ApiVersion.V25_5)
+            .WithApiVersion(ApiVersion.V25_6)
             .Build();
 
         var client = new SectigoClient(config);

--- a/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
@@ -13,12 +13,12 @@ public sealed class ApiConfigLoaderTests
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);
         var path = Path.Combine(tempDir, "cred.json");
-        File.WriteAllText(path, "{\"baseUrl\":\"https://example.com\",\"username\":\"user\",\"password\":\"pass\",\"customerUri\":\"cst1\",\"apiVersion\":\"V25_5\"}");
+        File.WriteAllText(path, "{\"baseUrl\":\"https://example.com\",\"username\":\"user\",\"password\":\"pass\",\"customerUri\":\"cst1\",\"apiVersion\":\"V25_6\"}");
 
         var config = ApiConfigLoader.Load(path);
 
         Assert.Equal("https://example.com", config.BaseUrl);
-        Assert.Equal(ApiVersion.V25_5, config.ApiVersion);
+        Assert.Equal(ApiVersion.V25_6, config.ApiVersion);
 
         Directory.Delete(tempDir, true);
     }

--- a/SectigoCertificateManager.Tests/SectigoClientTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientTests.cs
@@ -45,14 +45,14 @@ public sealed class SectigoClientTests
             .WithBaseUrl("https://example.com")
             .WithCredentials("user", "pass")
             .WithCustomerUri("cst1")
-            .WithApiVersion(ApiVersion.V25_5)
+            .WithApiVersion(ApiVersion.V25_6)
             .Build();
 
         Assert.Equal("https://example.com", config.BaseUrl);
         Assert.Equal("user", config.Username);
         Assert.Equal("pass", config.Password);
         Assert.Equal("cst1", config.CustomerUri);
-        Assert.Equal(ApiVersion.V25_5, config.ApiVersion);
+        Assert.Equal(ApiVersion.V25_6, config.ApiVersion);
     }
 
     [Fact]

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -13,7 +13,7 @@ public sealed class ApiConfigBuilder
     private string _username = string.Empty;
     private string _password = string.Empty;
     private string _customerUri = string.Empty;
-    private ApiVersion _apiVersion = ApiVersion.V25_4;
+    private ApiVersion _apiVersion = ApiVersion.V25_6;
     private X509Certificate2? _clientCertificate;
     private Action<HttpClientHandler>? _configureHandler;
 

--- a/SectigoCertificateManager/ApiVersion.cs
+++ b/SectigoCertificateManager/ApiVersion.cs
@@ -14,4 +14,9 @@ public enum ApiVersion
     /// Version 25.5 of the API.
     /// </summary>
     V25_5,
+
+    /// <summary>
+    /// Version 25.6 of the API.
+    /// </summary>
+    V25_6,
 }


### PR DESCRIPTION
## Summary
- add V25_6 to `ApiVersion`
- default to V25_6 in `ApiConfigBuilder`
- update examples, docs and tests for new version

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -v minimal`
- `dotnet build SectigoCertificateManager.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68676baa7b04832e9c0fe359151a9ffc