### PR TITLE
Add bearer token support

### DIFF
--- a/SectigoCertificateManager.Tests/SectigoClientTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientTests.cs
@@ -51,6 +51,21 @@ public sealed class SectigoClientTests {
     }
 
     [Fact]
+    public async Task TokenOverridesCredentialsWhenBothProvided() {
+        var config = new ApiConfig("https://example.com/api/", "user", "pass", "cst1", ApiVersion.V25_4, token: "tkn");
+        var handler = new TestHandler();
+        var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(config, httpClient);
+
+        await client.GetAsync("v1/test");
+
+        Assert.True(httpClient.DefaultRequestHeaders.Authorization?.Scheme == "Bearer");
+        Assert.Equal("tkn", httpClient.DefaultRequestHeaders.Authorization?.Parameter);
+        Assert.False(httpClient.DefaultRequestHeaders.Contains("login"));
+        Assert.False(httpClient.DefaultRequestHeaders.Contains("password"));
+    }
+
+    [Fact]
     public void ApiConfigBuilderCreatesValidConfig() {
         var config = new ApiConfigBuilder()
             .WithBaseUrl("https://example.com")

--- a/SectigoCertificateManager/ApiConfig.cs
+++ b/SectigoCertificateManager/ApiConfig.cs
@@ -14,6 +14,7 @@ using System.Security.Cryptography.X509Certificates;
 /// <param name="apiVersion">Version of the API to use.</param>
 /// <param name="clientCertificate">Optional client certificate used for mutual TLS.</param>
 /// <param name="configureHandler">Optional delegate used to configure the <see cref="HttpClientHandler"/> created by <see cref="SectigoClient"/>.</param>
+/// <param name="token">Optional bearer token used for authentication.</param>
 public sealed class ApiConfig(
     string baseUrl,
     string username,

--- a/SectigoCertificateManager/SectigoClient.cs
+++ b/SectigoCertificateManager/SectigoClient.cs
@@ -90,7 +90,7 @@ public sealed class SectigoClient : ISectigoClient {
         _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         _client.DefaultRequestHeaders.Add("customerUri", cfg.CustomerUri);
 
-        if (!string.IsNullOrWhiteSpace(cfg.Token)) {
+        if (cfg.Token is not null && cfg.Token.Length > 0) {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", cfg.Token);
         } else {
             _client.DefaultRequestHeaders.Add("login", cfg.Username);


### PR DESCRIPTION
## Summary
- add XML docs for token constructor parameter
- check Token property in SectigoClient
- cover token override scenario in tests

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6867a27a326c832e9701209963aeca61