### PR TITLE
Ensure csproj nullable and fix build warnings

### DIFF
--- a/SectigoCertificateManager.PowerShell/GetSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoCertificateCommand.cs
@@ -4,27 +4,35 @@ using System.Management.Automation;
 
 namespace SectigoCertificateManager.PowerShell;
 
+/// <summary>Retrieves a certificate from Sectigo Certificate Manager.</summary>
 [Cmdlet(VerbsCommon.Get, "SectigoCertificate")]
 [OutputType(typeof(Models.Certificate))]
 public sealed class GetSectigoCertificateCommand : PSCmdlet {
+    /// <para>Base address of the Sectigo API.</para>
     [Parameter(Mandatory = true)]
     public string BaseUrl { get; set; } = string.Empty;
 
+    /// <para>API username.</para>
     [Parameter(Mandatory = true)]
     public string Username { get; set; } = string.Empty;
 
+    /// <para>API password.</para>
     [Parameter(Mandatory = true)]
     public string Password { get; set; } = string.Empty;
 
+    /// <para>Customer URI associated with the account.</para>
     [Parameter(Mandatory = true)]
     public string CustomerUri { get; set; } = string.Empty;
 
+    /// <para>API version to use.</para>
     [Parameter]
     public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
 
+    /// <para>Identifier of the certificate to retrieve.</para>
     [Parameter(Mandatory = true, Position = 0)]
     public int CertificateId { get; set; }
 
+    /// <summary>Executes the cmdlet.</summary>
     protected override void ProcessRecord() {
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);

--- a/SectigoCertificateManager.PowerShell/GetSectigoOrdersCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoOrdersCommand.cs
@@ -4,24 +4,31 @@ using System.Management.Automation;
 
 namespace SectigoCertificateManager.PowerShell;
 
+/// <summary>Lists orders from Sectigo Certificate Manager.</summary>
 [Cmdlet(VerbsCommon.Get, "SectigoOrders")]
 [OutputType(typeof(Models.Order))]
 public sealed class GetSectigoOrdersCommand : PSCmdlet {
+    /// <para>Base address of the Sectigo API.</para>
     [Parameter(Mandatory = true)]
     public string BaseUrl { get; set; } = string.Empty;
 
+    /// <para>API username.</para>
     [Parameter(Mandatory = true)]
     public string Username { get; set; } = string.Empty;
 
+    /// <para>API password.</para>
     [Parameter(Mandatory = true)]
     public string Password { get; set; } = string.Empty;
 
+    /// <para>Customer URI associated with the account.</para>
     [Parameter(Mandatory = true)]
     public string CustomerUri { get; set; } = string.Empty;
 
+    /// <para>API version to use.</para>
     [Parameter]
     public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
 
+    /// <summary>Executes the cmdlet.</summary>
     protected override void ProcessRecord() {
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);

--- a/SectigoCertificateManager.PowerShell/GetSectigoProfileCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoProfileCommand.cs
@@ -4,27 +4,35 @@ using System.Management.Automation;
 
 namespace SectigoCertificateManager.PowerShell;
 
+/// <summary>Retrieves a profile from Sectigo Certificate Manager.</summary>
 [Cmdlet(VerbsCommon.Get, "SectigoProfile")]
 [OutputType(typeof(Models.Profile))]
 public sealed class GetSectigoProfileCommand : PSCmdlet {
+    /// <para>Base address of the Sectigo API.</para>
     [Parameter(Mandatory = true)]
     public string BaseUrl { get; set; } = string.Empty;
 
+    /// <para>API username.</para>
     [Parameter(Mandatory = true)]
     public string Username { get; set; } = string.Empty;
 
+    /// <para>API password.</para>
     [Parameter(Mandatory = true)]
     public string Password { get; set; } = string.Empty;
 
+    /// <para>Customer URI associated with the account.</para>
     [Parameter(Mandatory = true)]
     public string CustomerUri { get; set; } = string.Empty;
 
+    /// <para>API version to use.</para>
     [Parameter]
     public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
 
+    /// <para>Identifier of the profile to retrieve.</para>
     [Parameter(Mandatory = true, Position = 0)]
     public int ProfileId { get; set; }
 
+    /// <summary>Executes the cmdlet.</summary>
     protected override void ProcessRecord() {
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);

--- a/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
@@ -5,33 +5,43 @@ using System.Management.Automation;
 
 namespace SectigoCertificateManager.PowerShell;
 
+/// <summary>Submits a new certificate order to Sectigo.</summary>
 [Cmdlet(VerbsCommon.New, "SectigoOrder")]
 [OutputType(typeof(Models.Certificate))]
 public sealed class NewSectigoOrderCommand : PSCmdlet {
+    /// <para>Base address of the Sectigo API.</para>
     [Parameter(Mandatory = true)]
     public string BaseUrl { get; set; } = string.Empty;
 
+    /// <para>API username.</para>
     [Parameter(Mandatory = true)]
     public string Username { get; set; } = string.Empty;
 
+    /// <para>API password.</para>
     [Parameter(Mandatory = true)]
     public string Password { get; set; } = string.Empty;
 
+    /// <para>Customer URI associated with the account.</para>
     [Parameter(Mandatory = true)]
     public string CustomerUri { get; set; } = string.Empty;
 
+    /// <para>API version to use.</para>
     [Parameter]
     public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
 
+    /// <para>Common name for the certificate.</para>
     [Parameter(Mandatory = true)]
     public string CommonName { get; set; } = string.Empty;
 
+    /// <para>Identifier of the certificate profile.</para>
     [Parameter(Mandatory = true)]
     public int ProfileId { get; set; }
 
+    /// <para>Certificate term in months.</para>
     [Parameter]
     public int Term { get; set; } = 12;
 
+    /// <para>Subject alternative names for the certificate.</para>
     [Parameter]
     [Alias("SubjectAlternativeName", "San")]
     public string[] SubjectAlternativeNames { get; set; } = System.Array.Empty<string>();

--- a/SectigoCertificateManager.Tests/CertificateExportTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateExportTests.cs
@@ -56,8 +56,20 @@ public sealed class CertificateExportTests {
         try {
             CertificateExport.SavePfx(cert, path, "pwd");
             Assert.True(File.Exists(path));
+#if NET472
             using var loaded = new X509Certificate2(path, "pwd");
             Assert.Equal(cert.Thumbprint, loaded.Thumbprint);
+#elif NET9_0_OR_GREATER
+            using var loaded = X509CertificateLoader.LoadPkcs12FromFile(
+                path,
+                "pwd",
+                X509KeyStorageFlags.DefaultKeySet,
+                Pkcs12LoaderLimits.Defaults);
+            Assert.Equal(cert.Thumbprint, loaded.Thumbprint);
+#else
+            using var loaded = new X509Certificate2(path, "pwd");
+            Assert.Equal(cert.Thumbprint, loaded.Thumbprint);
+#endif
         } finally {
             File.Delete(path);
         }

--- a/SectigoCertificateManager/Models/Certificate.cs
+++ b/SectigoCertificateManager/Models/Certificate.cs
@@ -79,6 +79,10 @@ public sealed class Certificate {
         }
 
         var bytes = Convert.FromBase64String(data);
+#if NET9_0_OR_GREATER
+        return X509CertificateLoader.LoadCertificate(bytes);
+#else
         return new X509Certificate2(bytes);
+#endif
     }
 }


### PR DESCRIPTION
## Summary
- update certificate creation to use `X509CertificateLoader` on .NET 9
- document PowerShell cmdlets per XmlDoc2CmdletDoc
- adjust test certificate loading for .NET versions

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68693fa8dff4832e96801eac36184409