### PR TITLE
Add stream CSR overload

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/StreamCertificateExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/StreamCertificateExample.cs
@@ -1,0 +1,18 @@
+using SectigoCertificateManager.Models;
+using System.IO;
+using System.Text;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates loading a certificate from a stream with progress reporting.
+/// </summary>
+public static class StreamCertificateExample {
+    public static void Run() {
+        const string base64 = "<base64 certificate>";
+        using var stream = new MemoryStream(Encoding.ASCII.GetBytes(base64));
+        var progress = new Progress<double>(p => Console.WriteLine($"Read {p:P0}"));
+        using var cert = Certificate.FromBase64(stream, progress);
+        Console.WriteLine($"Thumbprint: {cert.Thumbprint}");
+    }
+}

--- a/SectigoCertificateManager.Tests/CertificateTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateTests.cs
@@ -19,4 +19,30 @@ public sealed class CertificateTests {
     public void FromBase64_WithInvalidData_Throws() {
         Assert.Throws<FormatException>(() => Certificate.FromBase64("invalid"));
     }
+
+    [Fact]
+    public void FromBase64_StreamOverload_CreatesCertificate() {
+        var bytes = System.Text.Encoding.ASCII.GetBytes(Base64Cert);
+        using var stream = new System.IO.MemoryStream(bytes);
+
+        using var result = Certificate.FromBase64(stream);
+
+        Assert.Equal("51A908D14C9C984231B7E2F6C37ABB1368A57F1F", result.Thumbprint);
+    }
+
+    [Fact]
+    public void FromBase64_StreamOverload_ReportsProgress() {
+        var bytes = System.Text.Encoding.ASCII.GetBytes(Base64Cert);
+        using var stream = new System.IO.MemoryStream(bytes);
+        var progress = new TestProgress();
+
+        using var _ = Certificate.FromBase64(stream, progress);
+
+        Assert.Equal(1d, progress.Value, 3);
+    }
+
+    private sealed class TestProgress : IProgress<double> {
+        public double Value { get; private set; }
+        public void Report(double value) => Value = value;
+    }
 }

--- a/SectigoCertificateManager.Tests/RenewCertificateRequestTests.cs
+++ b/SectigoCertificateManager.Tests/RenewCertificateRequestTests.cs
@@ -1,0 +1,38 @@
+using SectigoCertificateManager.Requests;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+public sealed class RenewCertificateRequestTests {
+    private const string Base64Csr = "VGVzdENzUg=="; // "TestCsr" in base64
+
+    private sealed class TestProgress : IProgress<double> {
+        public double Value { get; private set; }
+        public void Report(double value) => Value = value;
+    }
+
+    [Fact]
+    public void SetCsr_FromStream_SetsProperty() {
+        var bytes = Encoding.ASCII.GetBytes(Base64Csr);
+        using var stream = new MemoryStream(bytes);
+        var request = new RenewCertificateRequest();
+
+        request.SetCsr(stream);
+
+        Assert.Equal(Base64Csr, request.Csr);
+    }
+
+    [Fact]
+    public void SetCsr_ReportsProgress() {
+        var bytes = Encoding.ASCII.GetBytes(Base64Csr);
+        using var stream = new MemoryStream(bytes);
+        var request = new RenewCertificateRequest();
+        var progress = new TestProgress();
+
+        request.SetCsr(stream, progress);
+
+        Assert.Equal(1d, progress.Value, 3);
+    }
+}

--- a/SectigoCertificateManager/Requests/RenewCertificateRequest.cs
+++ b/SectigoCertificateManager/Requests/RenewCertificateRequest.cs
@@ -1,5 +1,8 @@
 namespace SectigoCertificateManager.Requests;
 
+using System.IO;
+using System.Text;
+
 /// <summary>
 /// Request payload used to renew a certificate.
 /// </summary>
@@ -12,4 +15,32 @@ public sealed class RenewCertificateRequest {
 
     /// <summary>Gets or sets the DCV email.</summary>
     public string? DcvEmail { get; set; }
+
+    /// <summary>
+    /// Populates <see cref="Csr"/> from a stream containing base64 encoded data.
+    /// </summary>
+    /// <param name="stream">Stream providing CSR bytes.</param>
+    /// <param name="progress">Optional progress reporter.</param>
+    public void SetCsr(Stream stream, IProgress<double>? progress = null) {
+        if (stream is null) {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        using var reader = new StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
+        var builder = new StringBuilder();
+        var buffer = new char[4096];
+        long read = 0;
+        long total = stream.CanSeek ? stream.Length : -1;
+
+        int count;
+        while ((count = reader.Read(buffer, 0, buffer.Length)) > 0) {
+            builder.Append(buffer, 0, count);
+            read += count;
+            if (progress is not null && total > 0) {
+                progress.Report((double)read / total);
+            }
+        }
+
+        Csr = builder.ToString();
+    }
 }


### PR DESCRIPTION
## Summary
- read CSR data from `Stream` with progress support
- add helper tests for stream progress
- remove PowerShell sample function

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686a167c18c4832ea114ec9424bf19f0