### PR TITLE
Fix export to nested directories

### DIFF
--- a/SectigoCertificateManager.Tests/CertificateExportTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateExportTests.cs
@@ -36,6 +36,21 @@ public sealed class CertificateExportTests {
     }
 
     [Fact]
+    public void SavePem_WritesFile_ToNewDirectory() {
+        using var cert = CreateCertificate();
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(dir, "cert.pem");
+        try {
+            CertificateExport.SavePem(cert, path);
+            Assert.True(File.Exists(path));
+        } finally {
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+
+    [Fact]
     public void SaveDer_WritesFile() {
         using var cert = CreateCertificate();
         var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -50,6 +65,21 @@ public sealed class CertificateExportTests {
     }
 
     [Fact]
+    public void SaveDer_WritesFile_ToNewDirectory() {
+        using var cert = CreateCertificate();
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(dir, "cert.der");
+        try {
+            CertificateExport.SaveDer(cert, path);
+            Assert.True(File.Exists(path));
+        } finally {
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+
+    [Fact]
     public void SavePfx_WritesFile() {
         using var cert = CreateCertificate();
         var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -60,6 +90,23 @@ public sealed class CertificateExportTests {
             Assert.Equal(cert.Thumbprint, loaded.Thumbprint);
         } finally {
             File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SavePfx_WritesFile_ToNewDirectory() {
+        using var cert = CreateCertificate();
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(dir, "cert.pfx");
+        try {
+            CertificateExport.SavePfx(cert, path, "pwd");
+            Assert.True(File.Exists(path));
+            using var loaded = new X509Certificate2(path, "pwd");
+            Assert.Equal(cert.Thumbprint, loaded.Thumbprint);
+        } finally {
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
+            }
         }
     }
 }

--- a/SectigoCertificateManager/Utilities/CertificateExport.cs
+++ b/SectigoCertificateManager/Utilities/CertificateExport.cs
@@ -13,6 +13,7 @@ public static class CertificateExport {
     /// <param name="certificate">Certificate to export.</param>
     /// <param name="path">Destination file path.</param>
     public static void SavePem(X509Certificate2 certificate, string path) {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         var builder = new StringBuilder();
         builder.AppendLine("-----BEGIN CERTIFICATE-----");
         builder.AppendLine(Convert.ToBase64String(certificate.Export(X509ContentType.Cert), Base64FormattingOptions.InsertLineBreaks));
@@ -24,6 +25,7 @@ public static class CertificateExport {
     /// <param name="certificate">Certificate to export.</param>
     /// <param name="path">Destination file path.</param>
     public static void SaveDer(X509Certificate2 certificate, string path) {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         File.WriteAllBytes(path, certificate.Export(X509ContentType.Cert));
     }
 
@@ -32,6 +34,7 @@ public static class CertificateExport {
     /// <param name="path">Destination file path.</param>
     /// <param name="password">Optional password protecting the PFX.</param>
     public static void SavePfx(X509Certificate2 certificate, string path, string? password = null) {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         var bytes = password is null
             ? certificate.Export(X509ContentType.Pfx)
             : certificate.Export(X509ContentType.Pfx, password);


### PR DESCRIPTION
## Summary
- ensure `CertificateExport` creates directories before writing
- test export to non-existent directories

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68693f944ae4832ebb7cc3e348e35e65