### PR TITLE
Implement paged certificate search

### DIFF
--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -5,6 +5,7 @@ using SectigoCertificateManager.Requests;
 using SectigoCertificateManager.Responses;
 using System.IO;
 using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 
@@ -104,15 +105,84 @@ public sealed class CertificatesClient {
     /// <summary>
     /// Searches for certificates using the provided filter.
     /// </summary>
-    public async Task<CertificateResponse?> SearchAsync(CertificateSearchRequest request, CancellationToken cancellationToken = default) {
+    public async Task<CertificateResponse?> SearchAsync(
+        CertificateSearchRequest request,
+        CancellationToken cancellationToken = default) {
         if (request is null) {
             throw new ArgumentNullException(nameof(request));
         }
 
-        var query = BuildQuery(request);
-        var response = await _client.GetAsync($"v1/certificate{query}", cancellationToken);
-        var items = await response.Content.ReadFromJsonAsync<IReadOnlyList<Certificate>>(s_json, cancellationToken);
-        return items is null ? null : new CertificateResponse { Certificates = items };
+        var list = new List<Certificate>();
+        await foreach (var certificate in EnumerateSearchAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false)) {
+            list.Add(certificate);
+        }
+
+        return list.Count == 0 ? null : new CertificateResponse { Certificates = list };
+    }
+
+    /// <summary>
+    /// Streams search results page by page.
+    /// </summary>
+    /// <param name="request">Filter describing certificates to retrieve.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async IAsyncEnumerable<Certificate> EnumerateSearchAsync(
+        CertificateSearchRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var originalSize = request.Size;
+        var originalPosition = request.Position;
+        var pageSize = request.Size ?? 200;
+        var position = request.Position ?? 0;
+
+        try {
+            var query = BuildQuery(request);
+            var response = await _client.GetAsync($"v1/certificate{query}", cancellationToken).ConfigureAwait(false);
+            var page = await response.Content
+                .ReadFromJsonAsync<IReadOnlyList<Certificate>>(s_json, cancellationToken)
+                .ConfigureAwait(false);
+            if (page is null || page.Count == 0) {
+                yield break;
+            }
+
+            foreach (var certificate in page) {
+                yield return certificate;
+            }
+
+            if (page.Count < pageSize) {
+                yield break;
+            }
+
+            request.Size = pageSize;
+            position += pageSize;
+
+            while (true) {
+                request.Position = position;
+                query = BuildQuery(request);
+                response = await _client.GetAsync($"v1/certificate{query}", cancellationToken).ConfigureAwait(false);
+                page = await response.Content
+                    .ReadFromJsonAsync<IReadOnlyList<Certificate>>(s_json, cancellationToken)
+                    .ConfigureAwait(false);
+                if (page is null || page.Count == 0) {
+                    yield break;
+                }
+
+                foreach (var certificate in page) {
+                    yield return certificate;
+                }
+
+                if (page.Count < pageSize) {
+                    yield break;
+                }
+
+                position += pageSize;
+            }
+        } finally {
+            request.Size = originalSize;
+            request.Position = originalPosition;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- stream certificate search results with `EnumerateSearchAsync`
- build search lists using enumeration
- test multi-page certificate search retrieval

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release --no-build -v n`

------
https://chatgpt.com/codex/tasks/task_e_6877a535faa4832e8ac8fbcdd4be261a