### PR TITLE
Add organization update support

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/UpdateOrganizationExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/UpdateOrganizationExample.cs
@@ -1,0 +1,29 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Requests;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates updating an organization using <see cref="OrganizationsClient"/>.
+/// </summary>
+public static class UpdateOrganizationExample {
+    /// <summary>
+    /// Executes the example that updates an organization.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var organizations = new OrganizationsClient(client);
+
+        Console.WriteLine("Updating organization...");
+        var request = new UpdateOrganizationRequest { Name = "New Name" };
+        await organizations.UpdateAsync(123, request);
+    }
+}

--- a/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
@@ -135,4 +135,41 @@ public sealed class OrganizationsClientTests {
         Assert.NotNull(result);
         Assert.Empty(result);
     }
+
+    [Fact]
+    public async Task UpdateAsync_SendsPayload() {
+        var response = new HttpResponseMessage(HttpStatusCode.NoContent);
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var organizations = new OrganizationsClient(client);
+
+        var request = new UpdateOrganizationRequest { Name = "new" };
+        await organizations.UpdateAsync(7, request);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal(HttpMethod.Put, handler.Request!.Method);
+        Assert.Equal("https://example.com/v1/organization/7", handler.Request.RequestUri!.ToString());
+        Assert.NotNull(handler.Body);
+        Assert.Contains("\"name\":\"new\"", handler.Body);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NullRequest_Throws() {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var organizations = new OrganizationsClient(client);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => organizations.UpdateAsync(5, null!));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-3)]
+    public async Task UpdateAsync_InvalidId_Throws(int id) {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var organizations = new OrganizationsClient(client);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => organizations.UpdateAsync(id, new UpdateOrganizationRequest()));
+    }
 }

--- a/SectigoCertificateManager/Clients/OrganizationsClient.cs
+++ b/SectigoCertificateManager/Clients/OrganizationsClient.cs
@@ -56,6 +56,26 @@ public sealed class OrganizationsClient {
     }
 
     /// <summary>
+    /// Updates an existing organization.
+    /// </summary>
+    /// <param name="organizationId">Identifier of the organization to update.</param>
+    /// <param name="request">Payload describing updated fields.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task UpdateAsync(int organizationId, UpdateOrganizationRequest request, CancellationToken cancellationToken = default) {
+        if (organizationId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(organizationId));
+        }
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var response = await _client
+            .PutAsync($"v1/organization/{organizationId}", JsonContent.Create(request, options: s_json), cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>
     /// Retrieves all organizations visible to the user.
     /// </summary>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>

--- a/SectigoCertificateManager/Requests/UpdateOrganizationRequest.cs
+++ b/SectigoCertificateManager/Requests/UpdateOrganizationRequest.cs
@@ -1,0 +1,61 @@
+namespace SectigoCertificateManager.Requests;
+using SectigoCertificateManager.Models;
+
+/// <summary>
+/// Request payload used to update an organization.
+/// </summary>
+public sealed class UpdateOrganizationRequest {
+    /// <summary>Gets or sets the organization name.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>Gets or sets the alternative name.</summary>
+    public string? AlternativeName { get; set; }
+
+    /// <summary>Gets or sets the SCHAC home organization (deprecated).</summary>
+    public string? SchacHomeOrganization { get; set; }
+
+    /// <summary>Gets or sets the organization alias.</summary>
+    public string? Alias { get; set; }
+
+    /// <summary>Gets or sets contact emails separated by comma.</summary>
+    public string? ContactEmails { get; set; }
+
+    /// <summary>Gets or sets the contact webhook URL.</summary>
+    public string? ContactWebhook { get; set; }
+
+    /// <summary>Gets or sets the contact Slack webhook URL.</summary>
+    public string? ContactSlack { get; set; }
+
+    /// <summary>Gets or sets the contact Teams webhook URL.</summary>
+    public string? ContactTeams { get; set; }
+
+    /// <summary>Gets or sets the first address line.</summary>
+    public string? Address1 { get; set; }
+
+    /// <summary>Gets or sets the second address line.</summary>
+    public string? Address2 { get; set; }
+
+    /// <summary>Gets or sets the third address line.</summary>
+    public string? Address3 { get; set; }
+
+    /// <summary>Gets or sets the city.</summary>
+    public string? City { get; set; }
+
+    /// <summary>Gets or sets the state or province.</summary>
+    public string? StateOrProvince { get; set; }
+
+    /// <summary>Gets or sets the postal code.</summary>
+    public string? PostalCode { get; set; }
+
+    /// <summary>Gets or sets the country code.</summary>
+    public string? Country { get; set; }
+
+    /// <summary>Gets or sets client certificate options.</summary>
+    public OrganizationClientCertificate? ClientCertificate { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether SSL certificates API is enabled.</summary>
+    public bool? SslCertsApiEnabled { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether client certificates API is enabled.</summary>
+    public bool? ClientCertsApiEnabled { get; set; }
+}


### PR DESCRIPTION
## Summary
- implement `OrganizationsClient.UpdateAsync` for PUT `/v1/organization/{id}`
- add `UpdateOrganizationRequest` model
- test updating organizations
- demonstrate updating an organization in examples

## Testing
- `dotnet test -c Release --verbosity minimal`
- `dotnet build --no-restore -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68778993e200832e830adf917f8b7f67