### PR TITLE
Add revocation reason descriptions

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/RevocationReasonExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/RevocationReasonExample.cs
@@ -1,0 +1,14 @@
+using SectigoCertificateManager;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+public static class RevocationReasonExample {
+    /// <summary>
+    /// Demonstrates retrieving a revocation reason description.
+    /// </summary>
+    public static void Run() {
+        const int code = 4;
+        var description = RevocationReasons.GetRevocationReasonDescription(code);
+        Console.WriteLine($"Reason {code}: {description}");
+    }
+}

--- a/SectigoCertificateManager.Tests/RevocationReasonTests.cs
+++ b/SectigoCertificateManager.Tests/RevocationReasonTests.cs
@@ -1,0 +1,23 @@
+using SectigoCertificateManager;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+public sealed class RevocationReasonTests {
+    [Theory]
+    [InlineData(0, "unspecified")]
+    [InlineData(1, "keyCompromise")]
+    [InlineData(3, "affiliationChanged")]
+    [InlineData(4, "superseded")]
+    [InlineData(5, "cessationOfOperation")]
+    public void GetRevocationReasonDescription_ReturnsExpected(int code, string expected) {
+        var result = RevocationReasons.GetRevocationReasonDescription(code);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetRevocationReasonDescription_Unknown_ReturnsNull() {
+        var result = RevocationReasons.GetRevocationReasonDescription(99);
+        Assert.Null(result);
+    }
+}

--- a/SectigoCertificateManager/RevocationReasons.cs
+++ b/SectigoCertificateManager/RevocationReasons.cs
@@ -1,0 +1,22 @@
+namespace SectigoCertificateManager;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Provides descriptions for revocation reason codes.
+/// </summary>
+public static class RevocationReasons {
+    private static readonly IReadOnlyDictionary<int, string> s_descriptions = new Dictionary<int, string> {
+        [0] = "unspecified",
+        [1] = "keyCompromise",
+        [3] = "affiliationChanged",
+        [4] = "superseded",
+        [5] = "cessationOfOperation"
+    };
+
+    /// <summary>Gets the description associated with a revocation reason code.</summary>
+    /// <param name="code">Revocation reason code.</param>
+    /// <returns>The matching description, or <c>null</c> if the code is unknown.</returns>
+    public static string? GetRevocationReasonDescription(int code) =>
+        s_descriptions.TryGetValue(code, out var desc) ? desc : null;
+}


### PR DESCRIPTION
## Summary
- map revocation codes to their textual descriptions
- expose `GetRevocationReasonDescription` helper
- add example demonstrating the new helper
- test revocation reason descriptions

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687800fe889c832eac72dd7995e3f07f