### PR TITLE
Wrap HttpClient in using statements for tests

### DIFF
--- a/SectigoCertificateManager.Tests/ApiErrorHandlerTests.cs
+++ b/SectigoCertificateManager.Tests/ApiErrorHandlerTests.cs
@@ -36,7 +36,7 @@ public sealed class ApiErrorHandlerTests {
             Content = JsonContent.Create(new ApiError { Code = -16, Description = "Unknown user" })
         };
 
-        var client = CreateClient(response);
+        using var client = CreateClient(response);
 
         var ex = await Assert.ThrowsAsync<AuthenticationException>(() => client.GetAsync("v1/test"));
         Assert.Equal(-16, ex.ErrorCode);
@@ -48,7 +48,7 @@ public sealed class ApiErrorHandlerTests {
             Content = JsonContent.Create(new ApiError { Code = -10, Description = "Invalid" })
         };
 
-        var client = CreateClient(response);
+        using var client = CreateClient(response);
 
         var ex = await Assert.ThrowsAsync<ValidationException>(() => client.GetAsync("v1/test"));
         Assert.Equal(-10, ex.ErrorCode);
@@ -60,7 +60,7 @@ public sealed class ApiErrorHandlerTests {
             Content = JsonContent.Create(new ApiError { Code = -2, Description = "Boom" })
         };
 
-        var client = CreateClient(response);
+        using var client = CreateClient(response);
 
         var ex = await Assert.ThrowsAsync<ApiException>(() => client.GetAsync("v1/test"));
         Assert.Equal(-2, ex.ErrorCode);

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -43,7 +43,8 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         var request = new CertificateSearchRequest {
@@ -72,7 +73,8 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         var request = new IssueCertificateRequest { CommonName = "example.com", ProfileId = 1, Term = 12 };
@@ -92,7 +94,8 @@ public sealed class CertificatesClientTests {
     [InlineData(-5)]
     public async Task IssueAsync_InvalidTerm_Throws(int term) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         var request = new IssueCertificateRequest { CommonName = "example.com", ProfileId = 1, Term = term };
@@ -104,7 +107,8 @@ public sealed class CertificatesClientTests {
     [InlineData(-2)]
     public async Task GetAsync_InvalidCertificateId_Throws(int certificateId) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.GetAsync(certificateId));
@@ -115,7 +119,8 @@ public sealed class CertificatesClientTests {
         var response = new HttpResponseMessage(HttpStatusCode.NoContent);
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         var request = new RevokeCertificateRequest { CertId = 5, ReasonCode = 4, Reason = "superseded" };
@@ -136,7 +141,8 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         var request = new CertificateSearchRequest();
@@ -153,7 +159,8 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         var request = new RenewCertificateRequest { Csr = "csr", DcvMode = "EMAIL", DcvEmail = "admin@example.com" };
@@ -175,7 +182,8 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         var request = new CertificateSearchRequest {
@@ -198,7 +206,8 @@ public sealed class CertificatesClientTests {
     [Fact]
     public async Task RevokeAsync_NullRequest_Throws() {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => certificates.RevokeAsync(null!));
@@ -207,7 +216,8 @@ public sealed class CertificatesClientTests {
     [Fact]
     public async Task RenewAsync_NullRequest_Throws() {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(new RenewCertificateResponse { SslId = 1 }) });
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => certificates.RenewAsync(1, null!));
@@ -223,7 +233,8 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -249,7 +260,8 @@ public sealed class CertificatesClientTests {
     [InlineData(null)]
     public async Task DownloadAsync_InvalidPath_Throws(string? path) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentException>(() => certificates.DownloadAsync(1, path!));
@@ -262,7 +274,8 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         var result = await certificates.GetStatusAsync(3);
@@ -277,7 +290,8 @@ public sealed class CertificatesClientTests {
     [InlineData(-1)]
     public async Task GetStatusAsync_InvalidCertificateId_Throws(int certificateId) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.GetStatusAsync(certificateId));
@@ -286,7 +300,8 @@ public sealed class CertificatesClientTests {
     [Fact]
     public async Task SearchAsync_NullRequest_Throws() {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Array.Empty<Certificate>()) });
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => certificates.SearchAsync(null!));

--- a/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
@@ -33,7 +33,8 @@ public sealed class OrderStatusClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var statuses = new OrderStatusClient(client);
 
         var result = await statuses.GetStatusAsync(5);
@@ -48,7 +49,8 @@ public sealed class OrderStatusClientTests {
     [InlineData(-2)]
     public async Task GetStatusAsync_InvalidOrderId_Throws(int orderId) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var statuses = new OrderStatusClient(client);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => statuses.GetStatusAsync(orderId));

--- a/SectigoCertificateManager.Tests/OrdersClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrdersClientTests.cs
@@ -36,7 +36,8 @@ public sealed class OrdersClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var orders = new OrdersClient(client);
 
         var result = await orders.ListOrdersAsync();
@@ -52,7 +53,8 @@ public sealed class OrdersClientTests {
     public async Task CancelAsync_SendsPostRequest() {
         var response = new HttpResponseMessage(HttpStatusCode.NoContent);
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var orders = new OrdersClient(client);
 
         await orders.CancelAsync(5);
@@ -67,7 +69,8 @@ public sealed class OrdersClientTests {
     [InlineData(-1)]
     public async Task GetAsync_InvalidOrderId_Throws(int orderId) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var orders = new OrdersClient(client);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => orders.GetAsync(orderId));
@@ -78,7 +81,8 @@ public sealed class OrdersClientTests {
     [InlineData(-3)]
     public async Task CancelAsync_InvalidOrderId_Throws(int orderId) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var orders = new OrdersClient(client);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => orders.CancelAsync(orderId));
@@ -107,7 +111,8 @@ public sealed class OrdersClientTests {
         };
 
         var handler = new SequenceHandler(responses);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var orders = new OrdersClient(client);
 
         var results = new List<Order>();

--- a/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
@@ -40,7 +40,8 @@ public sealed class OrganizationsClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var organizations = new OrganizationsClient(client);
 
         var result = await organizations.GetAsync(3);
@@ -57,7 +58,8 @@ public sealed class OrganizationsClientTests {
         response.Headers.Location = new System.Uri("https://example.com/v1/organization/10");
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var organizations = new OrganizationsClient(client);
 
         var request = new CreateOrganizationRequest {
@@ -80,7 +82,8 @@ public sealed class OrganizationsClientTests {
         response.Headers.Location = new System.Uri("https://example.com/v1/organization/11/");
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var organizations = new OrganizationsClient(client);
 
         var request = new CreateOrganizationRequest { Name = "org" };
@@ -92,7 +95,8 @@ public sealed class OrganizationsClientTests {
     [Fact]
     public async Task CreateAsync_NullRequest_Throws() {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.Created));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var organizations = new OrganizationsClient(client);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => organizations.CreateAsync(null!));
@@ -106,7 +110,8 @@ public sealed class OrganizationsClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var organizations = new OrganizationsClient(client);
 
         var result = await organizations.ListOrganizationsAsync();
@@ -125,7 +130,8 @@ public sealed class OrganizationsClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var organizations = new OrganizationsClient(client);
 
         var result = await organizations.ListOrganizationsAsync();
@@ -140,7 +146,8 @@ public sealed class OrganizationsClientTests {
     public async Task UpdateAsync_SendsPayload() {
         var response = new HttpResponseMessage(HttpStatusCode.NoContent);
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var organizations = new OrganizationsClient(client);
 
         var request = new UpdateOrganizationRequest { Name = "new" };
@@ -156,7 +163,8 @@ public sealed class OrganizationsClientTests {
     [Fact]
     public async Task UpdateAsync_NullRequest_Throws() {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var organizations = new OrganizationsClient(client);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => organizations.UpdateAsync(5, null!));
@@ -167,7 +175,8 @@ public sealed class OrganizationsClientTests {
     [InlineData(-3)]
     public async Task UpdateAsync_InvalidId_Throws(int id) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var organizations = new OrganizationsClient(client);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => organizations.UpdateAsync(id, new UpdateOrganizationRequest()));

--- a/SectigoCertificateManager.Tests/SectigoClientTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientTests.cs
@@ -39,7 +39,7 @@ public sealed class SectigoClientTests {
     public async Task AddsHeadersAndUsesBaseUrl_WithCredentials() {
         var config = new ApiConfig("https://example.com/api/", "user", "pass", "cst1", ApiVersion.V25_4);
         var handler = new TestHandler();
-        var httpClient = new HttpClient(handler);
+        using var httpClient = new HttpClient(handler);
         var client = new SectigoClient(config, httpClient);
 
         await client.GetAsync("v1/test");
@@ -54,7 +54,7 @@ public sealed class SectigoClientTests {
     public async Task AddsBearerHeaderWhenTokenPresent() {
         var config = new ApiConfig("https://example.com/api/", string.Empty, string.Empty, "cst1", ApiVersion.V25_4, token: "tkn");
         var handler = new TestHandler();
-        var httpClient = new HttpClient(handler);
+        using var httpClient = new HttpClient(handler);
         var client = new SectigoClient(config, httpClient);
 
         await client.GetAsync("v1/test");
@@ -70,7 +70,7 @@ public sealed class SectigoClientTests {
     public async Task TokenOverridesCredentialsWhenBothProvided() {
         var config = new ApiConfig("https://example.com/api/", "user", "pass", "cst1", ApiVersion.V25_4, token: "tkn");
         var handler = new TestHandler();
-        var httpClient = new HttpClient(handler);
+        using var httpClient = new HttpClient(handler);
         var client = new SectigoClient(config, httpClient);
 
         await client.GetAsync("v1/test");
@@ -121,7 +121,7 @@ public sealed class SectigoClientTests {
     public void DisposeDisposesHttpClient() {
         var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
         var handler = new DisposableHandler();
-        var httpClient = new HttpClient(handler);
+        using var httpClient = new HttpClient(handler);
         var client = new SectigoClient(config, httpClient);
 
         client.Dispose();
@@ -133,7 +133,7 @@ public sealed class SectigoClientTests {
     public void DisposeIsIdempotent() {
         var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
         var handler = new DisposableHandler();
-        var httpClient = new HttpClient(handler);
+        using var httpClient = new HttpClient(handler);
         var client = new SectigoClient(config, httpClient);
 
         client.Dispose();
@@ -146,7 +146,7 @@ public sealed class SectigoClientTests {
     public async Task MethodsThrowAfterDispose() {
         var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
         var handler = new TestHandler();
-        var httpClient = new HttpClient(handler);
+        using var httpClient = new HttpClient(handler);
         var client = new SectigoClient(config, httpClient);
 
         client.Dispose();
@@ -173,7 +173,7 @@ public sealed class SectigoClientTests {
             tokenExpiresAt: expired,
             refreshToken: Refresh);
         var handler = new TestHandler();
-        var httpClient = new HttpClient(handler);
+        using var httpClient = new HttpClient(handler);
         var client = new SectigoClient(config, httpClient);
 
         await client.GetAsync("v1/test");
@@ -201,7 +201,7 @@ public sealed class SectigoClientTests {
             tokenExpiresAt: expires,
             refreshToken: Refresh);
         var handler = new TestHandler();
-        var httpClient = new HttpClient(handler);
+        using var httpClient = new HttpClient(handler);
         var client = new SectigoClient(config, httpClient);
 
         await client.GetAsync("v1/test");
@@ -235,7 +235,7 @@ public sealed class SectigoClientTests {
     [Fact]
     public async Task ConcurrencyIsLimited() {
         var handler = new ThrottleHandler(TimeSpan.FromMilliseconds(50));
-        var httpClient = new HttpClient(handler);
+        using var httpClient = new HttpClient(handler);
         var config = new ApiConfigBuilder()
             .WithBaseUrl("https://example.com/")
             .WithCredentials("u", "p")


### PR DESCRIPTION
## Summary
- ensure `HttpClient` instances in tests are disposed with `using`
- dispose client returned from helper methods

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6877a4e2cf5c832eb13580d9b0d75b34