### PR TITLE
Fix integration test setup cleanup

### DIFF
--- a/SectigoCertificateManager.Tests/SectigoApiIntegrationTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoApiIntegrationTests.cs
@@ -18,13 +18,23 @@ public sealed class SectigoApiIntegrationTests : IAsyncLifetime {
     private ProfilesClient _profiles = null!;
 
     public Task InitializeAsync() {
+        var success = false;
         _server = WireMockServer.Start();
-        var config = new ApiConfig(_server.Url!, "user", "pass", "cst1", ApiVersion.V25_4);
-        var client = new SectigoClient(config, new HttpClient());
-        _certificates = new CertificatesClient(client);
-        _orders = new OrdersClient(client);
-        _profiles = new ProfilesClient(client);
-        return Task.CompletedTask;
+        try {
+            var config = new ApiConfig(_server.Url!, "user", "pass", "cst1", ApiVersion.V25_4);
+            var client = new SectigoClient(config, new HttpClient());
+            _certificates = new CertificatesClient(client);
+            _orders = new OrdersClient(client);
+            _profiles = new ProfilesClient(client);
+            success = true;
+            return Task.CompletedTask;
+        }
+        finally {
+            if (!success) {
+                _server.Stop();
+                _server.Dispose();
+            }
+        }
     }
 
     public Task DisposeAsync() {


### PR DESCRIPTION
## Summary
- dispose the mock server if initialization fails
- verify the full test suite still passes across target frameworks

## Testing
- `dotnet restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686a160f9980832eaacb9c9682f3d483