### PR TITLE
Add data annotation validation

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/ValidationExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/ValidationExample.cs
@@ -1,0 +1,19 @@
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Requests;
+using SectigoCertificateManager.Utilities;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates client-side validation failures.
+/// </summary>
+public static class ValidationExample {
+    public static void Run() {
+        var request = new IssueCertificateRequest();
+        try {
+            RequestValidator.Validate(request);
+        } catch (System.ComponentModel.DataAnnotations.ValidationException ex) {
+            Console.WriteLine($"Validation failed: {ex.Message}");
+        }
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -1,3 +1,4 @@
 using SectigoCertificateManager.Examples.Examples;
 
 await BasicApiExample.RunAsync();
+ValidationExample.Run();

--- a/SectigoCertificateManager.PowerShell/Examples/ValidationExample.ps1
+++ b/SectigoCertificateManager.PowerShell/Examples/ValidationExample.ps1
@@ -1,0 +1,6 @@
+# Demonstrates validation behavior in the PowerShell module
+try {
+    New-SectigoOrder -BaseUrl 'https://example.com/' -Username 'user' -Password 'pass' -CustomerUri 'cust' -CommonName '' -ProfileId 1 -Term 0
+} catch {
+    Write-Host $_.Exception.Message
+}

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -85,7 +85,7 @@ public sealed class CertificatesClientTests {
         var certificates = new CertificatesClient(client);
 
         var request = new IssueCertificateRequest { CommonName = "example.com", ProfileId = 1, Term = term };
-        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.IssueAsync(request));
+        await Assert.ThrowsAsync<System.ComponentModel.DataAnnotations.ValidationException>(() => certificates.IssueAsync(request));
     }
 
     [Fact]

--- a/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
@@ -80,4 +80,14 @@ public sealed class OrganizationsClientTests {
 
         Assert.Equal(11, id);
     }
+
+    [Fact]
+    public async Task CreateAsync_InvalidRequest_Throws() {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.Created));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var organizations = new OrganizationsClient(client);
+
+        var request = new CreateOrganizationRequest();
+        await Assert.ThrowsAsync<System.ComponentModel.DataAnnotations.ValidationException>(() => organizations.CreateAsync(request));
+    }
 }

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -3,6 +3,7 @@ namespace SectigoCertificateManager.Clients;
 using SectigoCertificateManager.Models;
 using SectigoCertificateManager.Requests;
 using SectigoCertificateManager.Responses;
+using SectigoCertificateManager.Utilities;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
@@ -42,9 +43,7 @@ public sealed class CertificatesClient {
             throw new ArgumentNullException(nameof(request));
         }
 
-        if (request.Term <= 0) {
-            throw new ArgumentOutOfRangeException(nameof(request.Term));
-        }
+        RequestValidator.Validate(request);
 
         var response = await _client.PostAsync("v1/certificate/issue", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         return await response.Content.ReadFromJsonAsync<Certificate>(s_json, cancellationToken).ConfigureAwait(false);
@@ -56,6 +55,7 @@ public sealed class CertificatesClient {
     /// <param name="request">Payload describing the certificate to revoke.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task RevokeAsync(RevokeCertificateRequest request, CancellationToken cancellationToken = default) {
+        RequestValidator.Validate(request);
         var response = await _client.PostAsync("v1/certificate/revoke", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
@@ -68,6 +68,7 @@ public sealed class CertificatesClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>The identifier of the newly issued certificate.</returns>
     public async Task<int> RenewAsync(int certificateId, RenewCertificateRequest request, CancellationToken cancellationToken = default) {
+        RequestValidator.Validate(request);
         var response = await _client.PostAsync($"v1/certificate/renewById/{certificateId}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         var result = await response.Content.ReadFromJsonAsync<RenewCertificateResponse>(s_json, cancellationToken).ConfigureAwait(false);
         return result?.SslId ?? 0;
@@ -77,6 +78,7 @@ public sealed class CertificatesClient {
     /// Searches for certificates using the provided filter.
     /// </summary>
     public async Task<CertificateResponse?> SearchAsync(CertificateSearchRequest request, CancellationToken cancellationToken = default) {
+        RequestValidator.Validate(request);
         var query = BuildQuery(request);
         var response = await _client.GetAsync($"v1/certificate{query}", cancellationToken);
         var items = await response.Content.ReadFromJsonAsync<IReadOnlyList<Certificate>>(s_json, cancellationToken);

--- a/SectigoCertificateManager/Clients/OrganizationsClient.cs
+++ b/SectigoCertificateManager/Clients/OrganizationsClient.cs
@@ -2,6 +2,7 @@ namespace SectigoCertificateManager.Clients;
 
 using SectigoCertificateManager.Models;
 using SectigoCertificateManager.Requests;
+using SectigoCertificateManager.Utilities;
 using System;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -38,6 +39,7 @@ public sealed class OrganizationsClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>The identifier of the created organization.</returns>
     public async Task<int> CreateAsync(CreateOrganizationRequest request, CancellationToken cancellationToken = default) {
+        RequestValidator.Validate(request);
         var response = await _client.PostAsync("v1/organization", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         var location = response.Headers.Location;
         if (location is not null) {

--- a/SectigoCertificateManager/Requests/CertificateSearchRequest.cs
+++ b/SectigoCertificateManager/Requests/CertificateSearchRequest.cs
@@ -1,11 +1,15 @@
 namespace SectigoCertificateManager.Requests;
 
+using System.ComponentModel.DataAnnotations;
+
 /// <summary>
 /// Request used to search for certificates.
 /// </summary>
 public sealed class CertificateSearchRequest {
+    [Range(1, int.MaxValue)]
     public int? Size { get; set; }
 
+    [Range(1, int.MaxValue)]
     public int? Position { get; set; }
 
     public string? CommonName { get; set; }
@@ -14,12 +18,14 @@ public sealed class CertificateSearchRequest {
 
     public CertificateStatus? Status { get; set; }
 
+    [Range(1, int.MaxValue)]
     public int? SslTypeId { get; set; }
 
     public string? DiscoveryStatus { get; set; }
 
     public string? Vendor { get; set; }
 
+    [Range(1, int.MaxValue)]
     public int? OrgId { get; set; }
 
     public string? InstallStatus { get; set; }
@@ -38,6 +44,7 @@ public sealed class CertificateSearchRequest {
 
     public string? KeyAlgorithm { get; set; }
 
+    [Range(1, int.MaxValue)]
     public int? KeySize { get; set; }
 
     public string? KeyParam { get; set; }

--- a/SectigoCertificateManager/Requests/CreateOrganizationRequest.cs
+++ b/SectigoCertificateManager/Requests/CreateOrganizationRequest.cs
@@ -1,11 +1,13 @@
 namespace SectigoCertificateManager.Requests;
 using SectigoCertificateManager.Models;
+using System.ComponentModel.DataAnnotations;
 
 /// <summary>
 /// Request payload used to create an organization.
 /// </summary>
 public sealed class CreateOrganizationRequest {
     /// <summary>Gets or sets the organization name.</summary>
+    [Required]
     public string Name { get; set; } = string.Empty;
 
     /// <summary>Gets or sets the alternative name.</summary>

--- a/SectigoCertificateManager/Requests/IssueCertificateRequest.cs
+++ b/SectigoCertificateManager/Requests/IssueCertificateRequest.cs
@@ -1,6 +1,7 @@
 namespace SectigoCertificateManager.Requests;
 
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 /// <summary>
 /// Request payload used when issuing a new certificate.
@@ -9,16 +10,19 @@ public sealed class IssueCertificateRequest {
     /// <summary>
     /// Gets or sets the common name of the certificate.
     /// </summary>
+    [Required]
     public string CommonName { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the identifier of the profile to use.
     /// </summary>
+    [Range(1, int.MaxValue)]
     public int ProfileId { get; set; }
 
     /// <summary>
     /// Gets or sets the term of the certificate.
     /// </summary>
+    [Range(1, int.MaxValue)]
     public int Term { get; set; }
 
     /// <summary>

--- a/SectigoCertificateManager/Requests/RenewCertificateRequest.cs
+++ b/SectigoCertificateManager/Requests/RenewCertificateRequest.cs
@@ -1,10 +1,12 @@
 namespace SectigoCertificateManager.Requests;
 
+using System.ComponentModel.DataAnnotations;
 /// <summary>
 /// Request payload used to renew a certificate.
 /// </summary>
 public sealed class RenewCertificateRequest {
     /// <summary>Gets or sets the certificate signing request.</summary>
+    [Required]
     public string? Csr { get; set; }
 
     /// <summary>Gets or sets the DCV mode.</summary>

--- a/SectigoCertificateManager/Requests/RevokeCertificateRequest.cs
+++ b/SectigoCertificateManager/Requests/RevokeCertificateRequest.cs
@@ -1,5 +1,6 @@
 namespace SectigoCertificateManager.Requests;
 
+using System.ComponentModel.DataAnnotations;
 /// <summary>
 /// Request payload used to revoke a certificate.
 /// </summary>
@@ -17,6 +18,7 @@ public sealed class RevokeCertificateRequest {
     public DateTimeOffset? RevokeDate { get; set; }
 
     /// <summary>Gets or sets the revocation reason code.</summary>
+    [Range(0, int.MaxValue)]
     public int ReasonCode { get; set; }
 
     /// <summary>Gets or sets the revocation reason message.</summary>

--- a/SectigoCertificateManager/Utilities/RequestValidator.cs
+++ b/SectigoCertificateManager/Utilities/RequestValidator.cs
@@ -1,0 +1,14 @@
+namespace SectigoCertificateManager.Utilities;
+
+using System.ComponentModel.DataAnnotations;
+
+/// <summary>
+/// Provides helper methods to validate request objects using data annotations.
+/// </summary>
+internal static class RequestValidator {
+    public static void Validate(object request) {
+        _ = request ?? throw new ArgumentNullException(nameof(request));
+        var context = new ValidationContext(request);
+        Validator.ValidateObject(request, context, validateAllProperties: true);
+    }
+}


### PR DESCRIPTION
## Summary
- apply `Required` and `Range` attributes to request objects
- validate requests via `Validator` before sending them
- cover validation with new unit tests
- show validation usage in examples and PowerShell script

## Testing
- `dotnet test --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686a163b73b0832e8e50dbb271bd8c9f