### PR TITLE
Add validation for certificate ID

### DIFF
--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -99,6 +99,17 @@ public sealed class CertificatesClientTests {
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.IssueAsync(request));
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-2)]
+    public async Task GetAsync_InvalidCertificateId_Throws(int certificateId) {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var certificates = new CertificatesClient(client);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.GetAsync(certificateId));
+    }
+
     [Fact]
     public async Task RevokeAsync_SendsPayload() {
         var response = new HttpResponseMessage(HttpStatusCode.NoContent);

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -29,6 +29,10 @@ public sealed class CertificatesClient {
     /// <param name="certificateId">Identifier of the certificate to retrieve.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Certificate?> GetAsync(int certificateId, CancellationToken cancellationToken = default) {
+        if (certificateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(certificateId));
+        }
+
         var response = await _client.GetAsync($"v1/certificate/{certificateId}", cancellationToken).ConfigureAwait(false);
         return await response.Content.ReadFromJsonAsync<Certificate>(s_json, cancellationToken).ConfigureAwait(false);
     }


### PR DESCRIPTION
## Summary
- validate certificateId in CertificatesClient.GetAsync
- add unit tests for invalid certificateId

## Testing
- `dotnet test -c Release`
- `dotnet build --no-restore -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68778962dbcc832ea1297cf8f83e7724