### PR TITLE
Handle base URL paths when collecting certificates

### DIFF
--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -290,6 +290,29 @@ public sealed class CertificatesClientTests {
     }
 
     [Fact]
+    public async Task DownloadAsync_WithBaseUrlPath_UsesCorrectUri() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new StringContent("DATA")
+        };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/api", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var certificates = new CertificatesClient(client);
+
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try {
+            await certificates.DownloadAsync(2, path);
+            Assert.NotNull(handler.Request);
+            Assert.Equal("https://example.com/api/ssl/v1/collect/2?format=base64", handler.Request!.RequestUri!.ToString());
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
     public async Task GetStatusAsync_ReturnsStatus() {
         var response = new HttpResponseMessage(HttpStatusCode.OK) {
             Content = JsonContent.Create(new { Status = "Issued" })

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -221,7 +221,10 @@ public sealed class CertificatesClient {
             throw new ArgumentException("Path cannot be null or empty.", nameof(path));
         }
 
-        var url = $"ssl/v1/collect/{certificateId}?format={Uri.EscapeDataString(format)}";
+        var basePath = _client.HttpClient.BaseAddress?.AbsolutePath.Trim('/') ?? string.Empty;
+        var segments = new[] { basePath, "ssl", "v1", "collect", certificateId.ToString() };
+        var endpoint = string.Join("/", segments.Where(s => !string.IsNullOrEmpty(s)));
+        var url = $"{endpoint}?format={Uri.EscapeDataString(format)}";
         var response = await _client.GetAsync(url, cancellationToken).ConfigureAwait(false);
         var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         using (stream) {


### PR DESCRIPTION
## Summary
- normalize certificate download path building
- add regression test for base URL containing path segment

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6877b1c72108832e80c952a62e1145dd