### PR TITLE
Add certificate download method

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/DownloadCertificateExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/DownloadCertificateExample.cs
@@ -1,0 +1,27 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates downloading an issued certificate.
+/// </summary>
+public static class DownloadCertificateExample {
+    /// <summary>
+    /// Executes the example that downloads a certificate to disk.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+
+        Console.WriteLine("Downloading certificate...");
+        await certificates.DownloadAsync(12345, "certificate.p7b");
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -2,3 +2,4 @@ using SectigoCertificateManager.Examples.Examples;
 
 await BasicApiExample.RunAsync();
 await SearchCertificatesExample.RunAsync();
+await DownloadCertificateExample.RunAsync();


### PR DESCRIPTION
## Summary
- add `DownloadAsync` to `CertificatesClient`
- add `DownloadCertificateExample`
- update `Program.cs` to run the new example
- test certificate download functionality

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686d2a211a58832ea5163e622803b7eb