### PR TITLE
Fix trailing slash parsing in OrganizationsClient

### DIFF
--- a/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
@@ -65,4 +65,19 @@ public sealed class OrganizationsClientTests {
         Assert.Contains("\"name\":\"org\"", handler.Body);
         Assert.Equal(10, id);
     }
+
+    [Fact]
+    public async Task CreateAsync_ParsesId_WhenLocationEndsWithSlash() {
+        var response = new HttpResponseMessage(HttpStatusCode.Created);
+        response.Headers.Location = new System.Uri("https://example.com/v1/organization/11/");
+
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var organizations = new OrganizationsClient(client);
+
+        var request = new CreateOrganizationRequest { Name = "org" };
+        var id = await organizations.CreateAsync(request);
+
+        Assert.Equal(11, id);
+    }
 }

--- a/SectigoCertificateManager/Clients/OrganizationsClient.cs
+++ b/SectigoCertificateManager/Clients/OrganizationsClient.cs
@@ -43,8 +43,9 @@ public sealed class OrganizationsClient {
         response.EnsureSuccessStatusCode();
         var location = response.Headers.Location;
         if (location is not null) {
-            var last = location.Segments[location.Segments.Length - 1];
-            if (int.TryParse(last, out var id)) {
+            var path = location.AbsolutePath.TrimEnd('/');
+            var segments = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length > 0 && int.TryParse(segments[segments.Length - 1], out var id)) {
                 return id;
             }
         }


### PR DESCRIPTION
## Summary
- handle trailing slashes when parsing `Location` header in `OrganizationsClient`
- parse numeric organization id safely
- add regression test for trailing slash scenario

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68693f7e2adc832e83b66cad465355eb