### PR TITLE
Remove EnsureSuccessStatusCode calls

### DIFF
--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -28,7 +28,6 @@ public sealed class CertificatesClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Certificate?> GetAsync(int certificateId, CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync($"v1/certificate/{certificateId}", cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<Certificate>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
@@ -39,7 +38,6 @@ public sealed class CertificatesClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Certificate?> IssueAsync(IssueCertificateRequest request, CancellationToken cancellationToken = default) {
         var response = await _client.PostAsync("v1/certificate/issue", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<Certificate>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
@@ -49,7 +47,6 @@ public sealed class CertificatesClient {
     public async Task<CertificateResponse?> SearchAsync(CertificateSearchRequest request, CancellationToken cancellationToken = default) {
         var query = BuildQuery(request);
         var response = await _client.GetAsync($"v1/certificate{query}", cancellationToken);
-        response.EnsureSuccessStatusCode();
         var items = await response.Content.ReadFromJsonAsync<IReadOnlyList<Certificate>>(s_json, cancellationToken);
         return items is null ? null : new CertificateResponse { Certificates = items };
     }

--- a/SectigoCertificateManager/Clients/OrderStatusClient.cs
+++ b/SectigoCertificateManager/Clients/OrderStatusClient.cs
@@ -25,7 +25,6 @@ public sealed class OrderStatusClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<OrderStatus?> GetStatusAsync(int orderId, CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync($"v1/order/{orderId}/status", cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadFromJsonAsync<StatusResponse>(s_json, cancellationToken).ConfigureAwait(false);
         return result?.Status;
     }

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -27,7 +27,6 @@ public sealed class OrdersClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Order?> GetAsync(int orderId, CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync($"v1/order/{orderId}", cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<Order>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
@@ -37,7 +36,6 @@ public sealed class OrdersClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<IReadOnlyList<Order>?> ListOrdersAsync(CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync("v1/order", cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<IReadOnlyList<Order>>(s_json, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/SectigoCertificateManager/Clients/OrganizationsClient.cs
+++ b/SectigoCertificateManager/Clients/OrganizationsClient.cs
@@ -28,7 +28,6 @@ public sealed class OrganizationsClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Organization?> GetAsync(int organizationId, CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync($"v1/organization/{organizationId}", cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<Organization>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
@@ -40,7 +39,6 @@ public sealed class OrganizationsClient {
     /// <returns>The identifier of the created organization.</returns>
     public async Task<int> CreateAsync(CreateOrganizationRequest request, CancellationToken cancellationToken = default) {
         var response = await _client.PostAsync("v1/organization", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
         var location = response.Headers.Location;
         if (location is not null) {
             var last = location.Segments[location.Segments.Length - 1];

--- a/SectigoCertificateManager/Clients/ProfilesClient.cs
+++ b/SectigoCertificateManager/Clients/ProfilesClient.cs
@@ -26,7 +26,6 @@ public sealed class ProfilesClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Profile?> GetAsync(int profileId, CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync($"v1/profile/{profileId}", cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<Profile>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
@@ -36,7 +35,6 @@ public sealed class ProfilesClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<IReadOnlyList<Profile>?> ListProfilesAsync(CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync("v1/profile", cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<IReadOnlyList<Profile>>(s_json, cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary
- remove explicit EnsureSuccessStatusCode calls in HTTP client wrappers

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -f net472 --logger "console;verbosity=normal"`
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -f net8.0 --logger "console;verbosity=normal"`
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -f net9.0 --logger "console;verbosity=normal"`


------
https://chatgpt.com/codex/tasks/task_e_68693f602210832ea0196f748d9102e0