### PR TITLE
Add output type attribute for Stop-SectigoOrder

### DIFF
--- a/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
@@ -7,6 +7,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>Cancels an order.</summary>
 /// <para>Creates an API client and calls the cancel endpoint.</para>
 [Cmdlet(VerbsLifecycle.Stop, "SectigoOrder")]
+[OutputType(typeof(void))]
 public sealed class StopSectigoOrderCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>
     [Parameter(Mandatory = true)]

--- a/SectigoCertificateManager.Tests/Pester/StopSectigoOrderCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/StopSectigoOrderCommand.Tests.ps1
@@ -1,0 +1,17 @@
+Describe "Stop-SectigoOrder" {
+    BeforeAll {
+        dotnet build "$PSScriptRoot/../../SectigoCertificateManager.PowerShell" -c Release | Out-Null
+        $dll = Join-Path $PSScriptRoot '../../SectigoCertificateManager.PowerShell/bin/Release/net8.0/SectigoCertificateManager.PowerShell.dll'
+        Import-Module $dll
+    }
+
+    It "exports the cmdlet" {
+        $cmd = Get-Command Stop-SectigoOrder -ErrorAction Stop
+        $cmd | Should -Not -BeNullOrEmpty
+    }
+
+    It "has the correct output type" {
+        $cmd = Get-Command Stop-SectigoOrder -ErrorAction Stop
+        ($cmd.OutputType | Select-Object -First 1).Name | Should -Be 'System.Void'
+    }
+}


### PR DESCRIPTION
## Summary
- add `[OutputType(typeof(void))]` to `StopSectigoOrderCommand`
- add Pester tests for `Stop-SectigoOrder` output type

## Testing
- `dotnet build SectigoCertificateManager.sln --no-restore`
- `dotnet test SectigoCertificateManager.sln --no-build --verbosity normal`
- `pwsh -NoProfile -Command "Invoke-Pester -Script ./SectigoCertificateManager.Tests/Pester -Output Detailed"`

------
https://chatgpt.com/codex/tasks/task_e_686d29eac370832eb4916cb9bd5dc845