### PR TITLE
Refactor exception classes into separate files

### DIFF
--- a/SectigoCertificateManager/ApiException.cs
+++ b/SectigoCertificateManager/ApiException.cs
@@ -5,38 +5,14 @@ using System;
 /// <summary>
 /// Base type for API related exceptions.
 /// </summary>
-public class ApiException : Exception
-{
+public class ApiException : Exception {
     /// <summary>Gets the API error code.</summary>
     public int ErrorCode { get; }
 
     /// <summary>Initializes a new instance of the <see cref="ApiException"/> class.</summary>
     /// <param name="error">Error information returned by the API.</param>
     public ApiException(ApiError error)
-        : base(error.Description)
-    {
+        : base(error.Description) {
         ErrorCode = error.Code;
-    }
-}
-
-/// <summary>Exception thrown when authentication fails.</summary>
-public sealed class AuthenticationException : ApiException
-{
-    /// <summary>Initializes a new instance of the <see cref="AuthenticationException"/> class.</summary>
-    /// <param name="error">Error information returned by the API.</param>
-    public AuthenticationException(ApiError error)
-        : base(error)
-    {
-    }
-}
-
-/// <summary>Exception thrown when a request fails validation.</summary>
-public sealed class ValidationException : ApiException
-{
-    /// <summary>Initializes a new instance of the <see cref="ValidationException"/> class.</summary>
-    /// <param name="error">Error information returned by the API.</param>
-    public ValidationException(ApiError error)
-        : base(error)
-    {
     }
 }

--- a/SectigoCertificateManager/AuthenticationException.cs
+++ b/SectigoCertificateManager/AuthenticationException.cs
@@ -1,0 +1,12 @@
+namespace SectigoCertificateManager;
+
+/// <summary>
+/// Exception thrown when authentication fails.
+/// </summary>
+public sealed class AuthenticationException : ApiException {
+    /// <summary>Initializes a new instance of the <see cref="AuthenticationException"/> class.</summary>
+    /// <param name="error">Error information returned by the API.</param>
+    public AuthenticationException(ApiError error)
+        : base(error) {
+    }
+}

--- a/SectigoCertificateManager/ValidationException.cs
+++ b/SectigoCertificateManager/ValidationException.cs
@@ -1,0 +1,12 @@
+namespace SectigoCertificateManager;
+
+/// <summary>
+/// Exception thrown when a request fails validation.
+/// </summary>
+public sealed class ValidationException : ApiException {
+    /// <summary>Initializes a new instance of the <see cref="ValidationException"/> class.</summary>
+    /// <param name="error">Error information returned by the API.</param>
+    public ValidationException(ApiError error)
+        : base(error) {
+    }
+}


### PR DESCRIPTION
## Summary
- isolate `AuthenticationException` and `ValidationException` into their own files
- keep `ApiException` focused on the base exception functionality

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_686781b11cc0832e80ec8d3a55600a22