### PR TITLE
Add certificate update support

### DIFF
--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -1,0 +1,71 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Requests;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+public sealed class CertificatesClientTests
+{
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Request { get; private set; }
+        private readonly HttpResponseMessage _response;
+
+        public RecordingHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            return Task.FromResult(_response);
+        }
+    }
+
+    private static CertificatesClient CreateClient(HttpResponseMessage response, out RecordingHandler handler)
+    {
+        handler = new RecordingHandler(response);
+        var config = new ApiConfig("https://example.com/api/", "u", "p", "c", ApiVersion.V25_4);
+        var client = new SectigoClient(config, new HttpClient(handler));
+        return new CertificatesClient(client);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SendsRequest()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new Certificate())
+        };
+        var api = CreateClient(response, out var handler);
+
+        var req = new UpdateCertificateRequest { Comments = "c" };
+        await api.UpdateAsync(5, req);
+
+        Assert.Equal(HttpMethod.Put, handler.Request!.Method);
+        Assert.Equal(new Uri("https://example.com/api/v1/certificate"), handler.Request.RequestUri);
+        var json = await handler.Request.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal(5, doc.RootElement.GetProperty("sslId").GetInt32());
+        Assert.Equal("c", doc.RootElement.GetProperty("comments").GetString());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ThrowsOnError()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = JsonContent.Create(new ApiError { Code = -1, Description = "bad" })
+        };
+        var api = CreateClient(response, out _);
+
+        await Assert.ThrowsAsync<ValidationException>(() => api.UpdateAsync(1, new UpdateCertificateRequest()));
+    }
+}

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -37,4 +37,15 @@ public sealed class CertificatesClient
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<Certificate>(cancellationToken: cancellationToken);
     }
+
+    /// <summary>
+    /// Updates an existing certificate.
+    /// </summary>
+    public async Task<Certificate?> UpdateAsync(int certificateId, UpdateCertificateRequest request, CancellationToken cancellationToken = default)
+    {
+        request.SslId = certificateId;
+        var response = await _client.PutAsync("v1/certificate", JsonContent.Create(request), cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<Certificate>(cancellationToken: cancellationToken);
+    }
 }

--- a/SectigoCertificateManager/Models/AutoRenewDetails.cs
+++ b/SectigoCertificateManager/Models/AutoRenewDetails.cs
@@ -1,0 +1,13 @@
+namespace SectigoCertificateManager.Models;
+
+/// <summary>
+/// Represents auto-renewal options for a certificate.
+/// </summary>
+public sealed class AutoRenewDetails
+{
+    /// <summary>Gets or sets the auto-renewal state.</summary>
+    public string? State { get; set; }
+
+    /// <summary>Gets or sets days before expiration to start auto-renewal.</summary>
+    public int? DaysBeforeExpiration { get; set; }
+}

--- a/SectigoCertificateManager/Models/CustomField.cs
+++ b/SectigoCertificateManager/Models/CustomField.cs
@@ -1,0 +1,13 @@
+namespace SectigoCertificateManager.Models;
+
+/// <summary>
+/// Represents a custom field value.
+/// </summary>
+public sealed class CustomField
+{
+    /// <summary>Gets or sets the field name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the field value.</summary>
+    public string Value { get; set; } = string.Empty;
+}

--- a/SectigoCertificateManager/Requests/UpdateCertificateRequest.cs
+++ b/SectigoCertificateManager/Requests/UpdateCertificateRequest.cs
@@ -1,0 +1,55 @@
+using SectigoCertificateManager.Models;
+using System.Collections.Generic;
+
+namespace SectigoCertificateManager.Requests;
+
+/// <summary>
+/// Request payload used when updating a certificate.
+/// </summary>
+public sealed class UpdateCertificateRequest
+{
+    /// <summary>Gets or sets the certificate identifier.</summary>
+    public int SslId { get; set; }
+
+    /// <summary>Gets or sets the certificate term.</summary>
+    public int? Term { get; set; }
+
+    /// <summary>Gets or sets the certificate profile identifier.</summary>
+    public int? CertTypeId { get; set; }
+
+    /// <summary>Gets or sets the organization identifier.</summary>
+    public int? OrgId { get; set; }
+
+    /// <summary>Gets or sets the certificate common name.</summary>
+    public string? CommonName { get; set; }
+
+    /// <summary>Gets or sets the CSR.</summary>
+    public string? Csr { get; set; }
+
+    /// <summary>Gets or sets external requester emails.</summary>
+    public string? ExternalRequester { get; set; }
+
+    /// <summary>Gets or sets comments.</summary>
+    public string? Comments { get; set; }
+
+    /// <summary>Gets or sets subject alternative names.</summary>
+    public IReadOnlyList<string> SubjectAlternativeNames { get; set; } = [];
+
+    /// <summary>Gets or sets custom fields.</summary>
+    public IReadOnlyList<CustomField> CustomFields { get; set; } = [];
+
+    /// <summary>Gets or sets auto renew details.</summary>
+    public AutoRenewDetails? AutoRenewDetails { get; set; }
+
+    /// <summary>Gets or sets whether notifications should be suspended.</summary>
+    public bool? SuspendNotifications { get; set; }
+
+    /// <summary>Gets or sets requester.</summary>
+    public string? Requester { get; set; }
+
+    /// <summary>Gets or sets requester admin identifier.</summary>
+    public int? RequesterAdminId { get; set; }
+
+    /// <summary>Gets or sets approver admin identifier.</summary>
+    public int? ApproverAdminId { get; set; }
+}


### PR DESCRIPTION
## Summary
- define UpdateCertificateRequest with fields like term, CSR, SANs, etc
- add CustomField and AutoRenewDetails models
- implement `UpdateAsync` on CertificatesClient
- test successful update call and validation failure

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68676c406878832ea3241249be025ff0