### PR TITLE
Add renew by order number endpoint

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/RenewCertificateByOrderNumberExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/RenewCertificateByOrderNumberExample.cs
@@ -1,0 +1,33 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Requests;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates renewing a certificate using an order number.
+/// </summary>
+public static class RenewCertificateByOrderNumberExample {
+    /// <summary>Executes the example that renews a certificate by order number.</summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+
+        Console.WriteLine("Renewing certificate by order number...");
+        var request = new RenewCertificateRequest {
+            Csr = "<csr>",
+            DcvMode = "EMAIL",
+            DcvEmail = "admin@example.com"
+        };
+        var newId = await certificates.RenewByOrderNumberAsync(12345, request);
+        Console.WriteLine($"New certificate id: {newId}");
+    }
+}
+

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -169,6 +169,28 @@ public sealed class CertificatesClientTests {
     }
 
     [Fact]
+    public async Task RenewByOrderNumberAsync_SendsRequestAndReturnsId() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create(new RenewCertificateResponse { SslId = 11 })
+        };
+
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var certificates = new CertificatesClient(client);
+
+        var request = new RenewCertificateRequest { Csr = "csr", DcvMode = "EMAIL", DcvEmail = "admin@example.com" };
+        var result = await certificates.RenewByOrderNumberAsync(555, request);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/v1/certificate/renew/555", handler.Request!.RequestUri!.ToString());
+        Assert.NotNull(handler.Body);
+        Assert.Contains("\"csr\":\"csr\"", handler.Body);
+        Assert.Contains("\"dcvMode\":\"EMAIL\"", handler.Body);
+        Assert.Contains("\"dcvEmail\":\"admin@example.com\"", handler.Body);
+        Assert.Equal(11, result);
+    }
+
+    [Fact]
     public async Task SearchAsync_EncodesAndOrdersQueryParameters() {
         var response = new HttpResponseMessage(HttpStatusCode.OK) {
             Content = JsonContent.Create(Array.Empty<Certificate>())

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -102,6 +102,23 @@ public sealed class CertificatesClient {
     }
 
     /// <summary>
+    /// Renews a certificate by order number.
+    /// </summary>
+    /// <param name="orderNumber">Order number used to identify the certificate.</param>
+    /// <param name="request">Payload describing renewal parameters.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The identifier of the newly issued certificate.</returns>
+    public async Task<int> RenewByOrderNumberAsync(long orderNumber, RenewCertificateRequest request, CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var response = await _client.PostAsync($"v1/certificate/renew/{orderNumber}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        var result = await response.Content.ReadFromJsonAsync<RenewCertificateResponse>(s_json, cancellationToken).ConfigureAwait(false);
+        return result?.SslId ?? 0;
+    }
+
+    /// <summary>
     /// Searches for certificates using the provided filter.
     /// </summary>
     public async Task<CertificateResponse?> SearchAsync(CertificateSearchRequest request, CancellationToken cancellationToken = default) {


### PR DESCRIPTION
## Summary
- add `RenewByOrderNumberAsync` to `CertificatesClient`
- document renewing by order number in examples
- test new renew-by-order-number API

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6877a5193080832e873d3a25d98b8bfb