### PR TITLE
feat(orders): add order history retrieval

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/GetOrderHistoryExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/GetOrderHistoryExample.cs
@@ -1,0 +1,29 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates retrieving history entries for an order.
+/// </summary>
+public static class GetOrderHistoryExample {
+    /// <summary>
+    /// Executes the example that fetches order history.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var orders = new OrdersClient(client);
+
+        var history = await orders.GetHistoryAsync(12345);
+        foreach (var entry in history) {
+            Console.WriteLine($"{entry.Date:u} - {entry.Event}");
+        }
+    }
+}

--- a/SectigoCertificateManager.PowerShell/Examples/GetOrderHistoryExample.ps1
+++ b/SectigoCertificateManager.PowerShell/Examples/GetOrderHistoryExample.ps1
@@ -1,0 +1,2 @@
+# Demonstrates retrieving history for an order.
+Get-SectigoOrderHistory -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -OrderId 10

--- a/SectigoCertificateManager.PowerShell/GetSectigoOrderHistoryCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoOrderHistoryCommand.cs
@@ -1,0 +1,51 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using System.Management.Automation;
+
+namespace SectigoCertificateManager.PowerShell;
+
+/// <summary>Retrieves order history.</summary>
+/// <para>Creates an API client and returns history entries for an order.</para>
+[Cmdlet(VerbsCommon.Get, "SectigoOrderHistory")]
+[OutputType(typeof(Models.OrderHistoryEntry))]
+public sealed class GetSectigoOrderHistoryCommand : PSCmdlet {
+    /// <summary>The API base URL.</summary>
+    [Parameter(Mandatory = true)]
+    public string BaseUrl { get; set; } = string.Empty;
+
+    /// <summary>The user name for authentication.</summary>
+    [Parameter(Mandatory = true)]
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>The password for authentication.</summary>
+    [Parameter(Mandatory = true)]
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>The customer URI assigned by Sectigo.</summary>
+    [Parameter(Mandatory = true)]
+    public string CustomerUri { get; set; } = string.Empty;
+
+    /// <summary>The API version to use.</summary>
+    [Parameter]
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+
+    /// <summary>The identifier of the order.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public int OrderId { get; set; }
+
+    /// <summary>Executes the cmdlet.</summary>
+    /// <para>Creates an API client and retrieves the history for the specified order.</para>
+    protected override void ProcessRecord() {
+        if (OrderId <= 0) {
+            var ex = new ArgumentOutOfRangeException(nameof(OrderId));
+            var record = new ErrorRecord(ex, "InvalidOrderId", ErrorCategory.InvalidArgument, OrderId);
+            ThrowTerminatingError(record);
+        }
+
+        var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
+        var client = new SectigoClient(config);
+        var orders = new OrdersClient(client);
+        var history = orders.GetHistoryAsync(OrderId).GetAwaiter().GetResult();
+        WriteObject(history, true);
+    }
+}

--- a/SectigoCertificateManager.Tests/OrdersClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrdersClientTests.cs
@@ -84,6 +84,37 @@ public sealed class OrdersClientTests {
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => orders.CancelAsync(orderId));
     }
 
+    [Fact]
+    public async Task GetHistoryAsync_ReturnsEntries() {
+        var entry = new OrderHistoryEntry { Date = DateTimeOffset.Now, Event = "Created" };
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create(new[] { entry })
+        };
+
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var orders = new OrdersClient(client);
+
+        var result = await orders.GetHistoryAsync(7);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/v1/order/7/history", handler.Request!.RequestUri!.ToString());
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal("Created", result[0].Event);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-2)]
+    public async Task GetHistoryAsync_InvalidOrderId_Throws(int orderId) {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var orders = new OrdersClient(client);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => orders.GetHistoryAsync(orderId));
+    }
+
     private sealed class SequenceHandler : HttpMessageHandler {
         private readonly Queue<HttpResponseMessage> _responses;
         public List<HttpRequestMessage> Requests { get; } = new();

--- a/SectigoCertificateManager.Tests/Pester/GetSectigoOrderHistoryCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/GetSectigoOrderHistoryCommand.Tests.ps1
@@ -1,0 +1,12 @@
+Describe "Get-SectigoOrderHistory" {
+    BeforeAll {
+        dotnet build "$PSScriptRoot/../../SectigoCertificateManager.PowerShell" -c Release | Out-Null
+        $dll = Join-Path $PSScriptRoot '../../SectigoCertificateManager.PowerShell/bin/Release/net8.0/SectigoCertificateManager.PowerShell.dll'
+        Import-Module $dll
+    }
+
+    It "exports the cmdlet" {
+        $cmd = Get-Command Get-SectigoOrderHistory -ErrorAction Stop
+        $cmd | Should -Not -BeNullOrEmpty
+    }
+}

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -95,4 +95,19 @@ public sealed class OrdersClient {
         var response = await _client.PostAsync($"v1/order/{orderId}/cancel", new StringContent(string.Empty), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
+
+    /// <summary>
+    /// Retrieves the history of an order by identifier.
+    /// </summary>
+    /// <param name="orderId">Identifier of the order.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<IReadOnlyList<OrderHistoryEntry>> GetHistoryAsync(int orderId, CancellationToken cancellationToken = default) {
+        if (orderId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(orderId));
+        }
+
+        var response = await _client.GetAsync($"v1/order/{orderId}/history", cancellationToken).ConfigureAwait(false);
+        var entries = await response.Content.ReadFromJsonAsync<IReadOnlyList<OrderHistoryEntry>>(s_json, cancellationToken).ConfigureAwait(false);
+        return entries ?? Array.Empty<OrderHistoryEntry>();
+    }
 }

--- a/SectigoCertificateManager/Models/OrderHistoryEntry.cs
+++ b/SectigoCertificateManager/Models/OrderHistoryEntry.cs
@@ -1,0 +1,15 @@
+namespace SectigoCertificateManager.Models;
+
+/// <summary>
+/// Represents a single event in the lifecycle of an order.
+/// </summary>
+public sealed class OrderHistoryEntry {
+    /// <summary>Gets or sets the timestamp of the event.</summary>
+    public DateTimeOffset Date { get; set; }
+
+    /// <summary>Gets or sets the textual description of the event.</summary>
+    public string Event { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the user responsible for the event.</summary>
+    public string? PerformedBy { get; set; }
+}


### PR DESCRIPTION
## Summary
- expose order history endpoint in `OrdersClient`
- add `OrderHistoryEntry` model
- cover order history with unit tests
- add example usage in Examples project
- provide `Get-SectigoOrderHistory` cmdlet and example
- include pester tests for the new command

## Testing
- `dotnet build --no-restore -c Release SectigoCertificateManager.sln`
- `dotnet test --no-build -c Release SectigoCertificateManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_6877a526f7c0832eaf1ddbf1af3f042b