### PR TITLE
Add renewal cmdlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Get-SectigoProfile -BaseUrl "https://example.com" -Username "user" -Password "pa
 New-SectigoOrder -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CommonName "example.com" -ProfileId 1 -SubjectAlternativeNames "www.example.com","admin.example.com"
 
 Get-SectigoOrders -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1"
+
+Update-SectigoCertificate -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CertificateId 123 -Csr "<csr>" -DcvMode "EMAIL" -DcvEmail "admin@example.com"
 ```
 
 Use `-SubjectAlternativeNames` to specify multiple SAN values when placing an order.

--- a/SectigoCertificateManager.Examples/Examples/RenewCertificateExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/RenewCertificateExample.cs
@@ -1,0 +1,31 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Requests;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates renewing a certificate using the API.
+/// </summary>
+public static class RenewCertificateExample {
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+
+        Console.WriteLine("Renewing certificate...");
+        var request = new RenewCertificateRequest {
+            Csr = "<csr>",
+            DcvMode = "EMAIL",
+            DcvEmail = "admin@example.com"
+        };
+        var newId = await certificates.RenewAsync(12345, request);
+        Console.WriteLine($"New certificate id: {newId}");
+    }
+}

--- a/SectigoCertificateManager.PowerShell/UpdateSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/UpdateSectigoCertificateCommand.cs
@@ -1,0 +1,52 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Requests;
+using System.Management.Automation;
+
+namespace SectigoCertificateManager.PowerShell;
+
+[Cmdlet(VerbsData.Update, "SectigoCertificate")]
+[OutputType(typeof(int))]
+public sealed class UpdateSectigoCertificateCommand : PSCmdlet {
+    [Parameter(Mandatory = true)]
+    public string BaseUrl { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string Username { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string Password { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string CustomerUri { get; set; } = string.Empty;
+
+    [Parameter]
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+
+    [Parameter(Mandatory = true, Position = 0)]
+    public int CertificateId { get; set; }
+
+    [Parameter(Mandatory = true)]
+    public string Csr { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string DcvMode { get; set; } = string.Empty;
+
+    [Parameter]
+    public string? DcvEmail { get; set; }
+
+    /// <summary>Renews a certificate using provided parameters.</summary>
+    /// <para>Builds an API client and submits a <see cref="RenewCertificateRequest"/>.</para>
+    protected override void ProcessRecord() {
+        var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+        var request = new RenewCertificateRequest {
+            Csr = Csr,
+            DcvMode = DcvMode,
+            DcvEmail = DcvEmail
+        };
+        var newId = certificates.RenewAsync(CertificateId, request).GetAwaiter().GetResult();
+        WriteObject(newId);
+    }
+}

--- a/SectigoCertificateManager.Tests/Pester/UpdateSectigoCertificateCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/UpdateSectigoCertificateCommand.Tests.ps1
@@ -1,0 +1,12 @@
+Describe "Update-SectigoCertificate" {
+    BeforeAll {
+        dotnet build "$PSScriptRoot/../../SectigoCertificateManager.PowerShell" -c Release | Out-Null
+        $dll = Join-Path $PSScriptRoot '../../SectigoCertificateManager.PowerShell/bin/Release/net8.0/SectigoCertificateManager.PowerShell.dll'
+        Import-Module $dll
+    }
+
+    It "exports the cmdlet" {
+        $cmd = Get-Command Update-SectigoCertificate -ErrorAction Stop
+        $cmd | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- expose renewal API via Update-SectigoCertificate cmdlet
- show renewal command usage in README
- add C# example for certificate renewal
- ensure PowerShell module exports renewal cmdlet via Pester test

## Testing
- `dotnet test -c Release --verbosity minimal`
- `pwsh -NoProfile -Command "Invoke-Pester SectigoCertificateManager.Tests/Pester/UpdateSectigoCertificateCommand.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_686a164b1494832e9fc9351e9355756c