### PR TITLE
Add profile list method

### DIFF
--- a/SectigoCertificateManager.Tests/ProfilesClientTests.cs
+++ b/SectigoCertificateManager.Tests/ProfilesClientTests.cs
@@ -61,4 +61,22 @@ public sealed class ProfilesClientTests {
         Assert.True(result.KeyTypes.ContainsKey("RSA"));
         Assert.Equal("2048", result.KeyTypes["RSA"][0]);
     }
+
+    [Fact]
+    public async Task ListProfilesAsync_ReturnsProfiles() {
+        var profile = new Profile { Id = 2, Name = "Test" };
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create(new[] { profile })
+        };
+        var client = new StubClient(response);
+        var profiles = new ProfilesClient(client);
+
+        var result = await profiles.ListProfilesAsync();
+
+        Assert.NotNull(client.Request);
+        Assert.Equal("v1/profile", client.Request!.RequestUri!.ToString());
+        Assert.NotNull(result);
+        Assert.Single(result!);
+        Assert.Equal(2, result[0].Id);
+    }
 }

--- a/SectigoCertificateManager/Clients/ProfilesClient.cs
+++ b/SectigoCertificateManager/Clients/ProfilesClient.cs
@@ -25,4 +25,14 @@ public sealed class ProfilesClient {
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<Profile>(cancellationToken: cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Retrieves all profiles visible to the user.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<IReadOnlyList<Profile>?> ListProfilesAsync(CancellationToken cancellationToken = default) {
+        var response = await _client.GetAsync("v1/profile", cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<IReadOnlyList<Profile>>(cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
 }


### PR DESCRIPTION
## Summary
- add `ListProfilesAsync` method for `ProfilesClient`
- verify profile listing in tests

## Testing
- `dotnet test --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6867b8fe83ac832eb2c3cae74f9d3b1b