### PR TITLE
Add order listing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,6 @@ Import-Module ./SectigoCertificateManager.PowerShell.dll
 Get-SectigoCertificate -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CertificateId 123
 
 New-SectigoOrder -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CommonName "example.com" -ProfileId 1
+
+Get-SectigoOrders -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1"
 ```

--- a/SectigoCertificateManager.PowerShell/GetSectigoOrdersCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoOrdersCommand.cs
@@ -1,0 +1,40 @@
+using System.Management.Automation;
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.PowerShell;
+
+[Cmdlet(VerbsCommon.Get, "SectigoOrders")]
+[OutputType(typeof(Models.Order))]
+public sealed class GetSectigoOrdersCommand : PSCmdlet
+{
+    [Parameter(Mandatory = true)]
+    public string BaseUrl { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string Username { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string Password { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string CustomerUri { get; set; } = string.Empty;
+
+    [Parameter]
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+
+    protected override void ProcessRecord()
+    {
+        var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
+        var client = new SectigoClient(config);
+        var orders = new OrdersClient(client);
+        var result = orders.ListOrdersAsync().GetAwaiter().GetResult();
+        if (result is not null)
+        {
+            foreach (var order in result)
+            {
+                WriteObject(order);
+            }
+        }
+    }
+}

--- a/SectigoCertificateManager.PowerShell/SectigoCertificateManager.PowerShell.csproj
+++ b/SectigoCertificateManager.PowerShell/SectigoCertificateManager.PowerShell.csproj
@@ -14,6 +14,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Compile Remove="GetSectigoCertificateCommand.cs" />
     <Compile Remove="NewSectigoOrderCommand.cs" />
+    <Compile Remove="GetSectigoOrdersCommand.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">

--- a/SectigoCertificateManager.Tests/OrdersClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrdersClientTests.cs
@@ -1,0 +1,50 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Models;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+public sealed class OrdersClientTests
+{
+    private sealed class TestHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+        public HttpRequestMessage? Request { get; private set; }
+
+        public TestHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            return Task.FromResult(_response);
+        }
+    }
+
+    [Fact]
+    public async Task ListOrdersAsync_RequestsOrders()
+    {
+        var order = new Order { Id = 1, OrderNumber = 10, BackendCertId = "a" };
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new[] { order })
+        };
+
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var orders = new OrdersClient(client);
+
+        var result = await orders.ListOrdersAsync();
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/v1/order", handler.Request!.RequestUri!.ToString());
+        Assert.NotNull(result);
+        Assert.Single(result!);
+        Assert.Equal(1, result[0].Id);
+    }
+}

--- a/SectigoCertificateManager.Tests/SectigoApiIntegrationTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoApiIntegrationTests.cs
@@ -82,4 +82,20 @@ public sealed class SectigoApiIntegrationTests : IAsyncLifetime
         Assert.Equal(5, result!.Id);
     }
 
+    [Fact]
+    public async Task OrdersClient_List_ReturnsOrders()
+    {
+        _server.Given(Request.Create().WithPath("/v1/order").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("[{\"id\":3,\"status\":0,\"orderNumber\":2,\"backendCertId\":\"def\"}]"));
+
+        var result = await _orders.ListOrdersAsync();
+
+        Assert.NotNull(result);
+        Assert.Single(result!);
+        Assert.Equal(3, result[0].Id);
+    }
+
 }

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -28,4 +28,15 @@ public sealed class OrdersClient
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<Order>(cancellationToken: cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Retrieves all orders visible to the user.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<IReadOnlyList<Order>?> ListOrdersAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await _client.GetAsync("v1/order", cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<IReadOnlyList<Order>>(cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
 }


### PR DESCRIPTION
## Summary
- implement `ListOrdersAsync` in `OrdersClient`
- add PowerShell `Get-SectigoOrders` cmdlet
- document usage in README
- add unit test for `OrdersClient` and integration coverage

## Testing
- `dotnet test`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686796762a24832e97688cb9651930d7