### PR TITLE
Add null guard to handler config

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
@@ -78,4 +78,11 @@ public sealed class ApiConfigBuilderTests {
         Assert.Equal(expires, config.TokenExpiresAt);
         Assert.Same(del, config.RefreshToken);
     }
+
+    [Fact]
+    public void WithHttpClientHandler_ThrowsForNullDelegate() {
+        var builder = new ApiConfigBuilder();
+
+        Assert.Throws<ArgumentNullException>(() => builder.WithHttpClientHandler(null!));
+    }
 }

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -86,6 +86,10 @@ public sealed class ApiConfigBuilder {
     /// <summary>Allows configuration of the <see cref="HttpClientHandler"/> used by <see cref="SectigoClient"/>.</summary>
     /// <param name="configure">Delegate used to configure the handler.</param>
     public ApiConfigBuilder WithHttpClientHandler(Action<HttpClientHandler> configure) {
+        if (configure is null) {
+            throw new ArgumentNullException(nameof(configure));
+        }
+
         _configureHandler = configure;
         return this;
     }


### PR DESCRIPTION
## Summary
- guard against null handler delegate in `WithHttpClientHandler`
- add unit test for the new `ArgumentNullException`

## Testing
- `dotnet test -c Debug`


------
https://chatgpt.com/codex/tasks/task_e_686972fdfa0c832ea0c6eec1e5cc066b