### PR TITLE
Add certificate deletion feature

### DIFF
--- a/Module/SectigoCertificateManager.psd1
+++ b/Module/SectigoCertificateManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Get-SectigoCertificate', 'Get-SectigoOrders', 'Get-SectigoOrganizations', 'Get-SectigoProfile', 'New-SectigoOrder', 'Stop-SectigoOrder', 'Update-SectigoCertificate')
+    CmdletsToExport      = @('Get-SectigoCertificate', 'Get-SectigoOrders', 'Get-SectigoOrganizations', 'Get-SectigoProfile', 'New-SectigoOrder', 'Stop-SectigoOrder', 'Update-SectigoCertificate', 'Remove-SectigoCertificate')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/SectigoCertificateManager.Examples/Examples/DeleteCertificateExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/DeleteCertificateExample.cs
@@ -1,0 +1,27 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates deleting a certificate.
+/// </summary>
+public static class DeleteCertificateExample {
+    /// <summary>
+    /// Executes the example that deletes a certificate.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+
+        Console.WriteLine("Deleting certificate...");
+        await certificates.DeleteAsync(12345);
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -3,3 +3,4 @@ using SectigoCertificateManager.Examples.Examples;
 await BasicApiExample.RunAsync();
 await SearchCertificatesExample.RunAsync();
 await DownloadCertificateExample.RunAsync();
+await DeleteCertificateExample.RunAsync();

--- a/SectigoCertificateManager.PowerShell/RemoveSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/RemoveSectigoCertificateCommand.cs
@@ -1,0 +1,50 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using System;
+using System.Management.Automation;
+
+namespace SectigoCertificateManager.PowerShell;
+
+/// <summary>Deletes a certificate.</summary>
+/// <para>Builds an API client and calls the delete endpoint.</para>
+[Cmdlet(VerbsCommon.Remove, "SectigoCertificate")]
+public sealed class RemoveSectigoCertificateCommand : PSCmdlet {
+    /// <summary>The API base URL.</summary>
+    [Parameter(Mandatory = true)]
+    public string BaseUrl { get; set; } = string.Empty;
+
+    /// <summary>The user name for authentication.</summary>
+    [Parameter(Mandatory = true)]
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>The password for authentication.</summary>
+    [Parameter(Mandatory = true)]
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>The customer URI assigned by Sectigo.</summary>
+    [Parameter(Mandatory = true)]
+    public string CustomerUri { get; set; } = string.Empty;
+
+    /// <summary>The API version to use.</summary>
+    [Parameter]
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+
+    /// <summary>The identifier of the certificate to delete.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public int CertificateId { get; set; }
+
+    /// <summary>Deletes a certificate.</summary>
+    /// <para>Builds an API client and calls the delete endpoint.</para>
+    protected override void ProcessRecord() {
+        if (CertificateId <= 0) {
+            var ex = new ArgumentOutOfRangeException(nameof(CertificateId));
+            var record = new ErrorRecord(ex, "InvalidCertificateId", ErrorCategory.InvalidArgument, CertificateId);
+            ThrowTerminatingError(record);
+        }
+
+        var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+        certificates.DeleteAsync(CertificateId).GetAwaiter().GetResult();
+    }
+}

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -284,6 +284,31 @@ public sealed class CertificatesClientTests {
     }
 
     [Fact]
+    public async Task DeleteAsync_SendsDeleteRequest() {
+        var response = new HttpResponseMessage(HttpStatusCode.NoContent);
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var certificates = new CertificatesClient(client);
+
+        await certificates.DeleteAsync(6);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal(HttpMethod.Delete, handler.Request!.Method);
+        Assert.Equal("https://example.com/v1/certificate/6", handler.Request.RequestUri!.ToString());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-2)]
+    public async Task DeleteAsync_InvalidCertificateId_Throws(int certificateId) {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var certificates = new CertificatesClient(client);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.DeleteAsync(certificateId));
+    }
+
+    [Fact]
     public async Task SearchAsync_NullRequest_Throws() {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Array.Empty<Certificate>()) });
         var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));

--- a/SectigoCertificateManager.Tests/Pester/RemoveSectigoCertificateCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/RemoveSectigoCertificateCommand.Tests.ps1
@@ -1,0 +1,11 @@
+Describe "Remove-SectigoCertificate" {
+    BeforeAll {
+        dotnet build "$PSScriptRoot/../../SectigoCertificateManager.PowerShell" -c Release | Out-Null
+        $dll = Join-Path $PSScriptRoot '../../SectigoCertificateManager.PowerShell/bin/Release/net8.0/SectigoCertificateManager.PowerShell.dll'
+        Import-Module $dll
+    }
+
+    It "throws when CertificateId is less than or equal to zero" {
+        { Remove-SectigoCertificate -BaseUrl 'b' -Username 'u' -Password 'p' -CustomerUri 'c' -CertificateId 0 } | Should -Throw
+    }
+}

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -147,6 +147,20 @@ public sealed class CertificatesClient {
         }
     }
 
+    /// <summary>
+    /// Deletes a certificate by identifier.
+    /// </summary>
+    /// <param name="certificateId">Identifier of the certificate to delete.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task DeleteAsync(int certificateId, CancellationToken cancellationToken = default) {
+        if (certificateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(certificateId));
+        }
+
+        var response = await _client.DeleteAsync($"v1/certificate/{certificateId}", cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
     private static string BuildQuery(CertificateSearchRequest request) {
         var builder = new StringBuilder();
 


### PR DESCRIPTION
## Summary
- implement `CertificatesClient.DeleteAsync`
- add new PowerShell cmdlet `Remove-SectigoCertificate`
- export cmdlet in module manifest
- add API example for deleting certificates
- include Pester & xUnit tests

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`
- `pwsh -NoLogo -NoProfile -Command "Import-Module Pester; Invoke-Pester ./SectigoCertificateManager.Tests/Pester"`

------
https://chatgpt.com/codex/tasks/task_e_6877a5216f20832e9d8e77d397ce30f9