### PR TITLE
Add check for certificate ID in DownloadAsync

### DIFF
--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -202,8 +202,11 @@ public sealed class CertificatesClientTests {
         await Assert.ThrowsAsync<ArgumentNullException>(() => certificates.RenewAsync(1, null!));
     }
 
-    [Fact]
-    public async Task DownloadAsync_WritesFile() {
+    [Theory]
+    [InlineData(2, true)]
+    [InlineData(0, false)]
+    [InlineData(-1, false)]
+    public async Task DownloadAsync_WritesFile(int certificateId, bool isValid) {
         var response = new HttpResponseMessage(HttpStatusCode.OK) {
             Content = new StringContent("DATA")
         };
@@ -214,11 +217,15 @@ public sealed class CertificatesClientTests {
 
         var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         try {
-            await certificates.DownloadAsync(2, path);
-            Assert.NotNull(handler.Request);
-            Assert.Equal("https://example.com/ssl/v1/collect/2?format=base64", handler.Request!.RequestUri!.ToString());
-            Assert.True(File.Exists(path));
-            Assert.Equal("DATA", File.ReadAllText(path));
+            if (isValid) {
+                await certificates.DownloadAsync(certificateId, path);
+                Assert.NotNull(handler.Request);
+                Assert.Equal($"https://example.com/ssl/v1/collect/{certificateId}?format=base64", handler.Request!.RequestUri!.ToString());
+                Assert.True(File.Exists(path));
+                Assert.Equal("DATA", File.ReadAllText(path));
+            } else {
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.DownloadAsync(certificateId, path));
+            }
         } finally {
             File.Delete(path);
         }

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -108,6 +108,9 @@ public sealed class CertificatesClient {
         string path,
         string format = "base64",
         CancellationToken cancellationToken = default) {
+        if (certificateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(certificateId));
+        }
         if (string.IsNullOrEmpty(path)) {
             throw new ArgumentException("Path cannot be null or empty.", nameof(path));
         }


### PR DESCRIPTION
## Summary
- validate certificateId when downloading
- extend tests for invalid IDs

## Testing
- `dotnet test`
- `dotnet build -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_68778968aed4832eb4908a25f17d0538