### PR TITLE
Add certificate types API

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/ListCertificateTypesExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/ListCertificateTypesExample.cs
@@ -1,0 +1,28 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates listing certificate types using <see cref="CertificateTypesClient"/>.
+/// </summary>
+public static class ListCertificateTypesExample {
+    /// <summary>
+    /// Executes the example that lists all certificate types.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var types = new CertificateTypesClient(client);
+
+        foreach (var type in await types.ListTypesAsync()) {
+            Console.WriteLine($"Type: {type.Name}");
+        }
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -4,3 +4,4 @@ await BasicApiExample.RunAsync();
 await SearchCertificatesExample.RunAsync();
 await DownloadCertificateExample.RunAsync();
 await DeleteCertificateExample.RunAsync();
+await ListCertificateTypesExample.RunAsync();

--- a/SectigoCertificateManager.Tests/CertificateTypesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateTypesClientTests.cs
@@ -1,0 +1,90 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Models;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="CertificateTypesClient"/>.
+/// </summary>
+public sealed class CertificateTypesClientTests {
+    private sealed class StubClient : ISectigoClient {
+        private readonly HttpResponseMessage _response;
+        public HttpRequestMessage? Request { get; private set; }
+        public HttpClient HttpClient { get; } = new();
+
+        public StubClient(HttpResponseMessage response) => _response = response;
+
+        public Task<HttpResponseMessage> GetAsync(string requestUri, CancellationToken cancellationToken = default) {
+            Request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            return Task.FromResult(_response);
+        }
+
+        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default)
+            => throw new System.NotImplementedException();
+
+        public Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default)
+            => throw new System.NotImplementedException();
+
+        public Task<HttpResponseMessage> DeleteAsync(string requestUri, CancellationToken cancellationToken = default)
+            => throw new System.NotImplementedException();
+    }
+
+    /// <summary>Lists certificate types.</summary>
+    [Fact]
+    public async Task ListTypesAsync_ReturnsTypes() {
+        var type = new CertificateType { Id = 1, Name = "SSL" };
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create(new[] { type })
+        };
+        var client = new StubClient(response);
+        var typesClient = new CertificateTypesClient(client);
+
+        var result = await typesClient.ListTypesAsync();
+
+        Assert.NotNull(client.Request);
+        Assert.Equal("v1/certificate/types", client.Request!.RequestUri!.ToString());
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+    }
+
+    /// <summary>Appends query when organizationId provided.</summary>
+    [Fact]
+    public async Task ListTypesAsync_WithOrganizationId_AppendsQuery() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create<object?>(null)
+        };
+        var client = new StubClient(response);
+        var typesClient = new CertificateTypesClient(client);
+
+        await typesClient.ListTypesAsync(5);
+
+        Assert.NotNull(client.Request);
+        Assert.Equal("v1/certificate/types?organizationId=5", client.Request!.RequestUri!.ToString());
+    }
+
+    /// <summary>Handles null response.</summary>
+    [Fact]
+    public async Task ListTypesAsync_ReturnsEmpty_WhenResponseNull() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create<object?>(null)
+        };
+        var client = new StubClient(response);
+        var typesClient = new CertificateTypesClient(client);
+
+        var result = await typesClient.ListTypesAsync();
+
+        Assert.NotNull(client.Request);
+        Assert.Equal("v1/certificate/types", client.Request!.RequestUri!.ToString());
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+}

--- a/SectigoCertificateManager/Clients/CertificateTypesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificateTypesClient.cs
@@ -1,0 +1,41 @@
+namespace SectigoCertificateManager.Clients;
+
+using SectigoCertificateManager.Models;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+/// <summary>
+/// Provides access to certificate type information.
+/// </summary>
+public sealed class CertificateTypesClient {
+    private readonly ISectigoClient _client;
+    private static readonly JsonSerializerOptions s_json = new() {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CertificateTypesClient"/> class.
+    /// </summary>
+    /// <param name="client">HTTP client wrapper.</param>
+    public CertificateTypesClient(ISectigoClient client) => _client = client;
+
+    /// <summary>
+    /// Retrieves available certificate types.
+    /// </summary>
+    /// <param name="organizationId">Optional organization identifier to filter types.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<IReadOnlyList<CertificateType>> ListTypesAsync(
+        int? organizationId = null,
+        CancellationToken cancellationToken = default) {
+        var endpoint = "v1/certificate/types";
+        if (organizationId.HasValue) {
+            endpoint += $"?organizationId={organizationId.Value}";
+        }
+
+        var response = await _client.GetAsync(endpoint, cancellationToken).ConfigureAwait(false);
+        var types = await response.Content
+            .ReadFromJsonAsync<IReadOnlyList<CertificateType>>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+        return types ?? Array.Empty<CertificateType>();
+    }
+}

--- a/SectigoCertificateManager/Models/CertificateType.cs
+++ b/SectigoCertificateManager/Models/CertificateType.cs
@@ -1,0 +1,26 @@
+namespace SectigoCertificateManager.Models;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents an available certificate type.
+/// </summary>
+public sealed class CertificateType {
+    /// <summary>Gets or sets the certificate type identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the certificate type name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the description.</summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets allowed certificate terms.</summary>
+    public IReadOnlyList<int> Terms { get; set; } = [];
+
+    /// <summary>Gets or sets supported key types.</summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> KeyTypes { get; set; } = new Dictionary<string, IReadOnlyList<string>>();
+
+    /// <summary>Gets or sets a value indicating whether secondary organization names can be used.</summary>
+    public bool UseSecondaryOrgName { get; set; }
+}


### PR DESCRIPTION
## Summary
- introduce `CertificateType` model
- add `CertificateTypesClient` with `/v1/certificate/types` endpoint
- test certificate type retrieval logic
- show example usage

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687801057c90832e958516cd9abf59d4