### PR TITLE
Ensure HTTP responses are disposed

### DIFF
--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -412,4 +412,21 @@ public sealed class CertificatesClientTests {
         Assert.NotNull(result);
         Assert.Equal(3, result!.Certificates.Count);
     }
+
+    [Fact]
+    public async Task GetAsync_DisposesResponse() {
+        var response = new DisposableResponse {
+            StatusCode = HttpStatusCode.OK,
+            Content = JsonContent.Create(new Certificate())
+        };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var certificates = new CertificatesClient(client);
+
+        _ = await certificates.GetAsync(1);
+
+        Assert.True(response.Disposed);
+    }
 }

--- a/SectigoCertificateManager.Tests/DisposableResponse.cs
+++ b/SectigoCertificateManager.Tests/DisposableResponse.cs
@@ -1,0 +1,14 @@
+using System.Net.Http;
+
+namespace SectigoCertificateManager.Tests;
+
+internal sealed class DisposableResponse : HttpResponseMessage
+{
+    public bool Disposed { get; private set; }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        Disposed = true;
+    }
+}

--- a/SectigoCertificateManager.Tests/InventoryClientTests.cs
+++ b/SectigoCertificateManager.Tests/InventoryClientTests.cs
@@ -53,4 +53,18 @@ public sealed class InventoryClientTests {
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => inventory.DownloadCsvAsync(null!));
     }
+
+    [Fact]
+    public async Task DownloadCsvAsync_DisposesResponse() {
+        const string csv = "id,commonName\n1,example.com";
+        var response = new DisposableResponse { Content = new StringContent(csv), StatusCode = HttpStatusCode.OK };
+
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var inventory = new InventoryClient(client);
+
+        _ = await inventory.DownloadCsvAsync(new InventoryCsvRequest());
+
+        Assert.True(response.Disposed);
+    }
 }

--- a/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
@@ -55,4 +55,20 @@ public sealed class OrderStatusClientTests {
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => statuses.GetStatusAsync(orderId));
     }
+
+    [Fact]
+    public async Task GetStatusAsync_DisposesResponse() {
+        var response = new DisposableResponse {
+            StatusCode = HttpStatusCode.OK,
+            Content = JsonContent.Create(new { Status = "Submitted" })
+        };
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var statuses = new OrderStatusClient(client);
+
+        _ = await statuses.GetStatusAsync(1);
+
+        Assert.True(response.Disposed);
+    }
 }

--- a/SectigoCertificateManager.Tests/OrdersClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrdersClientTests.cs
@@ -157,4 +157,21 @@ public sealed class OrdersClientTests {
         Assert.Equal(3, results.Count);
         Assert.Equal(3, results[2].Id);
     }
+
+    [Fact]
+    public async Task GetAsync_DisposesResponse() {
+        var response = new DisposableResponse {
+            StatusCode = HttpStatusCode.OK,
+            Content = JsonContent.Create(new Order())
+        };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var orders = new OrdersClient(client);
+
+        _ = await orders.GetAsync(1);
+
+        Assert.True(response.Disposed);
+    }
 }

--- a/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
@@ -181,4 +181,21 @@ public sealed class OrganizationsClientTests {
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => organizations.UpdateAsync(id, new UpdateOrganizationRequest()));
     }
+
+    [Fact]
+    public async Task GetAsync_DisposesResponse() {
+        var response = new DisposableResponse {
+            StatusCode = HttpStatusCode.OK,
+            Content = JsonContent.Create(new Organization())
+        };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var organizations = new OrganizationsClient(client);
+
+        _ = await organizations.GetAsync(1);
+
+        Assert.True(response.Disposed);
+    }
 }

--- a/SectigoCertificateManager.Tests/ProfilesClientTests.cs
+++ b/SectigoCertificateManager.Tests/ProfilesClientTests.cs
@@ -99,4 +99,18 @@ public sealed class ProfilesClientTests {
         Assert.NotNull(result);
         Assert.Empty(result);
     }
+
+    [Fact]
+    public async Task GetAsync_DisposesResponse() {
+        var response = new DisposableResponse {
+            StatusCode = HttpStatusCode.OK,
+            Content = JsonContent.Create(new Profile())
+        };
+        var client = new StubClient(response);
+        var profiles = new ProfilesClient(client);
+
+        _ = await profiles.GetAsync(1);
+
+        Assert.True(response.Disposed);
+    }
 }

--- a/SectigoCertificateManager/ApiErrorHandler.cs
+++ b/SectigoCertificateManager/ApiErrorHandler.cs
@@ -30,6 +30,7 @@ internal static class ApiErrorHandler {
             Description = response.ReasonPhrase ?? "Request failed",
         };
 
+        response.Dispose();
         throw response.StatusCode switch {
             HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => new AuthenticationException(error),
             HttpStatusCode.BadRequest => new ValidationException(error),

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -34,7 +34,7 @@ public sealed class CertificatesClient {
             throw new ArgumentOutOfRangeException(nameof(certificateId));
         }
 
-        var response = await _client.GetAsync($"v1/certificate/{certificateId}", cancellationToken).ConfigureAwait(false);
+        using var response = await _client.GetAsync($"v1/certificate/{certificateId}", cancellationToken).ConfigureAwait(false);
         return await response.Content.ReadFromJsonAsync<Certificate>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
@@ -48,7 +48,7 @@ public sealed class CertificatesClient {
             throw new ArgumentOutOfRangeException(nameof(certificateId));
         }
 
-        var response = await _client.GetAsync($"v1/certificate/{certificateId}/status", cancellationToken).ConfigureAwait(false);
+        using var response = await _client.GetAsync($"v1/certificate/{certificateId}/status", cancellationToken).ConfigureAwait(false);
         var result = await response.Content.ReadFromJsonAsync<StatusResponse>(s_json, cancellationToken).ConfigureAwait(false);
         return result?.Status;
     }
@@ -67,7 +67,7 @@ public sealed class CertificatesClient {
             throw new ArgumentOutOfRangeException(nameof(request.Term));
         }
 
-        var response = await _client.PostAsync("v1/certificate/issue", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        using var response = await _client.PostAsync("v1/certificate/issue", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         return await response.Content.ReadFromJsonAsync<Certificate>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
@@ -81,7 +81,7 @@ public sealed class CertificatesClient {
             throw new ArgumentNullException(nameof(request));
         }
 
-        var response = await _client.PostAsync("v1/certificate/revoke", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        using var response = await _client.PostAsync("v1/certificate/revoke", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
 
@@ -97,7 +97,7 @@ public sealed class CertificatesClient {
             throw new ArgumentNullException(nameof(request));
         }
 
-        var response = await _client.PostAsync($"v1/certificate/renewById/{certificateId}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        using var response = await _client.PostAsync($"v1/certificate/renewById/{certificateId}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         var result = await response.Content.ReadFromJsonAsync<RenewCertificateResponse>(s_json, cancellationToken).ConfigureAwait(false);
         return result?.SslId ?? 0;
     }
@@ -114,7 +114,7 @@ public sealed class CertificatesClient {
             throw new ArgumentNullException(nameof(request));
         }
 
-        var response = await _client.PostAsync($"v1/certificate/renew/{orderNumber}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        using var response = await _client.PostAsync($"v1/certificate/renew/{orderNumber}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         var result = await response.Content.ReadFromJsonAsync<RenewCertificateResponse>(s_json, cancellationToken).ConfigureAwait(false);
         return result?.SslId ?? 0;
     }
@@ -156,7 +156,7 @@ public sealed class CertificatesClient {
 
         try {
             var query = BuildQuery(request);
-            var response = await _client.GetAsync($"v1/certificate{query}", cancellationToken).ConfigureAwait(false);
+            using var response = await _client.GetAsync($"v1/certificate{query}", cancellationToken).ConfigureAwait(false);
             var page = await response.Content
                 .ReadFromJsonAsync<IReadOnlyList<Certificate>>(s_json, cancellationToken)
                 .ConfigureAwait(false);
@@ -178,8 +178,8 @@ public sealed class CertificatesClient {
             while (true) {
                 request.Position = position;
                 query = BuildQuery(request);
-                response = await _client.GetAsync($"v1/certificate{query}", cancellationToken).ConfigureAwait(false);
-                page = await response.Content
+                using var nextResponse = await _client.GetAsync($"v1/certificate{query}", cancellationToken).ConfigureAwait(false);
+                page = await nextResponse.Content
                     .ReadFromJsonAsync<IReadOnlyList<Certificate>>(s_json, cancellationToken)
                     .ConfigureAwait(false);
                 if (page is null || page.Count == 0) {
@@ -222,7 +222,7 @@ public sealed class CertificatesClient {
         }
 
         var url = $"ssl/v1/collect/{certificateId}?format={Uri.EscapeDataString(format)}";
-        var response = await _client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+        using var response = await _client.GetAsync(url, cancellationToken).ConfigureAwait(false);
         var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         using (stream) {
             using var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
@@ -244,7 +244,7 @@ public sealed class CertificatesClient {
             throw new ArgumentOutOfRangeException(nameof(certificateId));
         }
 
-        var response = await _client.DeleteAsync($"v1/certificate/{certificateId}", cancellationToken).ConfigureAwait(false);
+        using var response = await _client.DeleteAsync($"v1/certificate/{certificateId}", cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
 

--- a/SectigoCertificateManager/Clients/InventoryClient.cs
+++ b/SectigoCertificateManager/Clients/InventoryClient.cs
@@ -29,7 +29,7 @@ public sealed class InventoryClient {
         }
 
         var query = BuildQuery(request);
-        var response = await _client
+        using var response = await _client
             .GetAsync($"v1/inventory.csv{query}", cancellationToken)
             .ConfigureAwait(false);
 #if NETSTANDARD2_0 || NET472

--- a/SectigoCertificateManager/Clients/OrderStatusClient.cs
+++ b/SectigoCertificateManager/Clients/OrderStatusClient.cs
@@ -28,7 +28,7 @@ public sealed class OrderStatusClient {
             throw new ArgumentOutOfRangeException(nameof(orderId));
         }
 
-        var response = await _client.GetAsync($"v1/order/{orderId}/status", cancellationToken).ConfigureAwait(false);
+        using var response = await _client.GetAsync($"v1/order/{orderId}/status", cancellationToken).ConfigureAwait(false);
         var result = await response.Content.ReadFromJsonAsync<StatusResponse>(s_json, cancellationToken).ConfigureAwait(false);
         return result?.Status;
     }

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -32,7 +32,7 @@ public sealed class OrdersClient {
             throw new ArgumentOutOfRangeException(nameof(orderId));
         }
 
-        var response = await _client.GetAsync($"v1/order/{orderId}", cancellationToken).ConfigureAwait(false);
+        using var response = await _client.GetAsync($"v1/order/{orderId}", cancellationToken).ConfigureAwait(false);
         return await response.Content.ReadFromJsonAsync<Order>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
@@ -60,7 +60,7 @@ public sealed class OrdersClient {
         var position = 0;
 
         while (true) {
-            var response = await _client
+            using var response = await _client
                 .GetAsync($"v1/order?size={pageSize}&position={position}", cancellationToken)
                 .ConfigureAwait(false);
             var page = await response.Content
@@ -92,7 +92,7 @@ public sealed class OrdersClient {
             throw new ArgumentOutOfRangeException(nameof(orderId));
         }
 
-        var response = await _client.PostAsync($"v1/order/{orderId}/cancel", new StringContent(string.Empty), cancellationToken).ConfigureAwait(false);
+        using var response = await _client.PostAsync($"v1/order/{orderId}/cancel", new StringContent(string.Empty), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
 
@@ -106,7 +106,7 @@ public sealed class OrdersClient {
             throw new ArgumentOutOfRangeException(nameof(orderId));
         }
 
-        var response = await _client.GetAsync($"v1/order/{orderId}/history", cancellationToken).ConfigureAwait(false);
+        using var response = await _client.GetAsync($"v1/order/{orderId}/history", cancellationToken).ConfigureAwait(false);
         var entries = await response.Content.ReadFromJsonAsync<IReadOnlyList<OrderHistoryEntry>>(s_json, cancellationToken).ConfigureAwait(false);
         return entries ?? Array.Empty<OrderHistoryEntry>();
     }

--- a/SectigoCertificateManager/Clients/OrganizationsClient.cs
+++ b/SectigoCertificateManager/Clients/OrganizationsClient.cs
@@ -27,7 +27,7 @@ public sealed class OrganizationsClient {
     /// <param name="organizationId">Identifier of the organization to retrieve.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Organization?> GetAsync(int organizationId, CancellationToken cancellationToken = default) {
-        var response = await _client.GetAsync($"v1/organization/{organizationId}", cancellationToken).ConfigureAwait(false);
+        using var response = await _client.GetAsync($"v1/organization/{organizationId}", cancellationToken).ConfigureAwait(false);
         return await response.Content.ReadFromJsonAsync<Organization>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
@@ -42,7 +42,7 @@ public sealed class OrganizationsClient {
             throw new ArgumentNullException(nameof(request));
         }
 
-        var response = await _client.PostAsync("v1/organization", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        using var response = await _client.PostAsync("v1/organization", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         var location = response.Headers.Location;
         if (location is not null) {
             var path = location.AbsolutePath.TrimEnd('/');
@@ -69,7 +69,7 @@ public sealed class OrganizationsClient {
             throw new ArgumentNullException(nameof(request));
         }
 
-        var response = await _client
+        using var response = await _client
             .PutAsync($"v1/organization/{organizationId}", JsonContent.Create(request, options: s_json), cancellationToken)
             .ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
@@ -80,7 +80,7 @@ public sealed class OrganizationsClient {
     /// </summary>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<IReadOnlyList<Organization>> ListOrganizationsAsync(CancellationToken cancellationToken = default) {
-        var response = await _client.GetAsync("v1/organization", cancellationToken).ConfigureAwait(false);
+        using var response = await _client.GetAsync("v1/organization", cancellationToken).ConfigureAwait(false);
         var organizations = await response.Content
             .ReadFromJsonAsync<IReadOnlyList<Organization>>(s_json, cancellationToken)
             .ConfigureAwait(false);

--- a/SectigoCertificateManager/Clients/ProfilesClient.cs
+++ b/SectigoCertificateManager/Clients/ProfilesClient.cs
@@ -25,7 +25,7 @@ public sealed class ProfilesClient {
     /// <param name="profileId">Identifier of the profile to retrieve.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Profile?> GetAsync(int profileId, CancellationToken cancellationToken = default) {
-        var response = await _client.GetAsync($"v1/profile/{profileId}", cancellationToken).ConfigureAwait(false);
+        using var response = await _client.GetAsync($"v1/profile/{profileId}", cancellationToken).ConfigureAwait(false);
         return await response.Content.ReadFromJsonAsync<Profile>(s_json, cancellationToken).ConfigureAwait(false);
     }
 
@@ -34,7 +34,7 @@ public sealed class ProfilesClient {
     /// </summary>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<IReadOnlyList<Profile>> ListProfilesAsync(CancellationToken cancellationToken = default) {
-        var response = await _client.GetAsync("v1/profile", cancellationToken).ConfigureAwait(false);
+        using var response = await _client.GetAsync("v1/profile", cancellationToken).ConfigureAwait(false);
         var profiles = await response.Content
             .ReadFromJsonAsync<IReadOnlyList<Profile>>(s_json, cancellationToken)
             .ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- dispose HTTP responses in each client after processing
- dispose error responses before throwing
- verify disposal in unit tests using a custom `DisposableResponse`

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6877b1b087ec832eafca786aa9350194