### PR TITLE
Fix base64 parsing error handling

### DIFF
--- a/SectigoCertificateManager.Tests/CertificateTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateTests.cs
@@ -1,4 +1,5 @@
 using SectigoCertificateManager.Models;
+using SectigoCertificateManager;
 using System;
 using System.Security.Cryptography.X509Certificates;
 using Xunit;
@@ -17,6 +18,15 @@ public sealed class CertificateTests {
 
     [Fact]
     public void FromBase64_WithInvalidData_Throws() {
-        Assert.Throws<FormatException>(() => Certificate.FromBase64("invalid"));
+        var ex = Assert.Throws<ValidationException>(() => Certificate.FromBase64("invalid"));
+        Assert.Equal("Certificate data is not valid Base64.", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void FromBase64_WithMissingData_Throws(string? input) {
+        Assert.Throws<ArgumentException>(() => Certificate.FromBase64(input!));
     }
 }

--- a/SectigoCertificateManager/Models/Certificate.cs
+++ b/SectigoCertificateManager/Models/Certificate.cs
@@ -78,7 +78,16 @@ public sealed class Certificate {
             throw new ArgumentException("Value cannot be null or empty.", nameof(data));
         }
 
-        var bytes = Convert.FromBase64String(data);
+        byte[] bytes;
+        try {
+            bytes = Convert.FromBase64String(data);
+        } catch (FormatException) {
+            throw new ValidationException(new ApiError {
+                Code = -1,
+                Description = "Certificate data is not valid Base64."
+            });
+        }
+
         return new X509Certificate2(bytes);
     }
 }


### PR DESCRIPTION
## Summary
- handle invalid base64 data when creating certificates
- test invalid and missing values for certificate conversion

## Testing
- `dotnet test SectigoCertificateManager.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686a15e9223c832e87b6b6e492638b69