### PR TITLE
Add OrderStatusClient

### DIFF
--- a/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
@@ -1,0 +1,41 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+public sealed class OrderStatusClientTests {
+    private sealed class TestHandler : HttpMessageHandler {
+        private readonly HttpResponseMessage _response;
+        public HttpRequestMessage? Request { get; private set; }
+
+        public TestHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            Request = request;
+            return Task.FromResult(_response);
+        }
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_ReturnsOrderStatus() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create(new { Status = "Submitted" })
+        };
+
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var statuses = new OrderStatusClient(client);
+
+        var result = await statuses.GetStatusAsync(5);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/v1/order/5/status", handler.Request!.RequestUri!.ToString());
+        Assert.Equal(OrderStatus.Submitted, result);
+    }
+}

--- a/SectigoCertificateManager/Clients/OrderStatusClient.cs
+++ b/SectigoCertificateManager/Clients/OrderStatusClient.cs
@@ -1,0 +1,32 @@
+namespace SectigoCertificateManager.Clients;
+
+using System.Net.Http.Json;
+
+/// <summary>
+/// Provides access to order status information.
+/// </summary>
+public sealed class OrderStatusClient {
+    private readonly ISectigoClient _client;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrderStatusClient"/> class.
+    /// </summary>
+    /// <param name="client">HTTP client wrapper.</param>
+    public OrderStatusClient(ISectigoClient client) => _client = client;
+
+    /// <summary>
+    /// Retrieves the status of an order by identifier.
+    /// </summary>
+    /// <param name="orderId">Identifier of the order.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<OrderStatus?> GetStatusAsync(int orderId, CancellationToken cancellationToken = default) {
+        var response = await _client.GetAsync($"v1/order/{orderId}/status", cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<StatusResponse>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return result?.Status;
+    }
+
+    private sealed class StatusResponse {
+        public OrderStatus Status { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `OrderStatusClient` with `GetStatusAsync`
- parse status from response
- add unit tests for new client

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6867a2592024832eaa06f758c099de02