### PR TITLE
Add certificate revocation support

### DIFF
--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -44,6 +44,16 @@ public sealed class CertificatesClient {
     }
 
     /// <summary>
+    /// Revokes a certificate.
+    /// </summary>
+    /// <param name="request">Payload describing the certificate to revoke.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task RevokeAsync(RevokeCertificateRequest request, CancellationToken cancellationToken = default) {
+        var response = await _client.PostAsync("v1/certificate/revoke", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>
     /// Searches for certificates using the provided filter.
     /// </summary>
     public async Task<CertificateResponse?> SearchAsync(CertificateSearchRequest request, CancellationToken cancellationToken = default) {

--- a/SectigoCertificateManager/Requests/RevokeCertificateRequest.cs
+++ b/SectigoCertificateManager/Requests/RevokeCertificateRequest.cs
@@ -1,0 +1,24 @@
+namespace SectigoCertificateManager.Requests;
+
+/// <summary>
+/// Request payload used to revoke a certificate.
+/// </summary>
+public sealed class RevokeCertificateRequest {
+    /// <summary>Gets or sets the certificate identifier.</summary>
+    public int? CertId { get; set; }
+
+    /// <summary>Gets or sets the certificate serial number.</summary>
+    public string? SerialNumber { get; set; }
+
+    /// <summary>Gets or sets the certificate issuer.</summary>
+    public string? Issuer { get; set; }
+
+    /// <summary>Gets or sets the revocation date.</summary>
+    public DateTimeOffset? RevokeDate { get; set; }
+
+    /// <summary>Gets or sets the revocation reason code.</summary>
+    public int ReasonCode { get; set; }
+
+    /// <summary>Gets or sets the revocation reason message.</summary>
+    public string? Reason { get; set; }
+}


### PR DESCRIPTION
## Summary
- support revoking certificates with `RevokeAsync`
- include `RevokeCertificateRequest` model
- test revocation request payload

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -f net8.0`
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -f net9.0`
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -f net472`

------
https://chatgpt.com/codex/tasks/task_e_68693fd84630832e814e092883db75c8