### PR TITLE
Fix FromBase64 stream handling

### DIFF
--- a/SectigoCertificateManager.Tests/CertificateTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateTests.cs
@@ -55,6 +55,17 @@ public sealed class CertificateTests {
         Assert.Equal(1d, progress.Value, 3);
     }
 
+    [Fact]
+    public void FromBase64_StreamPrePositioned_CreatesCertificate() {
+        var bytes = System.Text.Encoding.ASCII.GetBytes(Base64Cert);
+        using var stream = new System.IO.MemoryStream(bytes);
+        stream.Position = 10;
+
+        using var result = Certificate.FromBase64(stream);
+
+        Assert.Equal("51A908D14C9C984231B7E2F6C37ABB1368A57F1F", result.Thumbprint);
+    }
+
     private sealed class TestProgress : IProgress<double> {
         public double Value { get; private set; }
         public void Report(double value) => Value = value;

--- a/SectigoCertificateManager/Models/Certificate.cs
+++ b/SectigoCertificateManager/Models/Certificate.cs
@@ -103,6 +103,10 @@ public sealed class Certificate {
             throw new ArgumentNullException(nameof(stream));
         }
 
+        if (stream.CanSeek) {
+            stream.Seek(0, SeekOrigin.Begin);
+        }
+
         using var reader = new StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
         var builder = new StringBuilder();
         var buffer = new char[4096];


### PR DESCRIPTION
## Summary
- ensure the input stream is reset before reading certificate data
- add test for stream that has a pre-set position

## Testing
- `dotnet test SectigoCertificateManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_686d2a417178832e8fbfdfba75fd91d8