### PR TITLE
Handle whitespace in Location header

### DIFF
--- a/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrganizationsClientTests.cs
@@ -93,6 +93,22 @@ public sealed class OrganizationsClientTests {
     }
 
     [Fact]
+    public async Task CreateAsync_ParsesId_WhenLocationContainsWhitespace() {
+        var response = new HttpResponseMessage(HttpStatusCode.Created);
+        response.Headers.TryAddWithoutValidation("Location", " https://example.com/v1/organization/12/ \t");
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var organizations = new OrganizationsClient(client);
+
+        var request = new CreateOrganizationRequest { Name = "org" };
+        var id = await organizations.CreateAsync(request);
+
+        Assert.Equal(12, id);
+    }
+
+    [Fact]
     public async Task CreateAsync_NullRequest_Throws() {
         var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.Created));
         using var httpClient = new HttpClient(handler);

--- a/SectigoCertificateManager/Clients/OrganizationsClient.cs
+++ b/SectigoCertificateManager/Clients/OrganizationsClient.cs
@@ -42,11 +42,14 @@ public sealed class OrganizationsClient {
             throw new ArgumentNullException(nameof(request));
         }
 
-        var response = await _client.PostAsync("v1/organization", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        var response = await _client
+            .PostAsync("v1/organization", JsonContent.Create(request, options: s_json), cancellationToken)
+            .ConfigureAwait(false);
+
         var location = response.Headers.Location;
         if (location is not null) {
-            var path = location.AbsolutePath.TrimEnd('/');
-            var segments = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            var url = location.ToString().Trim().TrimEnd('/');
+            var segments = url.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             if (segments.Length > 0 && int.TryParse(segments[segments.Length - 1], out var id)) {
                 return id;
             }


### PR DESCRIPTION
## Summary
- trim `response.Headers.Location` before parsing organization ID
- test parsing Location header with trailing slash and whitespace

## Testing
- `dotnet test SectigoCertificateManager.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6877b1bb77e0832ead2b243f6b2a365d