### PR TITLE
Add OrderId validation

### DIFF
--- a/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
@@ -1,5 +1,6 @@
 using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
+using System;
 using System.Management.Automation;
 
 namespace SectigoCertificateManager.PowerShell;
@@ -35,6 +36,12 @@ public sealed class StopSectigoOrderCommand : PSCmdlet {
     /// <summary>Cancels an order.</summary>
     /// <para>Builds an API client and calls the cancel endpoint.</para>
     protected override void ProcessRecord() {
+        if (OrderId <= 0) {
+            var ex = new ArgumentOutOfRangeException(nameof(OrderId));
+            var record = new ErrorRecord(ex, "InvalidOrderId", ErrorCategory.InvalidArgument, OrderId);
+            ThrowTerminatingError(record);
+        }
+
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var orders = new OrdersClient(client);

--- a/SectigoCertificateManager.Tests/Pester/StopSectigoOrderCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/StopSectigoOrderCommand.Tests.ps1
@@ -1,0 +1,11 @@
+Describe "Stop-SectigoOrder" {
+    BeforeAll {
+        dotnet build "$PSScriptRoot/../../SectigoCertificateManager.PowerShell" -c Release | Out-Null
+        $dll = Join-Path $PSScriptRoot '../../SectigoCertificateManager.PowerShell/bin/Release/net8.0/SectigoCertificateManager.PowerShell.dll'
+        Import-Module $dll
+    }
+
+    It "throws when OrderId is less than or equal to zero" {
+        { Stop-SectigoOrder -BaseUrl 'b' -Username 'u' -Password 'p' -CustomerUri 'c' -OrderId 0 } | Should -Throw
+    }
+}


### PR DESCRIPTION
## Summary
- validate the `OrderId` parameter in `StopSectigoOrderCommand`
- add a Pester test for the new validation

## Testing
- `dotnet test ./SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -c Release`
- `pwsh -NoLogo -Command "Invoke-Pester -Path ./SectigoCertificateManager.Tests/Pester"`

------
https://chatgpt.com/codex/tasks/task_e_686d2a59e3b0832e99cded667c88be85