### PR TITLE
Add base64 parsing helper

### DIFF
--- a/SectigoCertificateManager.Tests/CertificateTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateTests.cs
@@ -1,0 +1,22 @@
+using SectigoCertificateManager.Models;
+using System;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+public sealed class CertificateTests {
+    private const string Base64Cert = "MIIC/zCCAeegAwIBAgIULTQw6ATwfRI/1hVSQooJNHPEit8wDQYJKoZIhvcNAQELBQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yNTA3MDQxMzE2NDRaFw0yNTA3MDUxMzE2NDRaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDiO8kIwsJLCi3d8bX31IIISKSoA24iCcfV7m+uMm8CMdJlY2NGf8ThiF3suG2lHQCxESQacUrPFMN/J3cM7L+5R8p24CCnrmAP2WhMuO2IwFhgfjo4PsmnmCGNx5fDAPI+lnSS6pnHfZfAPw3dbPT2/cgbeil0q2ByFR6C2YXU+mFdOg7cJJ1f2GXbUL3QYRBuaDYCHRrDAym4e/8DkKjjaroDxw1BPD6sjvzrDdEDusJANDCp8K6Cr99nvG+YCLjueN+xvUXHbsp9gUfLI39X73p+M9zGcYGAeYyD/i+VM/+Kde5CEfS34eOKfRIJX6DHAbVu1SrJPNFFvQV0keb/AgMBAAGjUzBRMB0GA1UdDgQWBBQ8PwJEkQsHvU7i5i45XLLyJUi4eTAfBgNVHSMEGDAWgBQ8PwJEkQsHvU7i5i45XLLyJUi4eTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAjWADB2IC5xBHKOROcXZDa8mp3DaasUwL5mWjG7Ppr4LHrY1uCEojstJCg6s2FLBjGTs+0DTQ5UiBqSVJDK1GVhYG02xJSPoXNS4wNTp4a56NtbkDT96lO0BrH91lclMNXHU9NpMUFea0tt7h5tUeVtZ2CVK0nuy5MOifMdURVyhWsFgQVemmTNTYisVD5sNRvBJEq0M+3+JSjFYvRZVqfRSM3z1K4XcZJfhxv7Gq1ebb93R1QunIdGC0HiFnBZxpxhDCbcVOpbdbQOJ22dLSe5/4f+1V+D/bPCZJx5kF0yvM0jEhuQNxNV3H/DasvBhH/24JIjpe+WfKPw0jx7vR6";
+
+    [Fact]
+    public void FromBase64_CreatesCertificate() {
+        using var result = Certificate.FromBase64(Base64Cert);
+
+        Assert.Equal("51A908D14C9C984231B7E2F6C37ABB1368A57F1F", result.Thumbprint);
+    }
+
+    [Fact]
+    public void FromBase64_WithInvalidData_Throws() {
+        Assert.Throws<FormatException>(() => Certificate.FromBase64("invalid"));
+    }
+}

--- a/SectigoCertificateManager/Models/Certificate.cs
+++ b/SectigoCertificateManager/Models/Certificate.cs
@@ -2,6 +2,8 @@ namespace SectigoCertificateManager.Models;
 
 using SectigoCertificateManager;
 using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System;
 
 /// <summary>
 /// Represents a certificate returned by the Sectigo API.
@@ -66,4 +68,17 @@ public sealed class Certificate {
 
     /// <summary>Gets or sets a value indicating whether notifications are suspended.</summary>
     public bool SuspendNotifications { get; set; }
+
+    /// <summary>
+    /// Creates an <see cref="X509Certificate2"/> from a base64 encoded certificate.
+    /// </summary>
+    /// <param name="data">Base64 encoded certificate bytes.</param>
+    public static X509Certificate2 FromBase64(string data) {
+        if (string.IsNullOrWhiteSpace(data)) {
+            throw new ArgumentException("Value cannot be null or empty.", nameof(data));
+        }
+
+        var bytes = Convert.FromBase64String(data);
+        return new X509Certificate2(bytes);
+    }
 }


### PR DESCRIPTION
## Summary
- add `Certificate.FromBase64` helper for converting base64 text to an `X509Certificate2`
- cover the helper with unit tests

## Testing
- `dotnet test`
- `dotnet build SectigoCertificateManager.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6867d30ebc28832e8f4d68b49b4f112f