### PR TITLE
Implement IDisposable pattern for SectigoClient

### DIFF
--- a/SectigoCertificateManager.Tests/SectigoClientTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientTests.cs
@@ -126,6 +126,19 @@ public sealed class SectigoClientTests {
     }
 
     [Fact]
+    public void DisposeIsIdempotent() {
+        var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
+        var handler = new DisposableHandler();
+        var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(config, httpClient);
+
+        client.Dispose();
+        client.Dispose();
+
+        Assert.True(handler.Disposed);
+    }
+
+    [Fact]
     public async Task MethodsThrowAfterDispose() {
         var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
         var handler = new TestHandler();

--- a/SectigoCertificateManager/SectigoClient.cs
+++ b/SectigoCertificateManager/SectigoClient.cs
@@ -18,10 +18,21 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
     private DateTimeOffset? _tokenExpiresAt;
     private bool _disposed;
 
+    private void ThrowIfDisposed() {
+        if (_disposed) {
+            throw new ObjectDisposedException(nameof(SectigoClient));
+        }
+    }
+
     /// <summary>
     /// Gets the underlying <see cref="HttpClient"/> instance used for requests.
     /// </summary>
-    public HttpClient HttpClient => _client;
+    public HttpClient HttpClient {
+        get {
+            ThrowIfDisposed();
+            return _client;
+        }
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SectigoClient"/> class.
@@ -53,6 +64,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
     /// <param name="requestUri">Relative request URI.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<HttpResponseMessage> GetAsync(string requestUri, CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
         await EnsureValidTokenAsync(cancellationToken).ConfigureAwait(false);
         var response = await _client.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response).ConfigureAwait(false);
@@ -66,6 +78,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
     /// <param name="content">HTTP content to send.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
         await EnsureValidTokenAsync(cancellationToken).ConfigureAwait(false);
         var response = await _client.PostAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response).ConfigureAwait(false);
@@ -79,6 +92,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
     /// <param name="content">HTTP content to send.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
         await EnsureValidTokenAsync(cancellationToken).ConfigureAwait(false);
         var response = await _client.PutAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response).ConfigureAwait(false);
@@ -91,6 +105,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
     /// <param name="requestUri">Relative request URI.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<HttpResponseMessage> DeleteAsync(string requestUri, CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
         await EnsureValidTokenAsync(cancellationToken).ConfigureAwait(false);
         var response = await _client.DeleteAsync(requestUri, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- ensure `SectigoClient` checks for disposal before requests
- expose `HttpClient` only when not disposed
- add idempotent dispose test

## Testing
- `dotnet test --no-build -v n`

------
https://chatgpt.com/codex/tasks/task_e_6869730dba30832e8a46e53a328c68e0