### PR TITLE
Fix FileStream usage and buffer clearing

### DIFF
--- a/SectigoCertificateManager/Utilities/CertificateExport.cs
+++ b/SectigoCertificateManager/Utilities/CertificateExport.cs
@@ -36,7 +36,9 @@ public static class CertificateExport {
         var bytes = password is null
             ? certificate.Export(X509ContentType.Pfx)
             : certificate.Export(X509ContentType.Pfx, password);
-        File.WriteAllBytes(path, bytes);
+        using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None)) {
+            stream.Write(bytes, 0, bytes.Length);
+        }
 #if NET6_0_OR_GREATER
         CryptographicOperations.ZeroMemory(bytes);
 #else
@@ -55,7 +57,9 @@ public static class CertificateExport {
         var bytes = password is null
             ? certificate.Export(X509ContentType.Pfx)
             : certificate.Export(X509ContentType.Pfx, password);
-        File.WriteAllBytes(path, bytes);
+        using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None)) {
+            stream.Write(bytes, 0, bytes.Length);
+        }
 #if NET6_0_OR_GREATER
         CryptographicOperations.ZeroMemory(bytes);
 #else


### PR DESCRIPTION
## Summary
- open a FileStream in `CertificateExport.SavePfx` and `SavePfxForTest`
- write bytes to the stream and then clear the buffer

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj --no-build --verbosity minimal`
- `dotnet build --no-restore --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_686a1602af20832ebf400a0f7d50196e