### PR TITLE
Rename CreateOrganization property

### DIFF
--- a/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
@@ -60,13 +60,17 @@ public sealed class OrganizationsClientTests {
         var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var organizations = new OrganizationsClient(client);
 
-        var request = new CreateOrganizationRequest { Name = "org" };
+        var request = new CreateOrganizationRequest {
+            Name = "org",
+            StateOrProvince = "NC"
+        };
         var id = await organizations.CreateAsync(request);
 
         Assert.NotNull(handler.Request);
         Assert.Equal("https://example.com/v1/organization", handler.Request!.RequestUri!.ToString());
         Assert.NotNull(handler.Body);
         Assert.Contains("\"name\":\"org\"", handler.Body);
+        Assert.Contains("\"stateOrProvince\":\"NC\"", handler.Body);
         Assert.Equal(10, id);
     }
 

--- a/SectigoCertificateManager/Requests/CreateOrganizationRequest.cs
+++ b/SectigoCertificateManager/Requests/CreateOrganizationRequest.cs
@@ -42,7 +42,7 @@ public sealed class CreateOrganizationRequest {
     public string? City { get; set; }
 
     /// <summary>Gets or sets the state or province.</summary>
-    public string? StateProvince { get; set; }
+    public string? StateOrProvince { get; set; }
 
     /// <summary>Gets or sets the postal code.</summary>
     public string? PostalCode { get; set; }


### PR DESCRIPTION
## Summary
- rename `StateProvince` to `StateOrProvince` in the request model
- validate serialized body in organization tests

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686d29fd0dfc832e8656577b73433ece