### PR TITLE
Add missing file check in config loader

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
@@ -85,4 +85,12 @@ public sealed class ApiConfigLoaderTests {
 
         Directory.Delete(tempDir, true);
     }
+
+    [Fact]
+    public void Load_WithMissingFile_Throws() {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "missing.json");
+
+        var ex = Assert.Throws<FileNotFoundException>(() => ApiConfigLoader.Load(path));
+        Assert.Contains(path, ex.Message);
+    }
 }

--- a/SectigoCertificateManager/ApiConfigLoader.cs
+++ b/SectigoCertificateManager/ApiConfigLoader.cs
@@ -58,6 +58,10 @@ public static class ApiConfigLoader {
             }
         }
 
+        if (!File.Exists(path!)) {
+            throw new FileNotFoundException($"Configuration file not found: {path}", path);
+        }
+
         var json = File.ReadAllText(path!);
         var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
         var model = JsonSerializer.Deserialize<FileModel>(json, options)


### PR DESCRIPTION
## Summary
- check for credentials file before reading
- throw `FileNotFoundException` with file path
- add test covering missing credentials file

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_686a15dbd8dc832e83b22cbfbd128295