### PR TITLE
Add integration tests with WireMock

### DIFF
--- a/SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj
+++ b/SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="WireMock.Net" Version="1.8.13" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- integrate WireMock tests into the existing `SectigoCertificateManager.Tests` project
- remove the stray `EndProject` entry from the solution file

## Testing
- `dotnet restore SectigoCertificateManager.sln`
- `dotnet build SectigoCertificateManager.sln --no-restore --configuration Debug`
- `dotnet test SectigoCertificateManager.sln --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68676c36c44c832ebfdabb5215813489