### PR TITLE
Add term validation builder

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/IssueCertificateWithBuilderExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/IssueCertificateWithBuilderExample.cs
@@ -1,0 +1,37 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Requests;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates issuing a certificate using <see cref="IssueCertificateRequestBuilder"/>.
+/// </summary>
+public static class IssueCertificateWithBuilderExample {
+    /// <summary>
+    /// Executes the example that issues a certificate.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+
+        var profile = new Profile { Id = 1, Terms = new[] { 12, 24 } };
+
+        var request = new IssueCertificateRequestBuilder(profile.Terms)
+            .WithCommonName("example.com")
+            .WithProfileId(profile.Id)
+            .WithTerm(12)
+            .Build();
+
+        var result = await certificates.IssueAsync(request);
+        Console.WriteLine($"New certificate id: {result?.Id}");
+    }
+}

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -92,14 +92,10 @@ public sealed class CertificatesClientTests {
     [Theory]
     [InlineData(0)]
     [InlineData(-5)]
-    public async Task IssueAsync_InvalidTerm_Throws(int term) {
-        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
-        using var httpClient = new HttpClient(handler);
-        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
-        var certificates = new CertificatesClient(client);
+    public void IssueCertificateRequest_InvalidTerm_Throws(int term) {
+        var request = new IssueCertificateRequest();
 
-        var request = new IssueCertificateRequest { CommonName = "example.com", ProfileId = 1, Term = term };
-        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.IssueAsync(request));
+        Assert.Throws<ArgumentOutOfRangeException>(() => request.Term = term);
     }
 
     [Theory]

--- a/SectigoCertificateManager.Tests/IssueCertificateRequestTests.cs
+++ b/SectigoCertificateManager.Tests/IssueCertificateRequestTests.cs
@@ -1,0 +1,38 @@
+using SectigoCertificateManager.Requests;
+using System;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="IssueCertificateRequest"/> and <see cref="IssueCertificateRequestBuilder"/>.
+/// </summary>
+public sealed class IssueCertificateRequestTests {
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-3)]
+    public void TermSetter_InvalidValue_Throws(int term) {
+        var request = new IssueCertificateRequest();
+        Assert.Throws<ArgumentOutOfRangeException>(() => request.Term = term);
+    }
+
+    [Fact]
+    public void Builder_ThrowsForInvalidTerm() {
+        var builder = new IssueCertificateRequestBuilder(new[] { 12, 24 });
+        Assert.Throws<ArgumentOutOfRangeException>(() => builder.WithTerm(36));
+    }
+
+    [Fact]
+    public void Builder_BuildsRequest() {
+        var builder = new IssueCertificateRequestBuilder(new[] { 12, 24 });
+        var request = builder
+            .WithCommonName("example.com")
+            .WithProfileId(5)
+            .WithTerm(12)
+            .Build();
+
+        Assert.Equal("example.com", request.CommonName);
+        Assert.Equal(5, request.ProfileId);
+        Assert.Equal(12, request.Term);
+    }
+}

--- a/SectigoCertificateManager/Requests/IssueCertificateRequest.cs
+++ b/SectigoCertificateManager/Requests/IssueCertificateRequest.cs
@@ -1,5 +1,6 @@
 namespace SectigoCertificateManager.Requests;
 
+using System;
 using System.Collections.Generic;
 
 /// <summary>
@@ -19,7 +20,19 @@ public sealed class IssueCertificateRequest {
     /// <summary>
     /// Gets or sets the term of the certificate.
     /// </summary>
-    public int Term { get; set; }
+    private int _term;
+
+    /// <summary>Gets or sets the term of the certificate.</summary>
+    public int Term {
+        get => _term;
+        set {
+            if (value <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            _term = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets subject alternative names.

--- a/SectigoCertificateManager/Requests/IssueCertificateRequestBuilder.cs
+++ b/SectigoCertificateManager/Requests/IssueCertificateRequestBuilder.cs
@@ -1,0 +1,52 @@
+namespace SectigoCertificateManager.Requests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// Builds <see cref="IssueCertificateRequest"/> instances using a fluent API.
+/// </summary>
+public sealed class IssueCertificateRequestBuilder {
+    private readonly IssueCertificateRequest _request = new();
+    private readonly IReadOnlyList<int> _allowedTerms;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IssueCertificateRequestBuilder"/> class.
+    /// </summary>
+    /// <param name="allowedTerms">List of allowed certificate terms.</param>
+    public IssueCertificateRequestBuilder(IReadOnlyList<int> allowedTerms) {
+        _allowedTerms = allowedTerms ?? throw new ArgumentNullException(nameof(allowedTerms));
+    }
+
+    /// <summary>Sets the certificate common name.</summary>
+    public IssueCertificateRequestBuilder WithCommonName(string commonName) {
+        _request.CommonName = commonName;
+        return this;
+    }
+
+    /// <summary>Sets the profile identifier.</summary>
+    public IssueCertificateRequestBuilder WithProfileId(int profileId) {
+        _request.ProfileId = profileId;
+        return this;
+    }
+
+    /// <summary>Sets the certificate term.</summary>
+    public IssueCertificateRequestBuilder WithTerm(int term) {
+        if (!_allowedTerms.Contains(term)) {
+            throw new ArgumentOutOfRangeException(nameof(term));
+        }
+
+        _request.Term = term;
+        return this;
+    }
+
+    /// <summary>Sets subject alternative names.</summary>
+    public IssueCertificateRequestBuilder WithSubjectAlternativeNames(IEnumerable<string> sans) {
+        _request.SubjectAlternativeNames = sans?.ToArray() ?? Array.Empty<string>();
+        return this;
+    }
+
+    /// <summary>Builds the request instance.</summary>
+    public IssueCertificateRequest Build() => _request;
+}


### PR DESCRIPTION
## Summary
- validate `Term` in `IssueCertificateRequest`
- add `IssueCertificateRequestBuilder` with allowed term checks
- update certificate client tests for new validation
- cover builder with dedicated tests
- showcase builder usage in example

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687800d0e70c832e82a5e9184d278962