### PR TITLE
Add Get-SectigoOrganizations cmdlet

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/ListOrganizationsExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/ListOrganizationsExample.cs
@@ -1,0 +1,28 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates listing organizations using <see cref="OrganizationsClient"/>.
+/// </summary>
+public static class ListOrganizationsExample {
+    /// <summary>
+    /// Executes the example that lists all organizations.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var organizations = new OrganizationsClient(client);
+
+        foreach (var org in await organizations.ListOrganizationsAsync()) {
+            Console.WriteLine($"Organization: {org.Name}");
+        }
+    }
+}

--- a/SectigoCertificateManager.PowerShell/GetSectigoOrganizationsCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoOrganizationsCommand.cs
@@ -1,0 +1,43 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using System.Management.Automation;
+
+namespace SectigoCertificateManager.PowerShell;
+
+/// <summary>Retrieves organizations.</summary>
+/// <para>Builds an API client and lists all organizations for the account.</para>
+[Cmdlet(VerbsCommon.Get, "SectigoOrganizations")]
+[OutputType(typeof(Models.Organization))]
+public sealed class GetSectigoOrganizationsCommand : PSCmdlet {
+    /// <summary>The API base URL.</summary>
+    [Parameter(Mandatory = true)]
+    public string BaseUrl { get; set; } = string.Empty;
+
+    /// <summary>The user name for authentication.</summary>
+    [Parameter(Mandatory = true)]
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>The password for authentication.</summary>
+    [Parameter(Mandatory = true)]
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>The customer URI assigned by Sectigo.</summary>
+    [Parameter(Mandatory = true)]
+    public string CustomerUri { get; set; } = string.Empty;
+
+    /// <summary>The API version to use.</summary>
+    [Parameter]
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+
+    /// <summary>Executes the cmdlet.</summary>
+    /// <para>Creates an API client and outputs all organizations.</para>
+    protected override void ProcessRecord() {
+        var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
+        var client = new SectigoClient(config);
+        var organizations = new OrganizationsClient(client);
+        var list = organizations.ListOrganizationsAsync().GetAwaiter().GetResult();
+        foreach (var org in list) {
+            WriteObject(org);
+        }
+    }
+}

--- a/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
@@ -93,4 +93,42 @@ public sealed class OrganizationsClientTests {
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => organizations.CreateAsync(null!));
     }
+
+    [Fact]
+    public async Task ListOrganizationsAsync_ReturnsOrganizations() {
+        var org = new Organization { Id = 2, Name = "Test" };
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create(new[] { org })
+        };
+
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var organizations = new OrganizationsClient(client);
+
+        var result = await organizations.ListOrganizationsAsync();
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/v1/organization", handler.Request!.RequestUri!.ToString());
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal(2, result[0].Id);
+    }
+
+    [Fact]
+    public async Task ListOrganizationsAsync_ReturnsEmpty_WhenResponseNull() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create<object?>(null)
+        };
+
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var organizations = new OrganizationsClient(client);
+
+        var result = await organizations.ListOrganizationsAsync();
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/v1/organization", handler.Request!.RequestUri!.ToString());
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
 }

--- a/SectigoCertificateManager.Tests/Pester/GetSectigoOrganizationsCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/GetSectigoOrganizationsCommand.Tests.ps1
@@ -1,0 +1,12 @@
+Describe "Get-SectigoOrganizations" {
+    BeforeAll {
+        dotnet build "$PSScriptRoot/../../SectigoCertificateManager.PowerShell" -c Release | Out-Null
+        $dll = Join-Path $PSScriptRoot '../../SectigoCertificateManager.PowerShell/bin/Release/net8.0/SectigoCertificateManager.PowerShell.dll'
+        Import-Module $dll
+    }
+
+    It "exports the cmdlet" {
+        $cmd = Get-Command Get-SectigoOrganizations -ErrorAction Stop
+        $cmd | Should -Not -BeNullOrEmpty
+    }
+}

--- a/SectigoCertificateManager/Clients/OrganizationsClient.cs
+++ b/SectigoCertificateManager/Clients/OrganizationsClient.cs
@@ -54,4 +54,16 @@ public sealed class OrganizationsClient {
 
         return 0;
     }
+
+    /// <summary>
+    /// Retrieves all organizations visible to the user.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<IReadOnlyList<Organization>> ListOrganizationsAsync(CancellationToken cancellationToken = default) {
+        var response = await _client.GetAsync("v1/organization", cancellationToken).ConfigureAwait(false);
+        var organizations = await response.Content
+            .ReadFromJsonAsync<IReadOnlyList<Organization>>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+        return organizations ?? Array.Empty<Organization>();
+    }
 }


### PR DESCRIPTION
## Summary
- list organizations in `OrganizationsClient`
- expose `Get-SectigoOrganizations` cmdlet
- show organization listing in examples
- test new APIs and cmdlet

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -v minimal`
- `pwsh -NoProfile -Command Invoke-Pester -Path ./SectigoCertificateManager.Tests/Pester -CI`

------
https://chatgpt.com/codex/tasks/task_e_686d2a29d810832eafff8edf91af971c