### PR TITLE
Add path validation to export helpers

### DIFF
--- a/SectigoCertificateManager.Tests/CertificateExportTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateExportTests.cs
@@ -35,6 +35,22 @@ public sealed class CertificateExportTests {
         }
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void SavePem_InvalidPath_Throws(string path) {
+        using var cert = CreateCertificate();
+        Assert.Throws<ArgumentException>(() => CertificateExport.SavePem(cert, path!));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void SaveDer_InvalidPath_Throws(string path) {
+        using var cert = CreateCertificate();
+        Assert.Throws<ArgumentException>(() => CertificateExport.SaveDer(cert, path!));
+    }
+
     [Fact]
     public void SaveDer_WritesFile() {
         using var cert = CreateCertificate();
@@ -61,6 +77,14 @@ public sealed class CertificateExportTests {
         } finally {
             File.Delete(path);
         }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void SavePfx_InvalidPath_Throws(string path) {
+        using var cert = CreateCertificate();
+        Assert.Throws<ArgumentException>(() => CertificateExport.SavePfx(cert, path!, null));
     }
 
     [Fact]

--- a/SectigoCertificateManager/Utilities/CertificateExport.cs
+++ b/SectigoCertificateManager/Utilities/CertificateExport.cs
@@ -14,6 +14,9 @@ public static class CertificateExport {
     /// <param name="certificate">Certificate to export.</param>
     /// <param name="path">Destination file path.</param>
     public static void SavePem(X509Certificate2 certificate, string path) {
+        if (string.IsNullOrEmpty(path)) {
+            throw new ArgumentException("Path cannot be null or empty.", nameof(path));
+        }
         var builder = new StringBuilder();
         builder.AppendLine("-----BEGIN CERTIFICATE-----");
         builder.AppendLine(Convert.ToBase64String(certificate.Export(X509ContentType.Cert), Base64FormattingOptions.InsertLineBreaks));
@@ -25,6 +28,9 @@ public static class CertificateExport {
     /// <param name="certificate">Certificate to export.</param>
     /// <param name="path">Destination file path.</param>
     public static void SaveDer(X509Certificate2 certificate, string path) {
+        if (string.IsNullOrEmpty(path)) {
+            throw new ArgumentException("Path cannot be null or empty.", nameof(path));
+        }
         File.WriteAllBytes(path, certificate.Export(X509ContentType.Cert));
     }
 
@@ -33,6 +39,9 @@ public static class CertificateExport {
     /// <param name="path">Destination file path.</param>
     /// <param name="password">Optional password protecting the PFX.</param>
     public static void SavePfx(X509Certificate2 certificate, string path, string? password = null) {
+        if (string.IsNullOrEmpty(path)) {
+            throw new ArgumentException("Path cannot be null or empty.", nameof(path));
+        }
         var bytes = password is null
             ? certificate.Export(X509ContentType.Pfx)
             : certificate.Export(X509ContentType.Pfx, password);


### PR DESCRIPTION
## Summary
- validate null or empty paths for certificate export helpers
- test the new validations across frameworks

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686a15e5a550832ebb17b34a46d76f81