### PR TITLE
Fix CancelAsync JSON content-type

### DIFF
--- a/SectigoCertificateManager.Tests/OrdersClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrdersClientTests.cs
@@ -60,6 +60,7 @@ public sealed class OrdersClientTests {
         Assert.NotNull(handler.Request);
         Assert.Equal(HttpMethod.Post, handler.Request!.Method);
         Assert.Equal("https://example.com/v1/order/5/cancel", handler.Request.RequestUri!.ToString());
+        Assert.Equal("application/json; charset=utf-8", handler.Request.Content!.Headers.ContentType!.ToString());
     }
 
     private sealed class SequenceHandler : HttpMessageHandler {

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -4,6 +4,7 @@ using SectigoCertificateManager.Models;
 using SectigoCertificateManager.Responses;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using System.Runtime.CompilerServices;
 
@@ -84,7 +85,8 @@ public sealed class OrdersClient {
     /// <param name="orderId">Identifier of the order to cancel.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task CancelAsync(int orderId, CancellationToken cancellationToken = default) {
-        var response = await _client.PostAsync($"v1/order/{orderId}/cancel", new StringContent(string.Empty), cancellationToken).ConfigureAwait(false);
+        var content = new StringContent(string.Empty, Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync($"v1/order/{orderId}/cancel", content, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
 }


### PR DESCRIPTION
## Summary
- use `Encoding.UTF8` when posting cancel order
- verify JSON content type in unit tests

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686d2a500018832e8563b34b708100fe