### PR TITLE
Add camelCase JsonSerializer options

### DIFF
--- a/SectigoCertificateManager.Tests/SerializationTests.cs
+++ b/SectigoCertificateManager.Tests/SerializationTests.cs
@@ -8,22 +8,31 @@ public sealed class SerializationTests {
     [Fact]
     public void Deserialize_Certificate_Succeeds() {
         const string json = "{\"id\":1}";
-        var obj = JsonSerializer.Deserialize<Certificate>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var options = new JsonSerializerOptions {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        var obj = JsonSerializer.Deserialize<Certificate>(json, options);
         Assert.NotNull(obj);
     }
 
     [Fact]
     public void Deserialize_Profile_Succeeds() {
         const string json = "{\"id\":1}";
-        var obj = JsonSerializer.Deserialize<Profile>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var options = new JsonSerializerOptions {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        var obj = JsonSerializer.Deserialize<Profile>(json, options);
         Assert.NotNull(obj);
     }
 
     [Fact]
     public void CertificateStatus_RoundTrip_Succeeds() {
         foreach (CertificateStatus status in Enum.GetValues(typeof(CertificateStatus))) {
-            var json = JsonSerializer.Serialize(status);
-            var result = JsonSerializer.Deserialize<CertificateStatus>(json);
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            var json = JsonSerializer.Serialize(status, options);
+            var result = JsonSerializer.Deserialize<CertificateStatus>(json, options);
             Assert.Equal(status, result);
         }
     }
@@ -31,8 +40,9 @@ public sealed class SerializationTests {
     [Fact]
     public void OrderStatus_RoundTrip_Succeeds() {
         foreach (OrderStatus status in Enum.GetValues(typeof(OrderStatus))) {
-            var json = JsonSerializer.Serialize(status);
-            var result = JsonSerializer.Deserialize<OrderStatus>(json);
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            var json = JsonSerializer.Serialize(status, options);
+            var result = JsonSerializer.Deserialize<OrderStatus>(json, options);
             Assert.Equal(status, result);
         }
     }

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -4,12 +4,16 @@ using SectigoCertificateManager.Models;
 using SectigoCertificateManager.Requests;
 using SectigoCertificateManager.Responses;
 using System.Net.Http.Json;
+using System.Text.Json;
 
 /// <summary>
 /// Provides access to certificate related endpoints.
 /// </summary>
 public sealed class CertificatesClient {
     private readonly ISectigoClient _client;
+    private static readonly JsonSerializerOptions s_json = new() {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CertificatesClient"/> class.
@@ -25,7 +29,7 @@ public sealed class CertificatesClient {
     public async Task<Certificate?> GetAsync(int certificateId, CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync($"v1/certificate/{certificateId}", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<Certificate>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await response.Content.ReadFromJsonAsync<Certificate>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -34,9 +38,9 @@ public sealed class CertificatesClient {
     /// <param name="request">Payload describing the certificate to issue.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Certificate?> IssueAsync(IssueCertificateRequest request, CancellationToken cancellationToken = default) {
-        var response = await _client.PostAsync("v1/certificate/issue", JsonContent.Create(request), cancellationToken).ConfigureAwait(false);
+        var response = await _client.PostAsync("v1/certificate/issue", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<Certificate>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await response.Content.ReadFromJsonAsync<Certificate>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -46,7 +50,7 @@ public sealed class CertificatesClient {
         var query = BuildQuery(request);
         var response = await _client.GetAsync($"v1/certificate{query}", cancellationToken);
         response.EnsureSuccessStatusCode();
-        var items = await response.Content.ReadFromJsonAsync<IReadOnlyList<Certificate>>(cancellationToken: cancellationToken);
+        var items = await response.Content.ReadFromJsonAsync<IReadOnlyList<Certificate>>(s_json, cancellationToken);
         return items is null ? null : new CertificateResponse { Certificates = items };
     }
 

--- a/SectigoCertificateManager/Clients/OrderStatusClient.cs
+++ b/SectigoCertificateManager/Clients/OrderStatusClient.cs
@@ -1,12 +1,16 @@
 namespace SectigoCertificateManager.Clients;
 
 using System.Net.Http.Json;
+using System.Text.Json;
 
 /// <summary>
 /// Provides access to order status information.
 /// </summary>
 public sealed class OrderStatusClient {
     private readonly ISectigoClient _client;
+    private static readonly JsonSerializerOptions s_json = new() {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrderStatusClient"/> class.
@@ -22,7 +26,7 @@ public sealed class OrderStatusClient {
     public async Task<OrderStatus?> GetStatusAsync(int orderId, CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync($"v1/order/{orderId}/status", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        var result = await response.Content.ReadFromJsonAsync<StatusResponse>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        var result = await response.Content.ReadFromJsonAsync<StatusResponse>(s_json, cancellationToken).ConfigureAwait(false);
         return result?.Status;
     }
 

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -3,12 +3,16 @@ namespace SectigoCertificateManager.Clients;
 using SectigoCertificateManager.Models;
 using SectigoCertificateManager.Responses;
 using System.Net.Http.Json;
+using System.Text.Json;
 
 /// <summary>
 /// Provides access to order related endpoints.
 /// </summary>
 public sealed class OrdersClient {
     private readonly ISectigoClient _client;
+    private static readonly JsonSerializerOptions s_json = new() {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrdersClient"/> class.
@@ -24,7 +28,7 @@ public sealed class OrdersClient {
     public async Task<Order?> GetAsync(int orderId, CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync($"v1/order/{orderId}", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<Order>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await response.Content.ReadFromJsonAsync<Order>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -34,6 +38,6 @@ public sealed class OrdersClient {
     public async Task<IReadOnlyList<Order>?> ListOrdersAsync(CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync("v1/order", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<IReadOnlyList<Order>>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await response.Content.ReadFromJsonAsync<IReadOnlyList<Order>>(s_json, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/SectigoCertificateManager/Clients/OrganizationsClient.cs
+++ b/SectigoCertificateManager/Clients/OrganizationsClient.cs
@@ -4,12 +4,16 @@ using SectigoCertificateManager.Models;
 using SectigoCertificateManager.Requests;
 using System;
 using System.Net.Http.Json;
+using System.Text.Json;
 
 /// <summary>
 /// Provides access to organization related endpoints.
 /// </summary>
 public sealed class OrganizationsClient {
     private readonly ISectigoClient _client;
+    private static readonly JsonSerializerOptions s_json = new() {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrganizationsClient"/> class.
@@ -25,7 +29,7 @@ public sealed class OrganizationsClient {
     public async Task<Organization?> GetAsync(int organizationId, CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync($"v1/organization/{organizationId}", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<Organization>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await response.Content.ReadFromJsonAsync<Organization>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -35,7 +39,7 @@ public sealed class OrganizationsClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>The identifier of the created organization.</returns>
     public async Task<int> CreateAsync(CreateOrganizationRequest request, CancellationToken cancellationToken = default) {
-        var response = await _client.PostAsync("v1/organization", JsonContent.Create(request), cancellationToken).ConfigureAwait(false);
+        var response = await _client.PostAsync("v1/organization", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
         var location = response.Headers.Location;
         if (location is not null) {

--- a/SectigoCertificateManager/Clients/ProfilesClient.cs
+++ b/SectigoCertificateManager/Clients/ProfilesClient.cs
@@ -2,12 +2,16 @@ namespace SectigoCertificateManager.Clients;
 
 using SectigoCertificateManager.Models;
 using System.Net.Http.Json;
+using System.Text.Json;
 
 /// <summary>
 /// Provides access to profile related endpoints.
 /// </summary>
 public sealed class ProfilesClient {
     private readonly ISectigoClient _client;
+    private static readonly JsonSerializerOptions s_json = new() {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProfilesClient"/> class.
@@ -23,7 +27,7 @@ public sealed class ProfilesClient {
     public async Task<Profile?> GetAsync(int profileId, CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync($"v1/profile/{profileId}", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<Profile>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await response.Content.ReadFromJsonAsync<Profile>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -33,6 +37,6 @@ public sealed class ProfilesClient {
     public async Task<IReadOnlyList<Profile>?> ListProfilesAsync(CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync("v1/profile", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<IReadOnlyList<Profile>>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await response.Content.ReadFromJsonAsync<IReadOnlyList<Profile>>(s_json, cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary
- use camelCase property naming in all clients
- ensure serialization tests use the new options

## Testing
- `dotnet test --verbosity minimal`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6867d2e8f144832e8f20c2323c14b6f8