### PR TITLE
Ensure UTF-8 certificate exports

### DIFF
--- a/SectigoCertificateManager/Utilities/CertificateExport.cs
+++ b/SectigoCertificateManager/Utilities/CertificateExport.cs
@@ -21,7 +21,7 @@ public static class CertificateExport {
         builder.AppendLine("-----BEGIN CERTIFICATE-----");
         builder.AppendLine(Convert.ToBase64String(certificate.Export(X509ContentType.Cert), Base64FormattingOptions.InsertLineBreaks));
         builder.AppendLine("-----END CERTIFICATE-----");
-        File.WriteAllText(path, builder.ToString());
+        File.WriteAllText(path, builder.ToString(), Encoding.UTF8);
     }
 
     /// <summary>Saves the certificate in DER format.</summary>
@@ -104,6 +104,6 @@ public static class CertificateExport {
             builder.AppendLine("-----END CERTIFICATE-----");
         }
 
-        File.WriteAllText(path, builder.ToString());
+        File.WriteAllText(path, builder.ToString(), Encoding.UTF8);
     }
 }


### PR DESCRIPTION
## Summary
- save PEM files using UTF-8 encoding
- verify UTF-8 output in CertificateExport tests

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6877a4dc6e80832e886c2eeb6256183c