### PR TITLE
Add multiple SAN support to New-SectigoOrder

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,12 @@ Import-Module ./SectigoCertificateManager.PowerShell.dll
 
 Get-SectigoCertificate -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CertificateId 123
 
+
 Get-SectigoProfile -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -ProfileId 2
 
-New-SectigoOrder -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CommonName "example.com" -ProfileId 1
+New-SectigoOrder -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CommonName "example.com" -ProfileId 1 -SubjectAlternativeNames "www.example.com","admin.example.com"
 
 Get-SectigoOrders -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1"
 ```
+
+Use `-SubjectAlternativeNames` to specify multiple SAN values when placing an order.

--- a/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
@@ -33,7 +33,8 @@ public sealed class NewSectigoOrderCommand : PSCmdlet {
     public int Term { get; set; } = 12;
 
     [Parameter]
-    public string[] SubjectAlternativeName { get; set; } = System.Array.Empty<string>();
+    [Alias("SubjectAlternativeName", "San")]
+    public string[] SubjectAlternativeNames { get; set; } = System.Array.Empty<string>();
 
     /// <summary>Issues a certificate using provided parameters.</summary>
     /// <para>Builds an API client and submits an <see cref="IssueCertificateRequest"/>.</para>
@@ -45,7 +46,7 @@ public sealed class NewSectigoOrderCommand : PSCmdlet {
             CommonName = CommonName,
             ProfileId = ProfileId,
             Term = Term,
-            SubjectAlternativeNames = SubjectAlternativeName
+            SubjectAlternativeNames = SubjectAlternativeNames
         };
         var certificate = certificates.IssueAsync(request).GetAwaiter().GetResult();
         WriteObject(certificate);


### PR DESCRIPTION
## Summary
- accept multiple SANs via `-SubjectAlternativeNames`
- map them to `IssueCertificateRequest.SubjectAlternativeNames`
- document SAN usage in README

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6867d31ef180832eb27442a1301e4e16