### PR TITLE
Add certificate status endpoint

### DIFF
--- a/SectigoCertificateManager.PowerShell/Examples/GetCertificateStatusExample.ps1
+++ b/SectigoCertificateManager.PowerShell/Examples/GetCertificateStatusExample.ps1
@@ -1,0 +1,2 @@
+# Demonstrates retrieving certificate status.
+Get-SectigoCertificateStatus -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CertificateId 10

--- a/SectigoCertificateManager.PowerShell/GetSectigoCertificateStatusCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoCertificateStatusCommand.cs
@@ -1,0 +1,44 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using System.Management.Automation;
+
+namespace SectigoCertificateManager.PowerShell;
+
+/// <summary>Retrieves certificate status.</summary>
+/// <para>Creates an API client and returns the status of a certificate.</para>
+[Cmdlet(VerbsCommon.Get, "SectigoCertificateStatus")]
+public sealed class GetSectigoCertificateStatusCommand : PSCmdlet {
+    /// <summary>The API base URL.</summary>
+    [Parameter(Mandatory = true)]
+    public string BaseUrl { get; set; } = string.Empty;
+
+    /// <summary>The user name for authentication.</summary>
+    [Parameter(Mandatory = true)]
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>The password for authentication.</summary>
+    [Parameter(Mandatory = true)]
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>The customer URI assigned by Sectigo.</summary>
+    [Parameter(Mandatory = true)]
+    public string CustomerUri { get; set; } = string.Empty;
+
+    /// <summary>The API version to use.</summary>
+    [Parameter]
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+
+    /// <summary>The certificate identifier.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public int CertificateId { get; set; }
+
+    /// <summary>Executes the cmdlet.</summary>
+    /// <para>Creates an API client and retrieves certificate status.</para>
+    protected override void ProcessRecord() {
+        var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+        var status = certificates.GetStatusAsync(CertificateId).GetAwaiter().GetResult();
+        WriteObject(status);
+    }
+}

--- a/SectigoCertificateManager.Tests/Pester/GetSectigoCertificateStatusCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/GetSectigoCertificateStatusCommand.Tests.ps1
@@ -1,0 +1,12 @@
+Describe "Get-SectigoCertificateStatus" {
+    BeforeAll {
+        dotnet build "$PSScriptRoot/../../SectigoCertificateManager.PowerShell" -c Release | Out-Null
+        $dll = Join-Path $PSScriptRoot '../../SectigoCertificateManager.PowerShell/bin/Release/net8.0/SectigoCertificateManager.PowerShell.dll'
+        Import-Module $dll
+    }
+
+    It "exports the cmdlet" {
+        $cmd = Get-Command Get-SectigoCertificateStatus -ErrorAction Stop
+        $cmd | Should -Not -BeNullOrEmpty
+    }
+}

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -34,6 +34,21 @@ public sealed class CertificatesClient {
     }
 
     /// <summary>
+    /// Retrieves the status of a certificate by identifier.
+    /// </summary>
+    /// <param name="certificateId">Identifier of the certificate.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<CertificateStatus?> GetStatusAsync(int certificateId, CancellationToken cancellationToken = default) {
+        if (certificateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(certificateId));
+        }
+
+        var response = await _client.GetAsync($"v1/certificate/{certificateId}/status", cancellationToken).ConfigureAwait(false);
+        var result = await response.Content.ReadFromJsonAsync<StatusResponse>(s_json, cancellationToken).ConfigureAwait(false);
+        return result?.Status;
+    }
+
+    /// <summary>
     /// Issues a new certificate.
     /// </summary>
     /// <param name="request">Payload describing the certificate to issue.</param>
@@ -204,5 +219,10 @@ public sealed class CertificatesClient {
         AppendDate("dateTo", request.DateTo);
 
         return builder.ToString();
+    }
+
+    private sealed class StatusResponse {
+        /// <summary>Gets or sets the certificate status.</summary>
+        public CertificateStatus Status { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- add method to fetch certificate status
- implement PowerShell cmdlet to retrieve certificate status
- update CertificatesClient tests
- add example script and Pester tests

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release --no-build`
- `pwsh -c 'Install-Module -Name Pester -Force -Scope CurrentUser; Invoke-Pester -Configuration @{Run=@{Path="SectigoCertificateManager.Tests/Pester"}}'`

------
https://chatgpt.com/codex/tasks/task_e_687789857e20832eb6dfdd3fb6a1454f