### PR TITLE
Add order cancellation

### DIFF
--- a/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
@@ -1,0 +1,35 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using System.Management.Automation;
+
+namespace SectigoCertificateManager.PowerShell;
+
+[Cmdlet(VerbsLifecycle.Stop, "SectigoOrder")]
+public sealed class StopSectigoOrderCommand : PSCmdlet {
+    [Parameter(Mandatory = true)]
+    public string BaseUrl { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string Username { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string Password { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string CustomerUri { get; set; } = string.Empty;
+
+    [Parameter]
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+
+    [Parameter(Mandatory = true, Position = 0)]
+    public int OrderId { get; set; }
+
+    /// <summary>Cancels an order.</summary>
+    /// <para>Builds an API client and calls the cancel endpoint.</para>
+    protected override void ProcessRecord() {
+        var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
+        var client = new SectigoClient(config);
+        var orders = new OrdersClient(client);
+        orders.CancelAsync(OrderId).GetAwaiter().GetResult();
+    }
+}

--- a/SectigoCertificateManager.Tests/OrdersClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrdersClientTests.cs
@@ -42,4 +42,18 @@ public sealed class OrdersClientTests {
         Assert.Single(result!);
         Assert.Equal(1, result[0].Id);
     }
+
+    [Fact]
+    public async Task CancelAsync_SendsPostRequest() {
+        var response = new HttpResponseMessage(HttpStatusCode.NoContent);
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var orders = new OrdersClient(client);
+
+        await orders.CancelAsync(5);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal(HttpMethod.Post, handler.Request!.Method);
+        Assert.Equal("https://example.com/v1/order/5/cancel", handler.Request.RequestUri!.ToString());
+    }
 }

--- a/SectigoCertificateManager.Tests/SectigoApiIntegrationTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoApiIntegrationTests.cs
@@ -91,4 +91,11 @@ public sealed class SectigoApiIntegrationTests : IAsyncLifetime {
         Assert.Equal(3, result[0].Id);
     }
 
+    [Fact]
+    public async Task OrdersClient_Cancel_Succeeds() {
+        _server.Given(Request.Create().WithPath("/v1/order/7/cancel").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+        await _orders.CancelAsync(7);
+    }
 }

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -2,6 +2,7 @@ namespace SectigoCertificateManager.Clients;
 
 using SectigoCertificateManager.Models;
 using SectigoCertificateManager.Responses;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 
@@ -39,5 +40,15 @@ public sealed class OrdersClient {
         var response = await _client.GetAsync("v1/order", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<IReadOnlyList<Order>>(s_json, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Cancels an order by identifier.
+    /// </summary>
+    /// <param name="orderId">Identifier of the order to cancel.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task CancelAsync(int orderId, CancellationToken cancellationToken = default) {
+        var response = await _client.PostAsync($"v1/order/{orderId}/cancel", new StringContent(string.Empty), cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
     }
 }


### PR DESCRIPTION
## Summary
- implement `CancelAsync` in OrdersClient
- add `Stop-SectigoOrder` PowerShell cmdlet
- cover new behavior with unit tests

## Testing
- `dotnet restore`
- `dotnet test --no-build` *(fails: The argument ... is invalid)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68693fe26ef4832e9153b4413b7312db