### PR TITLE
Add inventory CSV support

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/DownloadInventoryCsvExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/DownloadInventoryCsvExample.cs
@@ -1,0 +1,25 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Requests;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+public static class DownloadInventoryCsvExample {
+    /// <summary>
+    /// Demonstrates downloading certificate inventory as CSV.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .Build();
+
+        var client = new SectigoClient(config);
+        var inventory = new InventoryClient(client);
+
+        var request = new InventoryCsvRequest { Size = 10 };
+        var records = await inventory.DownloadCsvAsync(request);
+        Console.WriteLine($"Downloaded {records.Count} records.");
+    }
+}

--- a/SectigoCertificateManager.Tests/InventoryClientTests.cs
+++ b/SectigoCertificateManager.Tests/InventoryClientTests.cs
@@ -1,0 +1,56 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Requests;
+using SectigoCertificateManager.Models;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="InventoryClient"/>.
+/// </summary>
+public sealed class InventoryClientTests {
+    private sealed class TestHandler : HttpMessageHandler {
+        private readonly HttpResponseMessage _response;
+        public HttpRequestMessage? Request { get; private set; }
+
+        public TestHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            Request = request;
+            return Task.FromResult(_response);
+        }
+    }
+
+    [Fact]
+    public async Task DownloadCsvAsync_BuildsQueryAndParsesCsv() {
+        const string csv = "id,commonName\n1,example.com";
+        var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(csv) };
+
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var inventory = new InventoryClient(client);
+
+        var request = new InventoryCsvRequest { Size = 5, Position = 10 };
+        var result = await inventory.DownloadCsvAsync(request);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/v1/inventory.csv?size=5&position=10", handler.Request!.RequestUri!.ToString());
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal("example.com", result[0].CommonName);
+    }
+
+    [Fact]
+    public async Task DownloadCsvAsync_NullRequest_Throws() {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var inventory = new InventoryClient(client);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => inventory.DownloadCsvAsync(null!));
+    }
+}

--- a/SectigoCertificateManager/Clients/InventoryClient.cs
+++ b/SectigoCertificateManager/Clients/InventoryClient.cs
@@ -1,0 +1,140 @@
+namespace SectigoCertificateManager.Clients;
+
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Requests;
+using System.Text;
+
+/// <summary>
+/// Provides access to inventory related endpoints.
+/// </summary>
+public sealed class InventoryClient {
+    private readonly ISectigoClient _client;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InventoryClient"/> class.
+    /// </summary>
+    /// <param name="client">HTTP client wrapper.</param>
+    public InventoryClient(ISectigoClient client) => _client = client;
+
+    /// <summary>
+    /// Downloads certificate inventory in CSV format.
+    /// </summary>
+    /// <param name="request">Request describing the filter.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<IReadOnlyList<InventoryRecord>> DownloadCsvAsync(
+        InventoryCsvRequest request,
+        CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var query = BuildQuery(request);
+        var response = await _client
+            .GetAsync($"v1/inventory.csv{query}", cancellationToken)
+            .ConfigureAwait(false);
+#if NETSTANDARD2_0 || NET472
+        var csv = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#else
+        var csv = await response.Content.ReadAsStringAsync(cancellationToken)
+            .ConfigureAwait(false);
+#endif
+        return ParseCsv(csv);
+    }
+
+    private static IReadOnlyList<InventoryRecord> ParseCsv(string csv) {
+        var list = new List<InventoryRecord>();
+        using var reader = new StringReader(csv);
+        var header = reader.ReadLine();
+        if (header is null) {
+            return list;
+        }
+        var columns = SplitCsvLine(header);
+        string? line;
+        while ((line = reader.ReadLine()) != null) {
+            var values = SplitCsvLine(line);
+            var record = new InventoryRecord();
+            for (var i = 0; i < columns.Length && i < values.Length; i++) {
+                var value = values[i];
+                switch (columns[i]) {
+                    case "id":
+                        if (int.TryParse(value, out var id)) {
+                            record.Id = id;
+                        }
+                        break;
+                    case "commonName":
+                        record.CommonName = value;
+                        break;
+                    case "organizationName":
+                        record.OrganizationName = value;
+                        break;
+                    case "status":
+                        record.Status = value;
+                        break;
+                    case "expires":
+                        record.Expires = value;
+                        break;
+                }
+            }
+            list.Add(record);
+        }
+        return list;
+    }
+
+    private static string[] SplitCsvLine(string line) {
+        var values = new List<string>();
+        var builder = new StringBuilder();
+        var inQuotes = false;
+        for (var i = 0; i < line.Length; i++) {
+            var ch = line[i];
+            if (ch == '"') {
+                inQuotes = !inQuotes;
+                continue;
+            }
+            if (ch == ',' && !inQuotes) {
+                values.Add(builder.ToString());
+                builder.Clear();
+                continue;
+            }
+            builder.Append(ch);
+        }
+        values.Add(builder.ToString());
+        return values.ToArray();
+    }
+
+    private static string BuildQuery(InventoryCsvRequest request) {
+        var builder = new StringBuilder();
+
+        void AppendSeparator() {
+            _ = builder.Length == 0 ? builder.Append('?') : builder.Append('&');
+        }
+
+
+        void AppendInt(string name, int value) {
+            AppendSeparator();
+            builder.Append(name).Append('=').Append(value);
+        }
+
+        void AppendDate(string name, DateTime? value) {
+            if (!value.HasValue) {
+                return;
+            }
+
+            AppendSeparator();
+            builder.Append(name).Append('=')
+                .Append(value.Value.ToString("yyyy-MM-dd"));
+        }
+
+        if (request.Size.HasValue) {
+            AppendInt("size", request.Size.Value);
+        }
+
+        if (request.Position.HasValue) {
+            AppendInt("position", request.Position.Value);
+        }
+
+        AppendDate("from", request.DateFrom);
+        AppendDate("to", request.DateTo);
+
+        return builder.ToString();
+    }
+}

--- a/SectigoCertificateManager/Models/InventoryRecord.cs
+++ b/SectigoCertificateManager/Models/InventoryRecord.cs
@@ -1,0 +1,21 @@
+namespace SectigoCertificateManager.Models;
+
+/// <summary>
+/// Represents a record in an inventory CSV file.
+/// </summary>
+public sealed class InventoryRecord {
+    /// <summary>Gets or sets the certificate identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the certificate common name.</summary>
+    public string? CommonName { get; set; }
+
+    /// <summary>Gets or sets the organization name.</summary>
+    public string? OrganizationName { get; set; }
+
+    /// <summary>Gets or sets the certificate status.</summary>
+    public string? Status { get; set; }
+
+    /// <summary>Gets or sets the expiration date.</summary>
+    public string? Expires { get; set; }
+}

--- a/SectigoCertificateManager/Requests/InventoryCsvRequest.cs
+++ b/SectigoCertificateManager/Requests/InventoryCsvRequest.cs
@@ -1,0 +1,18 @@
+namespace SectigoCertificateManager.Requests;
+
+/// <summary>
+/// Request describing inventory CSV filters.
+/// </summary>
+public sealed class InventoryCsvRequest {
+    /// <summary>Gets or sets the number of results to return.</summary>
+    public int? Size { get; set; }
+
+    /// <summary>Gets or sets the result offset.</summary>
+    public int? Position { get; set; }
+
+    /// <summary>Gets or sets the starting date for the inventory.</summary>
+    public DateTime? DateFrom { get; set; }
+
+    /// <summary>Gets or sets the ending date for the inventory.</summary>
+    public DateTime? DateTo { get; set; }
+}


### PR DESCRIPTION
## Summary
- add InventoryClient with CSV download capability
- expose InventoryCsvRequest and InventoryRecord models
- test InventoryClient request building and CSV parsing
- add inventory CSV download example

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6877a51084f8832e88a0a935cf16891d