### PR TITLE
Fix export folder creation

### DIFF
--- a/SectigoCertificateManager.Tests/CertificateExportTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateExportTests.cs
@@ -30,15 +30,17 @@ public sealed class CertificateExportTests {
     [Fact]
     public void SavePem_WritesFile() {
         using var cert = CreateCertificate();
-        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(dir, Path.GetRandomFileName());
         try {
             CertificateExport.SavePem(cert, path);
+            Assert.True(Directory.Exists(dir));
             Assert.True(File.Exists(path));
             var content = File.ReadAllText(path);
             Assert.Contains("BEGIN CERTIFICATE", content);
         } finally {
-            if (File.Exists(path)) {
-                File.Delete(path);
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
             }
         }
     }
@@ -62,15 +64,17 @@ public sealed class CertificateExportTests {
     [Fact]
     public void SaveDer_WritesFile() {
         using var cert = CreateCertificate();
-        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(dir, Path.GetRandomFileName());
         try {
             CertificateExport.SaveDer(cert, path);
+            Assert.True(Directory.Exists(dir));
             Assert.True(File.Exists(path));
             var bytes = File.ReadAllBytes(path);
             Assert.Equal(cert.RawData, bytes);
         } finally {
-            if (File.Exists(path)) {
-                File.Delete(path);
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
             }
         }
     }
@@ -78,15 +82,17 @@ public sealed class CertificateExportTests {
     [Fact]
     public void SavePfx_WritesFile() {
         using var cert = CreateCertificate();
-        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(dir, Path.GetRandomFileName());
         try {
             CertificateExport.SavePfx(cert, path, "pwd");
+            Assert.True(Directory.Exists(dir));
             Assert.True(File.Exists(path));
             using var loaded = new X509Certificate2(path, "pwd");
             Assert.Equal(cert.Thumbprint, loaded.Thumbprint);
         } finally {
-            if (File.Exists(path)) {
-                File.Delete(path);
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
             }
         }
     }
@@ -102,13 +108,15 @@ public sealed class CertificateExportTests {
     [Fact]
     public void SavePfxForTest_ClearsBuffer() {
         using var cert = CreateCertificate();
-        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(dir, Path.GetRandomFileName());
         try {
             var buffer = CertificateExport.SavePfxForTest(cert, path, "pwd");
+            Assert.True(Directory.Exists(dir));
             Assert.All(buffer, b => Assert.Equal(0, b));
         } finally {
-            if (File.Exists(path)) {
-                File.Delete(path);
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
             }
         }
     }
@@ -143,15 +151,17 @@ public sealed class CertificateExportTests {
         RandomNumberGenerator.Fill(serial);
         var leafCert = leafRequest.Create(rootCert, now.AddDays(-1), now.AddDays(1), serial);
 
-        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(dir, Path.GetRandomFileName());
         try {
             CertificateExport.SavePemChain(leafCert, path, new[] { rootCert });
+            Assert.True(Directory.Exists(dir));
             var content = File.ReadAllText(path);
             Assert.Contains("BEGIN CERTIFICATE", content);
             Assert.Equal(2, content.Split("-----END CERTIFICATE-----").Length - 1);
         } finally {
-            if (File.Exists(path)) {
-                File.Delete(path);
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
             }
         }
     }
@@ -159,7 +169,8 @@ public sealed class CertificateExportTests {
     [Fact]
     public void SavePem_UsesUtf8Encoding() {
         using var cert = CreateCertificate();
-        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(dir, Path.GetRandomFileName());
         try {
             CertificateExport.SavePem(cert, path);
             var bytes = File.ReadAllBytes(path);
@@ -209,7 +220,8 @@ public sealed class CertificateExportTests {
         RandomNumberGenerator.Fill(serial);
         var leafCert = leafRequest.Create(rootCert, now.AddDays(-1), now.AddDays(1), serial);
 
-        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(dir, Path.GetRandomFileName());
         try {
             CertificateExport.SavePemChain(leafCert, path, new[] { rootCert });
             var bytes = File.ReadAllBytes(path);
@@ -232,8 +244,8 @@ public sealed class CertificateExportTests {
 
             Assert.Equal(builder.ToString(), text);
         } finally {
-            if (File.Exists(path)) {
-                File.Delete(path);
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
             }
         }
     }

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -259,20 +259,23 @@ public sealed class CertificatesClientTests {
         var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
-        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(dir, Path.GetRandomFileName());
         try {
             if (isValid) {
                 await certificates.DownloadAsync(certificateId, path);
                 Assert.NotNull(handler.Request);
                 Assert.Equal($"https://example.com/ssl/v1/collect/{certificateId}?format=base64", handler.Request!.RequestUri!.ToString());
+                Assert.True(Directory.Exists(dir));
                 Assert.True(File.Exists(path));
                 Assert.Equal("DATA", File.ReadAllText(path));
             } else {
                 await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.DownloadAsync(certificateId, path));
+                Assert.False(Directory.Exists(dir));
             }
         } finally {
-            if (File.Exists(path)) {
-                File.Delete(path);
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
             }
         }
     }

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -225,6 +225,7 @@ public sealed class CertificatesClient {
         var response = await _client.GetAsync(url, cancellationToken).ConfigureAwait(false);
         var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         using (stream) {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             using var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
 #if NETSTANDARD2_0 || NET472
             await stream.CopyToAsync(file).ConfigureAwait(false);

--- a/SectigoCertificateManager/Utilities/CertificateExport.cs
+++ b/SectigoCertificateManager/Utilities/CertificateExport.cs
@@ -21,6 +21,7 @@ public static class CertificateExport {
         builder.AppendLine("-----BEGIN CERTIFICATE-----");
         builder.AppendLine(Convert.ToBase64String(certificate.Export(X509ContentType.Cert), Base64FormattingOptions.InsertLineBreaks));
         builder.AppendLine("-----END CERTIFICATE-----");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         File.WriteAllText(path, builder.ToString(), Encoding.UTF8);
     }
 
@@ -31,6 +32,7 @@ public static class CertificateExport {
         if (string.IsNullOrEmpty(path)) {
             throw new ArgumentException("Path cannot be null or empty.", nameof(path));
         }
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         File.WriteAllBytes(path, certificate.Export(X509ContentType.Cert));
     }
 
@@ -42,6 +44,7 @@ public static class CertificateExport {
         if (string.IsNullOrEmpty(path)) {
             throw new ArgumentException("Path cannot be null or empty.", nameof(path));
         }
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         var bytes = password is null
             ? certificate.Export(X509ContentType.Pfx)
             : certificate.Export(X509ContentType.Pfx, password);
@@ -66,6 +69,7 @@ public static class CertificateExport {
         var bytes = password is null
             ? certificate.Export(X509ContentType.Pfx)
             : certificate.Export(X509ContentType.Pfx, password);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None)) {
             stream.Write(bytes, 0, bytes.Length);
         }
@@ -104,6 +108,7 @@ public static class CertificateExport {
             builder.AppendLine("-----END CERTIFICATE-----");
         }
 
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         File.WriteAllText(path, builder.ToString(), Encoding.UTF8);
     }
 }


### PR DESCRIPTION
## Summary
- ensure CertificateExport methods create directories before writing files
- ensure CertificatesClient downloads to existing folders
- verify new folder creation in tests for file output

## Testing
- `dotnet test -f net8.0 --no-build --verbosity minimal`
- `dotnet test -f net9.0 --no-build --verbosity minimal`
- `dotnet test -f net472 --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6877b19f94c4832e995b56393c41baa0