### PR TITLE
Introduce SectigoClientFactory

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/BasicApiExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/BasicApiExample.cs
@@ -23,7 +23,8 @@ public static class BasicApiExample {
             .WithConcurrencyLimit(2)
             .Build();
 
-        var client = new SectigoClient(config);
+        var factory = new SectigoClientFactory();
+        var client = factory.Create(config);
         var certificates = new CertificatesClient(client);
 
         Console.WriteLine("Requesting certificate details...");

--- a/SectigoCertificateManager.Examples/Examples/DownloadCertificateExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/DownloadCertificateExample.cs
@@ -18,7 +18,8 @@ public static class DownloadCertificateExample {
             .WithApiVersion(ApiVersion.V25_6)
             .Build();
 
-        var client = new SectigoClient(config);
+        var factory = new SectigoClientFactory();
+        var client = factory.Create(config);
         var certificates = new CertificatesClient(client);
 
         Console.WriteLine("Downloading certificate...");

--- a/SectigoCertificateManager.Examples/Examples/ListOrganizationsExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/ListOrganizationsExample.cs
@@ -18,7 +18,8 @@ public static class ListOrganizationsExample {
             .WithApiVersion(ApiVersion.V25_6)
             .Build();
 
-        var client = new SectigoClient(config);
+        var factory = new SectigoClientFactory();
+        var client = factory.Create(config);
         var organizations = new OrganizationsClient(client);
 
         foreach (var org in await organizations.ListOrganizationsAsync()) {

--- a/SectigoCertificateManager.Examples/Examples/RenewCertificateExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/RenewCertificateExample.cs
@@ -19,7 +19,8 @@ public static class RenewCertificateExample {
             .WithApiVersion(ApiVersion.V25_6)
             .Build();
 
-        var client = new SectigoClient(config);
+        var factory = new SectigoClientFactory();
+        var client = factory.Create(config);
         var certificates = new CertificatesClient(client);
 
         Console.WriteLine("Renewing certificate...");

--- a/SectigoCertificateManager.Examples/Examples/SearchCertificatesExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/SearchCertificatesExample.cs
@@ -16,7 +16,8 @@ public static class SearchCertificatesExample {
             .WithApiVersion(ApiVersion.V25_6)
             .Build();
 
-        var client = new SectigoClient(config);
+        var factory = new SectigoClientFactory();
+        var client = factory.Create(config);
         var certificates = new CertificatesClient(client);
 
         var request = new CertificateSearchRequest {

--- a/SectigoCertificateManager.Examples/Examples/StreamOrdersExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/StreamOrdersExample.cs
@@ -18,7 +18,8 @@ public static class StreamOrdersExample {
             .WithApiVersion(ApiVersion.V25_6)
             .Build();
 
-        var client = new SectigoClient(config);
+        var factory = new SectigoClientFactory();
+        var client = factory.Create(config);
         var orders = new OrdersClient(client);
 
         await foreach (var order in orders.EnumerateOrdersAsync(pageSize: 50)) {

--- a/SectigoCertificateManager.Examples/Examples/UpdateOrganizationExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/UpdateOrganizationExample.cs
@@ -19,7 +19,8 @@ public static class UpdateOrganizationExample {
             .WithApiVersion(ApiVersion.V25_6)
             .Build();
 
-        var client = new SectigoClient(config);
+        var factory = new SectigoClientFactory();
+        var client = factory.Create(config);
         var organizations = new OrganizationsClient(client);
 
         Console.WriteLine("Updating organization...");

--- a/SectigoCertificateManager.Tests/ApiErrorHandlerTests.cs
+++ b/SectigoCertificateManager.Tests/ApiErrorHandlerTests.cs
@@ -26,7 +26,7 @@ public sealed class ApiErrorHandlerTests {
     private static SectigoClient CreateClient(HttpResponseMessage response) {
         var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
         var handler = new RespondingHandler(response);
-        return new SectigoClient(config, new HttpClient(handler));
+        return new SectigoClientFactory().Create(config, new HttpClient(handler));
     }
 
     /// <summary>Handles 401 responses correctly.</summary>

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -43,7 +43,7 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         var request = new CertificateSearchRequest {
@@ -72,7 +72,7 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         var request = new IssueCertificateRequest { CommonName = "example.com", ProfileId = 1, Term = 12 };
@@ -92,7 +92,7 @@ public sealed class CertificatesClientTests {
     [InlineData(-5)]
     public async Task IssueAsync_InvalidTerm_Throws(int term) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         var request = new IssueCertificateRequest { CommonName = "example.com", ProfileId = 1, Term = term };
@@ -104,7 +104,7 @@ public sealed class CertificatesClientTests {
     [InlineData(-2)]
     public async Task GetAsync_InvalidCertificateId_Throws(int certificateId) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.GetAsync(certificateId));
@@ -115,7 +115,7 @@ public sealed class CertificatesClientTests {
         var response = new HttpResponseMessage(HttpStatusCode.NoContent);
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         var request = new RevokeCertificateRequest { CertId = 5, ReasonCode = 4, Reason = "superseded" };
@@ -136,7 +136,7 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         var request = new CertificateSearchRequest();
@@ -153,7 +153,7 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         var request = new RenewCertificateRequest { Csr = "csr", DcvMode = "EMAIL", DcvEmail = "admin@example.com" };
@@ -175,7 +175,7 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         var request = new CertificateSearchRequest {
@@ -198,7 +198,7 @@ public sealed class CertificatesClientTests {
     [Fact]
     public async Task RevokeAsync_NullRequest_Throws() {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => certificates.RevokeAsync(null!));
@@ -207,7 +207,7 @@ public sealed class CertificatesClientTests {
     [Fact]
     public async Task RenewAsync_NullRequest_Throws() {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(new RenewCertificateResponse { SslId = 1 }) });
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => certificates.RenewAsync(1, null!));
@@ -223,7 +223,7 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -249,7 +249,7 @@ public sealed class CertificatesClientTests {
     [InlineData(null)]
     public async Task DownloadAsync_InvalidPath_Throws(string? path) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentException>(() => certificates.DownloadAsync(1, path!));
@@ -262,7 +262,7 @@ public sealed class CertificatesClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         var result = await certificates.GetStatusAsync(3);
@@ -277,7 +277,7 @@ public sealed class CertificatesClientTests {
     [InlineData(-1)]
     public async Task GetStatusAsync_InvalidCertificateId_Throws(int certificateId) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.GetStatusAsync(certificateId));
@@ -286,7 +286,7 @@ public sealed class CertificatesClientTests {
     [Fact]
     public async Task SearchAsync_NullRequest_Throws() {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Array.Empty<Certificate>()) });
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => certificates.SearchAsync(null!));

--- a/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
@@ -33,7 +33,7 @@ public sealed class OrderStatusClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var statuses = new OrderStatusClient(client);
 
         var result = await statuses.GetStatusAsync(5);
@@ -48,7 +48,7 @@ public sealed class OrderStatusClientTests {
     [InlineData(-2)]
     public async Task GetStatusAsync_InvalidOrderId_Throws(int orderId) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var statuses = new OrderStatusClient(client);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => statuses.GetStatusAsync(orderId));

--- a/SectigoCertificateManager.Tests/OrdersClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrdersClientTests.cs
@@ -36,7 +36,7 @@ public sealed class OrdersClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var orders = new OrdersClient(client);
 
         var result = await orders.ListOrdersAsync();
@@ -52,7 +52,7 @@ public sealed class OrdersClientTests {
     public async Task CancelAsync_SendsPostRequest() {
         var response = new HttpResponseMessage(HttpStatusCode.NoContent);
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var orders = new OrdersClient(client);
 
         await orders.CancelAsync(5);
@@ -67,7 +67,7 @@ public sealed class OrdersClientTests {
     [InlineData(-1)]
     public async Task GetAsync_InvalidOrderId_Throws(int orderId) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var orders = new OrdersClient(client);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => orders.GetAsync(orderId));
@@ -78,7 +78,7 @@ public sealed class OrdersClientTests {
     [InlineData(-3)]
     public async Task CancelAsync_InvalidOrderId_Throws(int orderId) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var orders = new OrdersClient(client);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => orders.CancelAsync(orderId));
@@ -107,7 +107,7 @@ public sealed class OrdersClientTests {
         };
 
         var handler = new SequenceHandler(responses);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var orders = new OrdersClient(client);
 
         var results = new List<Order>();

--- a/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
@@ -40,7 +40,7 @@ public sealed class OrganizationsClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var organizations = new OrganizationsClient(client);
 
         var result = await organizations.GetAsync(3);
@@ -57,7 +57,7 @@ public sealed class OrganizationsClientTests {
         response.Headers.Location = new System.Uri("https://example.com/v1/organization/10");
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var organizations = new OrganizationsClient(client);
 
         var request = new CreateOrganizationRequest {
@@ -80,7 +80,7 @@ public sealed class OrganizationsClientTests {
         response.Headers.Location = new System.Uri("https://example.com/v1/organization/11/");
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var organizations = new OrganizationsClient(client);
 
         var request = new CreateOrganizationRequest { Name = "org" };
@@ -92,7 +92,7 @@ public sealed class OrganizationsClientTests {
     [Fact]
     public async Task CreateAsync_NullRequest_Throws() {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.Created));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var organizations = new OrganizationsClient(client);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => organizations.CreateAsync(null!));
@@ -106,7 +106,7 @@ public sealed class OrganizationsClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var organizations = new OrganizationsClient(client);
 
         var result = await organizations.ListOrganizationsAsync();
@@ -125,7 +125,7 @@ public sealed class OrganizationsClientTests {
         };
 
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var organizations = new OrganizationsClient(client);
 
         var result = await organizations.ListOrganizationsAsync();
@@ -140,7 +140,7 @@ public sealed class OrganizationsClientTests {
     public async Task UpdateAsync_SendsPayload() {
         var response = new HttpResponseMessage(HttpStatusCode.NoContent);
         var handler = new TestHandler(response);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var organizations = new OrganizationsClient(client);
 
         var request = new UpdateOrganizationRequest { Name = "new" };
@@ -156,7 +156,7 @@ public sealed class OrganizationsClientTests {
     [Fact]
     public async Task UpdateAsync_NullRequest_Throws() {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var organizations = new OrganizationsClient(client);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => organizations.UpdateAsync(5, null!));
@@ -167,7 +167,7 @@ public sealed class OrganizationsClientTests {
     [InlineData(-3)]
     public async Task UpdateAsync_InvalidId_Throws(int id) {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var client = new SectigoClientFactory().Create(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
         var organizations = new OrganizationsClient(client);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => organizations.UpdateAsync(id, new UpdateOrganizationRequest()));

--- a/SectigoCertificateManager.Tests/SectigoApiIntegrationTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoApiIntegrationTests.cs
@@ -27,7 +27,7 @@ public sealed class SectigoApiIntegrationTests : IAsyncLifetime {
         _server = WireMockServer.Start();
         try {
             var config = new ApiConfig(_server.Url!, "user", "pass", "cst1", ApiVersion.V25_4);
-            var client = new SectigoClient(config, new HttpClient());
+            var client = new SectigoClientFactory().Create(config, new HttpClient());
             _certificates = new CertificatesClient(client);
             _orders = new OrdersClient(client);
             _profiles = new ProfilesClient(client);

--- a/SectigoCertificateManager.Tests/SectigoClientFactoryTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientFactoryTests.cs
@@ -1,0 +1,33 @@
+using SectigoCertificateManager;
+using System;
+using System.Net.Http;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SectigoClientFactory"/>.
+/// </summary>
+public sealed class SectigoClientFactoryTests {
+    [Fact]
+    public void Create_WithHttpClient_ReturnsClient() {
+        var factory = new SectigoClientFactory();
+        var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
+        var httpClient = new HttpClient();
+
+        using var client = factory.Create(config, httpClient);
+
+        Assert.IsType<SectigoClient>(client);
+        Assert.Same(httpClient, client.HttpClient);
+    }
+
+    [Fact]
+    public void Create_WithoutHttpClient_ConfiguresBaseAddress() {
+        var factory = new SectigoClientFactory();
+        var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
+
+        using var client = factory.Create(config);
+
+        Assert.Equal(new Uri("https://example.com/"), client.HttpClient.BaseAddress);
+    }
+}

--- a/SectigoCertificateManager.Tests/SectigoClientTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientTests.cs
@@ -40,7 +40,7 @@ public sealed class SectigoClientTests {
         var config = new ApiConfig("https://example.com/api/", "user", "pass", "cst1", ApiVersion.V25_4);
         var handler = new TestHandler();
         var httpClient = new HttpClient(handler);
-        var client = new SectigoClient(config, httpClient);
+        var client = new SectigoClientFactory().Create(config, httpClient);
 
         await client.GetAsync("v1/test");
 
@@ -55,7 +55,7 @@ public sealed class SectigoClientTests {
         var config = new ApiConfig("https://example.com/api/", string.Empty, string.Empty, "cst1", ApiVersion.V25_4, token: "tkn");
         var handler = new TestHandler();
         var httpClient = new HttpClient(handler);
-        var client = new SectigoClient(config, httpClient);
+        var client = new SectigoClientFactory().Create(config, httpClient);
 
         await client.GetAsync("v1/test");
 
@@ -71,7 +71,7 @@ public sealed class SectigoClientTests {
         var config = new ApiConfig("https://example.com/api/", "user", "pass", "cst1", ApiVersion.V25_4, token: "tkn");
         var handler = new TestHandler();
         var httpClient = new HttpClient(handler);
-        var client = new SectigoClient(config, httpClient);
+        var client = new SectigoClientFactory().Create(config, httpClient);
 
         await client.GetAsync("v1/test");
 
@@ -122,7 +122,7 @@ public sealed class SectigoClientTests {
         var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
         var handler = new DisposableHandler();
         var httpClient = new HttpClient(handler);
-        var client = new SectigoClient(config, httpClient);
+        var client = new SectigoClientFactory().Create(config, httpClient);
 
         client.Dispose();
 
@@ -134,7 +134,7 @@ public sealed class SectigoClientTests {
         var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
         var handler = new DisposableHandler();
         var httpClient = new HttpClient(handler);
-        var client = new SectigoClient(config, httpClient);
+        var client = new SectigoClientFactory().Create(config, httpClient);
 
         client.Dispose();
         client.Dispose();
@@ -147,7 +147,7 @@ public sealed class SectigoClientTests {
         var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
         var handler = new TestHandler();
         var httpClient = new HttpClient(handler);
-        var client = new SectigoClient(config, httpClient);
+        var client = new SectigoClientFactory().Create(config, httpClient);
 
         client.Dispose();
 
@@ -174,7 +174,7 @@ public sealed class SectigoClientTests {
             refreshToken: Refresh);
         var handler = new TestHandler();
         var httpClient = new HttpClient(handler);
-        var client = new SectigoClient(config, httpClient);
+        var client = new SectigoClientFactory().Create(config, httpClient);
 
         await client.GetAsync("v1/test");
 
@@ -202,7 +202,7 @@ public sealed class SectigoClientTests {
             refreshToken: Refresh);
         var handler = new TestHandler();
         var httpClient = new HttpClient(handler);
-        var client = new SectigoClient(config, httpClient);
+        var client = new SectigoClientFactory().Create(config, httpClient);
 
         await client.GetAsync("v1/test");
 
@@ -243,7 +243,7 @@ public sealed class SectigoClientTests {
             .WithConcurrencyLimit(2)
             .Build();
 
-        var client = new SectigoClient(config, httpClient);
+        var client = new SectigoClientFactory().Create(config, httpClient);
 
         await Task.WhenAll(
             client.GetAsync("v1/a"),

--- a/SectigoCertificateManager/ISectigoClientFactory.cs
+++ b/SectigoCertificateManager/ISectigoClientFactory.cs
@@ -1,0 +1,15 @@
+namespace SectigoCertificateManager;
+
+using System.Net.Http;
+
+/// <summary>
+/// Defines a factory for creating instances of <see cref="ISectigoClient"/>.
+/// </summary>
+public interface ISectigoClientFactory {
+    /// <summary>
+    /// Creates a new <see cref="ISectigoClient"/> instance.
+    /// </summary>
+    /// <param name="config">API configuration settings.</param>
+    /// <param name="httpClient">Optional pre-configured HTTP client.</param>
+    SectigoClient Create(ApiConfig config, HttpClient? httpClient = null);
+}

--- a/SectigoCertificateManager/SectigoClientFactory.cs
+++ b/SectigoCertificateManager/SectigoClientFactory.cs
@@ -1,0 +1,12 @@
+namespace SectigoCertificateManager;
+
+using System.Net.Http;
+
+/// <summary>
+/// Default implementation of <see cref="ISectigoClientFactory"/>.
+/// </summary>
+public sealed class SectigoClientFactory : ISectigoClientFactory {
+    /// <inheritdoc />
+    public SectigoClient Create(ApiConfig config, HttpClient? httpClient = null)
+        => new SectigoClient(config, httpClient);
+}


### PR DESCRIPTION
## Summary
- add `ISectigoClientFactory` interface
- implement `SectigoClientFactory` returning `SectigoClient`
- update examples to obtain clients via the factory
- update tests to create clients through the factory
- add unit tests for `SectigoClientFactory`

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6877a4eaf198832ea9624ae95ad8f107