### PR TITLE
Fix ProfilesClient collection return

### DIFF
--- a/SectigoCertificateManager.Tests/ProfilesClientTests.cs
+++ b/SectigoCertificateManager.Tests/ProfilesClientTests.cs
@@ -76,7 +76,23 @@ public sealed class ProfilesClientTests {
         Assert.NotNull(client.Request);
         Assert.Equal("v1/profile", client.Request!.RequestUri!.ToString());
         Assert.NotNull(result);
-        Assert.Single(result!);
+        Assert.Single(result);
         Assert.Equal(2, result[0].Id);
+    }
+
+    [Fact]
+    public async Task ListProfilesAsync_ReturnsEmpty_WhenResponseNull() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create<object?>(null)
+        };
+        var client = new StubClient(response);
+        var profiles = new ProfilesClient(client);
+
+        var result = await profiles.ListProfilesAsync();
+
+        Assert.NotNull(client.Request);
+        Assert.Equal("v1/profile", client.Request!.RequestUri!.ToString());
+        Assert.NotNull(result);
+        Assert.Empty(result);
     }
 }

--- a/SectigoCertificateManager/Clients/ProfilesClient.cs
+++ b/SectigoCertificateManager/Clients/ProfilesClient.cs
@@ -33,8 +33,11 @@ public sealed class ProfilesClient {
     /// Retrieves all profiles visible to the user.
     /// </summary>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    public async Task<IReadOnlyList<Profile>?> ListProfilesAsync(CancellationToken cancellationToken = default) {
+    public async Task<IReadOnlyList<Profile>> ListProfilesAsync(CancellationToken cancellationToken = default) {
         var response = await _client.GetAsync("v1/profile", cancellationToken).ConfigureAwait(false);
-        return await response.Content.ReadFromJsonAsync<IReadOnlyList<Profile>>(s_json, cancellationToken).ConfigureAwait(false);
+        var profiles = await response.Content
+            .ReadFromJsonAsync<IReadOnlyList<Profile>>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+        return profiles ?? Array.Empty<Profile>();
     }
 }


### PR DESCRIPTION
## Summary
- ensure `ProfilesClient.ListProfilesAsync` returns an empty array instead of null
- cover null payload case in tests

## Testing
- `dotnet test` *(fails: System.BadImageFormatException)*

------
https://chatgpt.com/codex/tasks/task_e_6869508c7cac832eaa37756cce600c77