### PR TITLE
Add basic caching mechanism

### DIFF
--- a/SectigoCertificateManager/ApiConfig.cs
+++ b/SectigoCertificateManager/ApiConfig.cs
@@ -21,7 +21,8 @@ public sealed class ApiConfig(
     string customerUri,
     ApiVersion apiVersion,
     X509Certificate2? clientCertificate = null,
-    Action<HttpClientHandler>? configureHandler = null)
+    Action<HttpClientHandler>? configureHandler = null,
+    TimeSpan cacheExpiration = default)
 {
     /// <summary>Gets the base URL of the API endpoint.</summary>
     public string BaseUrl { get; } = baseUrl;
@@ -43,4 +44,7 @@ public sealed class ApiConfig(
 
     /// <summary>Gets the optional handler configuration delegate.</summary>
     public Action<HttpClientHandler>? ConfigureHandler { get; } = configureHandler;
+
+    /// <summary>Gets the amount of time a response should be cached.</summary>
+    public TimeSpan CacheExpiration { get; } = cacheExpiration;
 }

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -16,6 +16,7 @@ public sealed class ApiConfigBuilder
     private ApiVersion _apiVersion = ApiVersion.V25_6;
     private X509Certificate2? _clientCertificate;
     private Action<HttpClientHandler>? _configureHandler;
+    private TimeSpan _cacheExpiration;
 
     /// <summary>Sets the base URL for the API endpoint.</summary>
     /// <param name="baseUrl">The root URL of the Sectigo API.</param>
@@ -67,6 +68,14 @@ public sealed class ApiConfigBuilder
         return this;
     }
 
+    /// <summary>Sets the duration to cache GET responses.</summary>
+    /// <param name="expiration">Maximum age of cache entries.</param>
+    public ApiConfigBuilder WithCacheExpiration(TimeSpan expiration)
+    {
+        _cacheExpiration = expiration;
+        return this;
+    }
+
     /// <summary>Builds a new <see cref="ApiConfig"/> instance using configured values.</summary>
     public ApiConfig Build()
     {
@@ -90,6 +99,6 @@ public sealed class ApiConfigBuilder
             throw new ArgumentException("Customer URI is required.", nameof(_customerUri));
         }
 
-        return new ApiConfig(_baseUrl, _username, _password, _customerUri, _apiVersion, _clientCertificate, _configureHandler);
+        return new ApiConfig(_baseUrl, _username, _password, _customerUri, _apiVersion, _clientCertificate, _configureHandler, _cacheExpiration);
     }
 }


### PR DESCRIPTION
## Summary
- add cache expiration to `ApiConfig`
- expose cache config via `ApiConfigBuilder`
- implement simple caching in `SectigoClient`
- test cache hit and expiration scenarios

## Testing
- `dotnet build SectigoCertificateManager/SectigoCertificateManager.csproj -f net8.0`
- `dotnet build SectigoCertificateManager/SectigoCertificateManager.csproj -f net9.0`
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -f net8.0 --no-build`
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -f net9.0 --no-build --logger "console;verbosity=minimal"`


------
https://chatgpt.com/codex/tasks/task_e_68678f42b628832e82ebd2b0a104969f