### PR TITLE
Add UsersClient for user endpoints

### DIFF
--- a/SectigoCertificateManager.Tests/UsersClientTests.cs
+++ b/SectigoCertificateManager.Tests/UsersClientTests.cs
@@ -1,0 +1,86 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Requests;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="UsersClient"/>.
+/// </summary>
+public sealed class UsersClientTests {
+    private sealed class TestHandler : HttpMessageHandler {
+        private readonly HttpResponseMessage _response;
+        public HttpRequestMessage? Request { get; private set; }
+        public string? Body { get; private set; }
+
+        public TestHandler(HttpResponseMessage response) => _response = response;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            Request = request;
+            if (request.Content is not null) {
+                Body = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+            return _response;
+        }
+    }
+
+    [Fact]
+    public async Task ListUsersAsync_RequestsUsers() {
+        var user = new User { Id = 1, Email = "a" };
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create(new[] { user })
+        };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var users = new UsersClient(client);
+
+        var result = await users.ListUsersAsync();
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/v1/user?size=200&position=0", handler.Request!.RequestUri!.ToString());
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+    }
+
+    [Fact]
+    public async Task CreateAsync_SendsPayloadAndReturnsId() {
+        var response = new HttpResponseMessage(HttpStatusCode.Created);
+        response.Headers.Location = new System.Uri("https://example.com/v1/user/5");
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var users = new UsersClient(client);
+
+        var request = new CreateUserRequest { Email = "a", ValidationType = "STANDARD", OrganizationId = 1 };
+        var id = await users.CreateAsync(request);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/v1/user", handler.Request!.RequestUri!.ToString());
+        Assert.NotNull(handler.Body);
+        Assert.Contains("\"email\":\"a\"", handler.Body);
+        Assert.Equal(5, id);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task GetAsync_InvalidUserId_Throws(int userId) {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var users = new UsersClient(client);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => users.GetAsync(userId));
+    }
+}

--- a/SectigoCertificateManager/Clients/UsersClient.cs
+++ b/SectigoCertificateManager/Clients/UsersClient.cs
@@ -1,0 +1,169 @@
+namespace SectigoCertificateManager.Clients;
+
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Requests;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+/// <summary>
+/// Provides access to user related endpoints.
+/// </summary>
+public sealed class UsersClient {
+    private readonly ISectigoClient _client;
+    private static readonly JsonSerializerOptions s_json = new() {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UsersClient"/> class.
+    /// </summary>
+    /// <param name="client">HTTP client wrapper.</param>
+    public UsersClient(ISectigoClient client) => _client = client;
+
+    /// <summary>
+    /// Retrieves a user by identifier.
+    /// </summary>
+    /// <param name="userId">Identifier of the user to retrieve.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<User?> GetAsync(int userId, CancellationToken cancellationToken = default) {
+        if (userId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(userId));
+        }
+
+        var response = await _client.GetAsync($"v1/user/{userId}", cancellationToken).ConfigureAwait(false);
+        return await response.Content.ReadFromJsonAsync<User>(s_json, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Retrieves all users visible to the caller.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<IReadOnlyList<User>> ListUsersAsync(CancellationToken cancellationToken = default) {
+        var list = new List<User>();
+        await foreach (var user in EnumerateUsersAsync(cancellationToken: cancellationToken).ConfigureAwait(false)) {
+            list.Add(user);
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// Streams users page by page.
+    /// </summary>
+    /// <param name="filter">Optional search filter.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async IAsyncEnumerable<User> EnumerateUsersAsync(
+        UserSearchRequest? filter = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+        filter ??= new UserSearchRequest();
+        var pageSize = filter.Size ?? 200;
+        var position = filter.Position ?? 0;
+
+        while (true) {
+            filter.Size = pageSize;
+            filter.Position = position;
+            var query = BuildQuery(filter);
+            var response = await _client.GetAsync($"v1/user{query}", cancellationToken).ConfigureAwait(false);
+            var page = await response.Content.ReadFromJsonAsync<IReadOnlyList<User>>(s_json, cancellationToken).ConfigureAwait(false);
+            if (page is null || page.Count == 0) {
+                yield break;
+            }
+
+            foreach (var user in page) {
+                yield return user;
+            }
+
+            if (page.Count < pageSize) {
+                yield break;
+            }
+
+            position += pageSize;
+        }
+    }
+
+    /// <summary>
+    /// Creates a new user.
+    /// </summary>
+    /// <param name="request">Payload describing the user to create.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The identifier of the created user.</returns>
+    public async Task<int> CreateAsync(CreateUserRequest request, CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var response = await _client.PostAsync("v1/user", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        var location = response.Headers.Location;
+        if (location is not null) {
+            var url = location.ToString().Trim().TrimEnd('/');
+            var segments = url.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length > 0 && int.TryParse(segments[segments.Length - 1], out var id)) {
+                return id;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Updates an existing user.
+    /// </summary>
+    /// <param name="userId">Identifier of the user to update.</param>
+    /// <param name="request">Payload describing updated fields.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task UpdateAsync(int userId, UpdateUserRequest request, CancellationToken cancellationToken = default) {
+        if (userId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(userId));
+        }
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var response = await _client.PutAsync($"v1/user/{userId}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>
+    /// Deletes a user by identifier.
+    /// </summary>
+    /// <param name="userId">Identifier of the user to delete.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task DeleteAsync(int userId, CancellationToken cancellationToken = default) {
+        if (userId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(userId));
+        }
+
+        var response = await _client.DeleteAsync($"v1/user/{userId}", cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    private static string BuildQuery(UserSearchRequest request) {
+        var query = new List<string>();
+        if (request.Size.HasValue) {
+            query.Add($"size={request.Size.Value}");
+        }
+        if (request.Position.HasValue) {
+            query.Add($"position={request.Position.Value}");
+        }
+        if (!string.IsNullOrEmpty(request.Name)) {
+            query.Add($"name={Uri.EscapeDataString(request.Name)}");
+        }
+        if (request.OrganizationId.HasValue) {
+            query.Add($"organizationId={request.OrganizationId.Value}");
+        }
+        if (!string.IsNullOrEmpty(request.Email)) {
+            query.Add($"email={Uri.EscapeDataString(request.Email)}");
+        }
+        if (!string.IsNullOrEmpty(request.CommonName)) {
+            query.Add($"commonName={Uri.EscapeDataString(request.CommonName)}");
+        }
+        if (!string.IsNullOrEmpty(request.SecondaryEmail)) {
+            query.Add($"secondaryEmail={Uri.EscapeDataString(request.SecondaryEmail)}");
+        }
+        if (!string.IsNullOrEmpty(request.Phone)) {
+            query.Add($"phone={Uri.EscapeDataString(request.Phone)}");
+        }
+        return query.Count == 0 ? string.Empty : "?" + string.Join("&", query);
+    }
+}

--- a/SectigoCertificateManager/Models/User.cs
+++ b/SectigoCertificateManager/Models/User.cs
@@ -1,0 +1,54 @@
+namespace SectigoCertificateManager.Models;
+
+/// <summary>
+/// Represents a user (person) entry.
+/// </summary>
+public sealed class User {
+    /// <summary>Gets or sets the user identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the organization identifier.</summary>
+    public int OrganizationId { get; set; }
+
+    /// <summary>Gets or sets the user email address.</summary>
+    public string? Email { get; set; }
+
+    /// <summary>Gets or sets the first name.</summary>
+    public string? FirstName { get; set; }
+
+    /// <summary>Gets or sets the last name.</summary>
+    public string? LastName { get; set; }
+
+    /// <summary>Gets or sets the middle name.</summary>
+    public string? MiddleName { get; set; }
+
+    /// <summary>Gets or sets the validation type.</summary>
+    public string? ValidationType { get; set; }
+
+    /// <summary>Gets or sets the phone number.</summary>
+    public string? Phone { get; set; }
+
+    /// <summary>Gets or sets the common name.</summary>
+    public string? CommonName { get; set; }
+
+    /// <summary>Gets or sets secondary email addresses.</summary>
+    public IReadOnlyList<string>? SecondaryEmails { get; set; }
+
+    /// <summary>Gets or sets the EPPN identifier.</summary>
+    public string? Eppn { get; set; }
+
+    /// <summary>Gets or sets the UPN identifier.</summary>
+    public string? Upn { get; set; }
+
+    /// <summary>Gets or sets the creation timestamp.</summary>
+    public DateTimeOffset? Created { get; set; }
+
+    /// <summary>Gets or sets the creator.</summary>
+    public string? CreatedBy { get; set; }
+
+    /// <summary>Gets or sets the last modification timestamp.</summary>
+    public DateTimeOffset? Modified { get; set; }
+
+    /// <summary>Gets or sets the modifier.</summary>
+    public string? ModifiedBy { get; set; }
+}

--- a/SectigoCertificateManager/Requests/CreateUserRequest.cs
+++ b/SectigoCertificateManager/Requests/CreateUserRequest.cs
@@ -1,0 +1,18 @@
+namespace SectigoCertificateManager.Requests;
+
+/// <summary>
+/// Request payload for creating a user.
+/// </summary>
+public sealed class CreateUserRequest {
+    public string? FirstName { get; set; }
+    public string? MiddleName { get; set; }
+    public string? LastName { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string ValidationType { get; set; } = string.Empty;
+    public int OrganizationId { get; set; }
+    public string? Phone { get; set; }
+    public string? CommonName { get; set; }
+    public IReadOnlyList<string>? SecondaryEmails { get; set; }
+    public string? Eppn { get; set; }
+    public string? Upn { get; set; }
+}

--- a/SectigoCertificateManager/Requests/UpdateUserRequest.cs
+++ b/SectigoCertificateManager/Requests/UpdateUserRequest.cs
@@ -1,0 +1,18 @@
+namespace SectigoCertificateManager.Requests;
+
+/// <summary>
+/// Request payload for updating a user.
+/// </summary>
+public sealed class UpdateUserRequest {
+    public string? FirstName { get; set; }
+    public string? MiddleName { get; set; }
+    public string? LastName { get; set; }
+    public string? Email { get; set; }
+    public string? ValidationType { get; set; }
+    public int? OrganizationId { get; set; }
+    public string? Phone { get; set; }
+    public string? CommonName { get; set; }
+    public IReadOnlyList<string>? SecondaryEmails { get; set; }
+    public string? Eppn { get; set; }
+    public string? Upn { get; set; }
+}

--- a/SectigoCertificateManager/Requests/UserSearchRequest.cs
+++ b/SectigoCertificateManager/Requests/UserSearchRequest.cs
@@ -1,0 +1,15 @@
+namespace SectigoCertificateManager.Requests;
+
+/// <summary>
+/// Filter parameters for searching users.
+/// </summary>
+public sealed class UserSearchRequest {
+    public int? Position { get; set; }
+    public int? Size { get; set; }
+    public string? Name { get; set; }
+    public int? OrganizationId { get; set; }
+    public string? Email { get; set; }
+    public string? CommonName { get; set; }
+    public string? SecondaryEmail { get; set; }
+    public string? Phone { get; set; }
+}


### PR DESCRIPTION
## Summary
- add `UsersClient` with methods for `/v1/user` endpoints
- implement request models for creating and updating users
- implement `UserSearchRequest` and `User` model
- add unit tests for `UsersClient`

## Testing
- `dotnet build`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6878011cc128832ea86bb9df11c54dd1