### PR TITLE
Add error and cancellation token tests

### DIFF
--- a/SectigoCertificateManager.Tests/OrdersClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrdersClientTests.cs
@@ -13,12 +13,14 @@ namespace SectigoCertificateManager.Tests;
 public sealed class OrdersClientTests {
     private sealed class TestHandler : HttpMessageHandler {
         private readonly HttpResponseMessage _response;
+        public CancellationToken Token { get; private set; }
         public HttpRequestMessage? Request { get; private set; }
 
         public TestHandler(HttpResponseMessage response) => _response = response;
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
             Request = request;
+            Token = cancellationToken;
             return Task.FromResult(_response);
         }
     }
@@ -41,5 +43,35 @@ public sealed class OrdersClientTests {
         Assert.NotNull(result);
         Assert.Single(result!);
         Assert.Equal(1, result[0].Id);
+    }
+
+    [Fact]
+    public async Task GetAsync_ThrowsApiExceptionOnFailure() {
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError) {
+            Content = JsonContent.Create(new ApiError { Code = -2, Description = "fail" })
+        };
+
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var orders = new OrdersClient(client);
+
+        var ex = await Assert.ThrowsAsync<ApiException>(() => orders.GetAsync(7));
+        Assert.Equal(-2, ex.ErrorCode);
+    }
+
+    [Fact]
+    public async Task GetAsync_PassesCancellationToken() {
+        var order = new Order { Id = 2 };
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create(order)
+        };
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var orders = new OrdersClient(client);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() => orders.GetAsync(2, cts.Token));
     }
 }


### PR DESCRIPTION
## Summary
- add test for error responses and cancellation tokens in `OrdersClient`
- check cancellation token handling in `SectigoClient`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68693fbc8ae0832e8f0e58db1bb3c2c6