### PR TITLE
Add order ID validation

### DIFF
--- a/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
@@ -42,4 +42,15 @@ public sealed class OrderStatusClientTests {
         Assert.Equal("https://example.com/v1/order/5/status", handler.Request!.RequestUri!.ToString());
         Assert.Equal(OrderStatus.Submitted, result);
     }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-2)]
+    public async Task GetStatusAsync_InvalidOrderId_Throws(int orderId) {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var statuses = new OrderStatusClient(client);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => statuses.GetStatusAsync(orderId));
+    }
 }

--- a/SectigoCertificateManager.Tests/OrdersClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrdersClientTests.cs
@@ -62,6 +62,28 @@ public sealed class OrdersClientTests {
         Assert.Equal("https://example.com/v1/order/5/cancel", handler.Request.RequestUri!.ToString());
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task GetAsync_InvalidOrderId_Throws(int orderId) {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var orders = new OrdersClient(client);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => orders.GetAsync(orderId));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-3)]
+    public async Task CancelAsync_InvalidOrderId_Throws(int orderId) {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var orders = new OrdersClient(client);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => orders.CancelAsync(orderId));
+    }
+
     private sealed class SequenceHandler : HttpMessageHandler {
         private readonly Queue<HttpResponseMessage> _responses;
         public List<HttpRequestMessage> Requests { get; } = new();

--- a/SectigoCertificateManager/Clients/OrderStatusClient.cs
+++ b/SectigoCertificateManager/Clients/OrderStatusClient.cs
@@ -24,6 +24,10 @@ public sealed class OrderStatusClient {
     /// <param name="orderId">Identifier of the order.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<OrderStatus?> GetStatusAsync(int orderId, CancellationToken cancellationToken = default) {
+        if (orderId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(orderId));
+        }
+
         var response = await _client.GetAsync($"v1/order/{orderId}/status", cancellationToken).ConfigureAwait(false);
         var result = await response.Content.ReadFromJsonAsync<StatusResponse>(s_json, cancellationToken).ConfigureAwait(false);
         return result?.Status;

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -28,6 +28,10 @@ public sealed class OrdersClient {
     /// <param name="orderId">Identifier of the order to retrieve.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Order?> GetAsync(int orderId, CancellationToken cancellationToken = default) {
+        if (orderId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(orderId));
+        }
+
         var response = await _client.GetAsync($"v1/order/{orderId}", cancellationToken).ConfigureAwait(false);
         return await response.Content.ReadFromJsonAsync<Order>(s_json, cancellationToken).ConfigureAwait(false);
     }
@@ -84,6 +88,10 @@ public sealed class OrdersClient {
     /// <param name="orderId">Identifier of the order to cancel.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task CancelAsync(int orderId, CancellationToken cancellationToken = default) {
+        if (orderId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(orderId));
+        }
+
         var response = await _client.PostAsync($"v1/order/{orderId}/cancel", new StringContent(string.Empty), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }


### PR DESCRIPTION
## Summary
- throw `ArgumentOutOfRangeException` when an order ID is not positive
- add unit tests for `OrdersClient` and `OrderStatusClient`

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -c Release`
- `dotnet build SectigoCertificateManager.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686d2a47c858832e9e13fe3401fa802f