### PR TITLE
Validate Term on certificate issue

### DIFF
--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -3,6 +3,7 @@ using SectigoCertificateManager.Clients;
 using SectigoCertificateManager.Models;
 using SectigoCertificateManager.Requests;
 using SectigoCertificateManager.Responses;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -73,6 +74,18 @@ public sealed class CertificatesClientTests {
         var actualResult = result!;
         Assert.Equal(2, actualResult.Id);
         Assert.Equal("example.com", actualResult.CommonName);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public async Task IssueAsync_InvalidTerm_Throws(int term) {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var certificates = new CertificatesClient(client);
+
+        var request = new IssueCertificateRequest { CommonName = "example.com", ProfileId = 1, Term = term };
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.IssueAsync(request));
     }
 
     [Fact]

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -37,6 +37,14 @@ public sealed class CertificatesClient {
     /// <param name="request">Payload describing the certificate to issue.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Certificate?> IssueAsync(IssueCertificateRequest request, CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        if (request.Term <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(request.Term));
+        }
+
         var response = await _client.PostAsync("v1/certificate/issue", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         return await response.Content.ReadFromJsonAsync<Certificate>(s_json, cancellationToken).ConfigureAwait(false);
     }


### PR DESCRIPTION
## Summary
- throw `ArgumentOutOfRangeException` when issuing a certificate with `Term <= 0`
- add unit tests covering the new validation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686950933fac832eaef64340662e6169