### PR TITLE
Add paging support and example

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/PagingExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/PagingExample.cs
@@ -1,0 +1,28 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates paging through certificate results.
+/// </summary>
+public static class PagingExample
+{
+    public static async Task RunAsync()
+    {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_5)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+
+        await foreach (var certificate in certificates.ListAsync())
+        {
+            Console.WriteLine($"Certificate ID: {certificate.Id}");
+        }
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -1,3 +1,4 @@
 using SectigoCertificateManager.Examples.Examples;
 
 await BasicApiExample.RunAsync();
+await PagingExample.RunAsync();

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -1,0 +1,69 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Responses;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+public sealed class CertificatesClientTests
+{
+    private sealed class PagingHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        public PagingHandler(IEnumerable<HttpResponseMessage> responses)
+        {
+            _responses = new Queue<HttpResponseMessage>(responses);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsItemsFromAllPages()
+    {
+        var first = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new CertificateResponse
+            {
+                Certificates = new[] { new Certificate { Id = 1 }, new Certificate { Id = 2 } }
+            })
+        };
+
+        var second = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new CertificateResponse
+            {
+                Certificates = new[] { new Certificate { Id = 3 } }
+            })
+        };
+
+        var handler = new PagingHandler(new[] { first, second });
+        var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
+        var client = new SectigoClient(config, new HttpClient(handler));
+        var certificates = new CertificatesClient(client);
+
+        var ids = new List<int>();
+        await foreach (var cert in certificates.ListAsync(pageSize: 2))
+        {
+            ids.Add(cert.Id);
+        }
+
+        Assert.Equal(new[] { 1, 2, 3 }, ids);
+        Assert.Collection(handler.Requests,
+            r => Assert.Equal("https://example.com/v1/certificate?page=1&size=2", r.RequestUri!.ToString()),
+            r => Assert.Equal("https://example.com/v1/certificate?page=2&size=2", r.RequestUri!.ToString()));
+    }
+}

--- a/SectigoCertificateManager/SectigoCertificateManager.csproj
+++ b/SectigoCertificateManager/SectigoCertificateManager.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- support paging in `CertificatesClient` with `ListAsync`
- add async paging example
- run paging example from `Program`
- add async interface package
- test paging logic

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68676bb2e2ac832ea821eb7e844a7c5d