### PR TITLE
Fix base URL validation in ApiConfigBuilder

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
@@ -43,4 +43,22 @@ public sealed class ApiConfigBuilderTests {
         Assert.Equal("tok", config.Token);
         Assert.Equal("https://example.com", config.BaseUrl);
     }
+
+    [Fact]
+    public void WithBaseUrl_ThrowsForInvalidUri() {
+        var builder = new ApiConfigBuilder();
+
+        Assert.Throws<ArgumentException>(() => builder.WithBaseUrl("not a url"));
+    }
+
+    [Fact]
+    public void WithBaseUrl_AllowsValidUri() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://example.com")
+            .WithToken("tok")
+            .WithCustomerUri("cst1")
+            .Build();
+
+        Assert.Equal("https://example.com", config.BaseUrl);
+    }
 }

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -20,6 +20,10 @@ public sealed class ApiConfigBuilder {
     /// <summary>Sets the base URL for the API endpoint.</summary>
     /// <param name="baseUrl">The root URL of the Sectigo API.</param>
     public ApiConfigBuilder WithBaseUrl(string baseUrl) {
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out _)) {
+            throw new ArgumentException("Base URL must be a valid absolute URI.", nameof(baseUrl));
+        }
+
         _baseUrl = baseUrl;
         return this;
     }


### PR DESCRIPTION
## Summary
- validate base URL with `Uri.TryCreate`
- test valid and invalid base URL inputs

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68693f76b348832e9fd60212ef0756db