### PR TITLE
Fix credential validation

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
@@ -96,4 +96,18 @@ public sealed class ApiConfigBuilderTests {
         var ex = Assert.Throws<ArgumentNullException>(() => builder.WithHttpClientHandler(null!));
         Assert.Equal("configure", ex.ParamName);
     }
+
+    [Fact]
+    public void WithCredentials_ThrowsForNullUsername() {
+        var builder = new ApiConfigBuilder();
+
+        Assert.Throws<ArgumentException>(() => builder.WithCredentials(null!, "pass"));
+    }
+
+    [Fact]
+    public void WithCredentials_ThrowsForNullPassword() {
+        var builder = new ApiConfigBuilder();
+
+        Assert.Throws<ArgumentException>(() => builder.WithCredentials("user", null!));
+    }
 }

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -37,6 +37,14 @@ public sealed class ApiConfigBuilder {
     /// <param name="username">User name for API authentication.</param>
     /// <param name="password">Password associated with <paramref name="username"/>.</param>
     public ApiConfigBuilder WithCredentials(string username, string password) {
+        if (string.IsNullOrWhiteSpace(username)) {
+            throw new ArgumentException("Username must not be null or empty.", nameof(username));
+        }
+
+        if (string.IsNullOrWhiteSpace(password)) {
+            throw new ArgumentException("Password must not be null or empty.", nameof(password));
+        }
+
         _username = username;
         _password = password;
         return this;


### PR DESCRIPTION
## Summary
- throw when setting empty credentials in ApiConfigBuilder
- test validation rules in ApiConfigBuilder

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6877b1a4f0b4832eba1547c559743e05