### PR TITLE
Change default API version to v25.6

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
@@ -56,6 +56,7 @@ public sealed class ApiConfigLoaderTests {
         var config = ApiConfigLoader.Load();
 
         Assert.Equal("https://example.com", config.BaseUrl);
+        Assert.Equal(ApiVersion.V25_6, config.ApiVersion);
 
         Environment.SetEnvironmentVariable("SECTIGO_CREDENTIALS_PATH", null);
         Directory.Delete(tempDir, true);
@@ -70,6 +71,7 @@ public sealed class ApiConfigLoaderTests {
         var config = ApiConfigLoader.Load();
 
         Assert.Equal("tok", config.Token);
+        Assert.Equal(ApiVersion.V25_6, config.ApiVersion);
 
         Environment.SetEnvironmentVariable("SECTIGO_BASE_URL", null);
         Environment.SetEnvironmentVariable("SECTIGO_TOKEN", null);
@@ -86,6 +88,7 @@ public sealed class ApiConfigLoaderTests {
         var config = ApiConfigLoader.Load(path);
 
         Assert.Equal("tok", config.Token);
+        Assert.Equal(ApiVersion.V25_6, config.ApiVersion);
 
         Directory.Delete(tempDir, true);
     }

--- a/SectigoCertificateManager/ApiConfigLoader.cs
+++ b/SectigoCertificateManager/ApiConfigLoader.cs
@@ -25,7 +25,7 @@ public static class ApiConfigLoader {
         public string CustomerUri { get; set; } = string.Empty;
 
         /// <summary>Gets or sets the API version string.</summary>
-        public string ApiVersion { get; set; } = "V25_4";
+        public string ApiVersion { get; set; } = "V25_6";
     }
 
     /// <summary>
@@ -70,5 +70,5 @@ public static class ApiConfigLoader {
     }
 
     private static ApiVersion ParseVersion(string? value)
-        => Enum.TryParse<ApiVersion>(value, ignoreCase: true, out var v) ? v : ApiVersion.V25_4;
+        => Enum.TryParse<ApiVersion>(value, ignoreCase: true, out var v) ? v : ApiVersion.V25_6;
 }


### PR DESCRIPTION
## Summary
- update default ApiVersion when loading config files
- adjust fallback logic in `ApiConfigLoader.ParseVersion`
- validate default version in related unit tests

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686d29f6d6a0832e8171a8159962b089