### PR TITLE
Add null guard clauses for client requests

### DIFF
--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -170,4 +170,31 @@ public sealed class CertificatesClientTests {
         Assert.NotNull(handler.Request);
         Assert.Equal("https://example.com/v1/certificate?size=10&position=5&commonName=te%20st&status=Issued&sslTypeId=2&issuer=A%26B&keyAlgorithm=RSA%2FDSA", handler.Request!.RequestUri!.AbsoluteUri);
     }
+
+    [Fact]
+    public async Task RevokeAsync_NullRequest_Throws() {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var certificates = new CertificatesClient(client);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => certificates.RevokeAsync(null!));
+    }
+
+    [Fact]
+    public async Task RenewAsync_NullRequest_Throws() {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(new RenewCertificateResponse { SslId = 1 }) });
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var certificates = new CertificatesClient(client);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => certificates.RenewAsync(1, null!));
+    }
+
+    [Fact]
+    public async Task SearchAsync_NullRequest_Throws() {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Array.Empty<Certificate>()) });
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var certificates = new CertificatesClient(client);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => certificates.SearchAsync(null!));
+    }
 }

--- a/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
@@ -80,4 +80,13 @@ public sealed class OrganizationsClientTests {
 
         Assert.Equal(11, id);
     }
+
+    [Fact]
+    public async Task CreateAsync_NullRequest_Throws() {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.Created));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var organizations = new OrganizationsClient(client);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => organizations.CreateAsync(null!));
+    }
 }

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -56,6 +56,10 @@ public sealed class CertificatesClient {
     /// <param name="request">Payload describing the certificate to revoke.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task RevokeAsync(RevokeCertificateRequest request, CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
         var response = await _client.PostAsync("v1/certificate/revoke", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
@@ -68,6 +72,10 @@ public sealed class CertificatesClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>The identifier of the newly issued certificate.</returns>
     public async Task<int> RenewAsync(int certificateId, RenewCertificateRequest request, CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
         var response = await _client.PostAsync($"v1/certificate/renewById/{certificateId}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         var result = await response.Content.ReadFromJsonAsync<RenewCertificateResponse>(s_json, cancellationToken).ConfigureAwait(false);
         return result?.SslId ?? 0;
@@ -77,6 +85,10 @@ public sealed class CertificatesClient {
     /// Searches for certificates using the provided filter.
     /// </summary>
     public async Task<CertificateResponse?> SearchAsync(CertificateSearchRequest request, CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
         var query = BuildQuery(request);
         var response = await _client.GetAsync($"v1/certificate{query}", cancellationToken);
         var items = await response.Content.ReadFromJsonAsync<IReadOnlyList<Certificate>>(s_json, cancellationToken);

--- a/SectigoCertificateManager/Clients/OrganizationsClient.cs
+++ b/SectigoCertificateManager/Clients/OrganizationsClient.cs
@@ -38,6 +38,10 @@ public sealed class OrganizationsClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>The identifier of the created organization.</returns>
     public async Task<int> CreateAsync(CreateOrganizationRequest request, CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
         var response = await _client.PostAsync("v1/organization", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         var location = response.Headers.Location;
         if (location is not null) {


### PR DESCRIPTION
## Summary
- guard against `null` requests in `CertificatesClient` and `OrganizationsClient`
- add unit tests for new guard clauses

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686a15e0a2c8832e9300fea580d3e6be