### PR TITLE
Validate SAN input in New-SectigoOrder

### DIFF
--- a/Module/Tests/NewSectigoOrderCommand.Tests.ps1
+++ b/Module/Tests/NewSectigoOrderCommand.Tests.ps1
@@ -1,0 +1,14 @@
+Describe 'New-SectigoOrder parameter validation' -Tag 'Cmdlet' {
+    It 'Throws when SubjectAlternativeNames contains null or whitespace' {
+        $params = @{ 
+            BaseUrl  = 'https://example.com'
+            Username = 'user'
+            Password = 'pass'
+            CustomerUri = 'cust'
+            CommonName = 'example.com'
+            ProfileId = 1
+            SubjectAlternativeNames = @('valid', '')
+        }
+        { New-SectigoOrder @params } | Should -Throw
+    }
+}

--- a/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
@@ -50,6 +50,14 @@ public sealed class NewSectigoOrderCommand : PSCmdlet {
     /// <summary>Issues a certificate using provided parameters.</summary>
     /// <para>Builds an API client and submits an <see cref="IssueCertificateRequest"/>.</para>
     protected override void ProcessRecord() {
+        foreach (var san in SubjectAlternativeNames) {
+            if (string.IsNullOrWhiteSpace(san)) {
+                var ex = new ArgumentException("Value cannot be empty.", nameof(SubjectAlternativeNames));
+                var record = new ErrorRecord(ex, "InvalidSubjectAlternativeName", ErrorCategory.InvalidArgument, san);
+                ThrowTerminatingError(record);
+            }
+        }
+
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var certificates = new CertificatesClient(client);


### PR DESCRIPTION
## Summary
- ensure New-SectigoOrder throws when SAN entries are empty
- cover SAN validation with new Pester test

## Testing
- `pwsh -NoLogo -NoProfile -Command ./Module/SectigoCertificateManager.Tests.ps1`
- `dotnet build SectigoCertificateManager.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6878a5b0b0ec832eac7344414e774a36