### PR TITLE
Remove sample test

### DIFF
--- a/Module/SectigoCertificateManager.Tests.ps1
+++ b/Module/SectigoCertificateManager.Tests.ps1
@@ -53,6 +53,12 @@ try {
     throw "Failed to import module $ModuleName"
 }
 
+$testFiles = Get-ChildItem -Path "$PSScriptRoot\Tests" -Filter '*.Tests.ps1' -Recurse -ErrorAction SilentlyContinue
+if (-not $testFiles) {
+    Write-Warning 'No Pester tests found. Skipping.'
+    return
+}
+
 $Configuration = [PesterConfiguration]::Default
 $Configuration.Run.Path = "$PSScriptRoot\Tests"
 $Configuration.Run.Exit = $true

--- a/Module/Tests/Sample.Tests.ps1
+++ b/Module/Tests/Sample.Tests.ps1
@@ -1,6 +1,0 @@
-Describe 'Sample Tests to be removed later' -Tag 'SampleTests' {
-    It 'Basic arithmetic works' {
-        1 | Should -Be 1
-    }
-}
-


### PR DESCRIPTION
## Summary
- delete `Sample.Tests.ps1`
- skip Pester run when no test files exist

## Testing
- `dotnet test SectigoCertificateManager.sln -v minimal`
- `pwsh -NoLogo -NoProfile -Command ./Module/SectigoCertificateManager.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6878a5cc31ac832e9a222d96f0ac4762