### PR TITLE
Add bearer token authentication

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
@@ -17,7 +17,7 @@ public sealed class ApiConfigBuilderTests
     }
 
     [Fact]
-    public void BuildThrowsWithoutCredentials()
+    public void BuildThrowsWithoutCredentialsOrToken()
     {
         var builder = new ApiConfigBuilder()
             .WithBaseUrl("https://example.com")
@@ -34,5 +34,18 @@ public sealed class ApiConfigBuilderTests
             .WithCredentials("user", "pass");
 
         Assert.Throws<ArgumentException>(() => builder.Build());
+    }
+
+    [Fact]
+    public void BuildSucceedsWithToken()
+    {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://example.com")
+            .WithCustomerUri("cst1")
+            .WithToken("tok")
+            .Build();
+
+        Assert.Equal("tok", config.Token);
+        Assert.Equal("https://example.com", config.BaseUrl);
     }
 }

--- a/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
@@ -60,4 +60,35 @@ public sealed class ApiConfigLoaderTests
         Environment.SetEnvironmentVariable("SECTIGO_CREDENTIALS_PATH", null);
         Directory.Delete(tempDir, true);
     }
+
+    [Fact]
+    public void Load_FromEnvironment_WithToken()
+    {
+        Environment.SetEnvironmentVariable("SECTIGO_BASE_URL", "https://example.com");
+        Environment.SetEnvironmentVariable("SECTIGO_TOKEN", "tok");
+        Environment.SetEnvironmentVariable("SECTIGO_CUSTOMER_URI", "cst1");
+
+        var config = ApiConfigLoader.Load();
+
+        Assert.Equal("tok", config.Token);
+
+        Environment.SetEnvironmentVariable("SECTIGO_BASE_URL", null);
+        Environment.SetEnvironmentVariable("SECTIGO_TOKEN", null);
+        Environment.SetEnvironmentVariable("SECTIGO_CUSTOMER_URI", null);
+    }
+
+    [Fact]
+    public void Load_FromFile_WithToken()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var path = Path.Combine(tempDir, "cred.json");
+        File.WriteAllText(path, "{\"baseUrl\":\"https://example.com\",\"token\":\"tok\",\"customerUri\":\"cst1\"}");
+
+        var config = ApiConfigLoader.Load(path);
+
+        Assert.Equal("tok", config.Token);
+
+        Directory.Delete(tempDir, true);
+    }
 }

--- a/SectigoCertificateManager.Tests/SectigoClientTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientTests.cs
@@ -23,7 +23,7 @@ public sealed class SectigoClientTests
     }
 
     [Fact]
-    public async Task AddsHeadersAndUsesBaseUrl()
+    public async Task AddsHeadersAndUsesBaseUrl_WithCredentials()
     {
         var config = new ApiConfig("https://example.com/api/", "user", "pass", "cst1", ApiVersion.V25_4);
         var handler = new TestHandler();
@@ -36,6 +36,23 @@ public sealed class SectigoClientTests
         Assert.Equal("user", httpClient.DefaultRequestHeaders.GetValues("login").Single());
         Assert.Equal("pass", httpClient.DefaultRequestHeaders.GetValues("password").Single());
         Assert.Equal("cst1", httpClient.DefaultRequestHeaders.GetValues("customerUri").Single());
+    }
+
+    [Fact]
+    public async Task AddsBearerHeaderWhenTokenPresent()
+    {
+        var config = new ApiConfig("https://example.com/api/", string.Empty, string.Empty, "cst1", ApiVersion.V25_4, token: "tkn");
+        var handler = new TestHandler();
+        var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(config, httpClient);
+
+        await client.GetAsync("v1/test");
+
+        Assert.True(httpClient.DefaultRequestHeaders.Authorization?.Scheme == "Bearer");
+        Assert.Equal("tkn", httpClient.DefaultRequestHeaders.Authorization?.Parameter);
+        Assert.Equal("cst1", httpClient.DefaultRequestHeaders.GetValues("customerUri").Single());
+        Assert.False(httpClient.DefaultRequestHeaders.Contains("login"));
+        Assert.False(httpClient.DefaultRequestHeaders.Contains("password"));
     }
 
     [Fact]

--- a/SectigoCertificateManager/ApiConfig.cs
+++ b/SectigoCertificateManager/ApiConfig.cs
@@ -21,7 +21,8 @@ public sealed class ApiConfig(
     string customerUri,
     ApiVersion apiVersion,
     X509Certificate2? clientCertificate = null,
-    Action<HttpClientHandler>? configureHandler = null)
+    Action<HttpClientHandler>? configureHandler = null,
+    string? token = null)
 {
     /// <summary>Gets the base URL of the API endpoint.</summary>
     public string BaseUrl { get; } = baseUrl;
@@ -43,4 +44,7 @@ public sealed class ApiConfig(
 
     /// <summary>Gets the optional handler configuration delegate.</summary>
     public Action<HttpClientHandler>? ConfigureHandler { get; } = configureHandler;
+
+    /// <summary>Gets the bearer token used for authentication, if any.</summary>
+    public string? Token { get; } = token;
 }

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -12,6 +12,7 @@ public sealed class ApiConfigBuilder
     private string _baseUrl = string.Empty;
     private string _username = string.Empty;
     private string _password = string.Empty;
+    private string? _token;
     private string _customerUri = string.Empty;
     private ApiVersion _apiVersion = ApiVersion.V25_6;
     private X509Certificate2? _clientCertificate;
@@ -32,6 +33,14 @@ public sealed class ApiConfigBuilder
     {
         _username = username;
         _password = password;
+        return this;
+    }
+
+    /// <summary>Sets the bearer token used for authentication.</summary>
+    /// <param name="token">Token value.</param>
+    public ApiConfigBuilder WithToken(string token)
+    {
+        _token = token;
         return this;
     }
 
@@ -75,14 +84,25 @@ public sealed class ApiConfigBuilder
             throw new ArgumentException("Base URL is required.", nameof(_baseUrl));
         }
 
-        if (string.IsNullOrWhiteSpace(_username))
+        var hasToken = !string.IsNullOrWhiteSpace(_token);
+        var hasCredentials = !string.IsNullOrWhiteSpace(_username) && !string.IsNullOrWhiteSpace(_password);
+
+        if (!hasToken && !hasCredentials)
         {
-            throw new ArgumentException("User name is required.", nameof(_username));
+            throw new ArgumentException("Credentials or token are required.");
         }
 
-        if (string.IsNullOrWhiteSpace(_password))
+        if (!hasToken)
         {
-            throw new ArgumentException("Password is required.", nameof(_password));
+            if (string.IsNullOrWhiteSpace(_username))
+            {
+                throw new ArgumentException("User name is required.", nameof(_username));
+            }
+
+            if (string.IsNullOrWhiteSpace(_password))
+            {
+                throw new ArgumentException("Password is required.", nameof(_password));
+            }
         }
 
         if (string.IsNullOrWhiteSpace(_customerUri))
@@ -90,6 +110,6 @@ public sealed class ApiConfigBuilder
             throw new ArgumentException("Customer URI is required.", nameof(_customerUri));
         }
 
-        return new ApiConfig(_baseUrl, _username, _password, _customerUri, _apiVersion, _clientCertificate, _configureHandler);
+        return new ApiConfig(_baseUrl, _username, _password, _customerUri, _apiVersion, _clientCertificate, _configureHandler, _token);
     }
 }

--- a/SectigoCertificateManager/ApiConfigLoader.cs
+++ b/SectigoCertificateManager/ApiConfigLoader.cs
@@ -20,6 +20,9 @@ public static class ApiConfigLoader
         /// <summary>Gets or sets the password.</summary>
         public string Password { get; set; } = string.Empty;
 
+        /// <summary>Gets or sets the bearer token.</summary>
+        public string? Token { get; set; }
+
         /// <summary>Gets or sets the customer URI.</summary>
         public string CustomerUri { get; set; } = string.Empty;
 
@@ -36,8 +39,14 @@ public static class ApiConfigLoader
         string? baseUrl = Environment.GetEnvironmentVariable("SECTIGO_BASE_URL");
         string? username = Environment.GetEnvironmentVariable("SECTIGO_USERNAME");
         string? password = Environment.GetEnvironmentVariable("SECTIGO_PASSWORD");
+        string? token = Environment.GetEnvironmentVariable("SECTIGO_TOKEN");
         string? customerUri = Environment.GetEnvironmentVariable("SECTIGO_CUSTOMER_URI");
         string? version = Environment.GetEnvironmentVariable("SECTIGO_API_VERSION");
+
+        if (baseUrl is not null && token is not null && customerUri is not null)
+        {
+            return new ApiConfig(baseUrl, string.Empty, string.Empty, customerUri, ParseVersion(version), token: token);
+        }
 
         if (baseUrl is not null && username is not null && password is not null && customerUri is not null)
         {
@@ -62,7 +71,7 @@ public static class ApiConfigLoader
         var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
         var model = JsonSerializer.Deserialize<FileModel>(json, options)
                     ?? throw new InvalidOperationException("Invalid configuration file.");
-        return new ApiConfig(model.BaseUrl, model.Username, model.Password, model.CustomerUri, ParseVersion(model.ApiVersion));
+        return new ApiConfig(model.BaseUrl, model.Username, model.Password, model.CustomerUri, ParseVersion(model.ApiVersion), token: model.Token);
     }
 
     private static ApiVersion ParseVersion(string? value)

--- a/SectigoCertificateManager/SectigoClient.cs
+++ b/SectigoCertificateManager/SectigoClient.cs
@@ -97,8 +97,16 @@ public sealed class SectigoClient : ISectigoClient
     {
         _client.DefaultRequestHeaders.Clear();
         _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        _client.DefaultRequestHeaders.Add("login", cfg.Username);
-        _client.DefaultRequestHeaders.Add("password", cfg.Password);
         _client.DefaultRequestHeaders.Add("customerUri", cfg.CustomerUri);
+
+        if (!string.IsNullOrWhiteSpace(cfg.Token))
+        {
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", cfg.Token);
+        }
+        else
+        {
+            _client.DefaultRequestHeaders.Add("login", cfg.Username);
+            _client.DefaultRequestHeaders.Add("password", cfg.Password);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add optional `Token` property to `ApiConfig`
- allow `ApiConfigBuilder` and `ApiConfigLoader` to handle bearer tokens
- update `SectigoClient` to emit `Authorization: Bearer` when token is present
- test builder, loader and client with token authentication

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68678f39347c832e86c7d1ce37fb48fd