### PR TITLE
Implement configure delegate guard

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
@@ -82,7 +82,14 @@ public sealed class ApiConfigBuilderTests {
     [Fact]
     public void WithHttpClientHandler_ThrowsForNullDelegate() {
         var builder = new ApiConfigBuilder();
-
         Assert.Throws<ArgumentNullException>(() => builder.WithHttpClientHandler(null!));
+    }
+
+    [Fact]
+    public void WithHttpClientHandler_ThrowsWithCorrectParameterName() {
+        var builder = new ApiConfigBuilder();
+
+        var ex = Assert.Throws<ArgumentNullException>(() => builder.WithHttpClientHandler(null!));
+        Assert.Equal("configure", ex.ParamName);
     }
 }

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -86,11 +86,7 @@ public sealed class ApiConfigBuilder {
     /// <summary>Allows configuration of the <see cref="HttpClientHandler"/> used by <see cref="SectigoClient"/>.</summary>
     /// <param name="configure">Delegate used to configure the handler.</param>
     public ApiConfigBuilder WithHttpClientHandler(Action<HttpClientHandler> configure) {
-        if (configure is null) {
-            throw new ArgumentNullException(nameof(configure));
-        }
-
-        _configureHandler = configure;
+        _configureHandler = configure ?? throw new ArgumentNullException(nameof(configure));
         return this;
     }
 


### PR DESCRIPTION
## Summary
- ensure `ApiConfigBuilder.WithHttpClientHandler` guards null `configure`
- check parameter name in new test

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -v n`

------
https://chatgpt.com/codex/tasks/task_e_686a15fb3a08832eb68bf4773250d115