### PR TITLE
Fix SectigoClient base URL handling

### DIFF
--- a/SectigoCertificateManager.Tests/SectigoClientTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientTests.cs
@@ -51,6 +51,18 @@ public sealed class SectigoClientTests {
     }
 
     [Fact]
+    public async Task UsesBaseUrlWithoutTrailingSlash() {
+        var config = new ApiConfig("https://example.com/api", "user", "pass", "cst1", ApiVersion.V25_4);
+        var handler = new TestHandler();
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(config, httpClient);
+
+        await client.GetAsync("v1/test");
+
+        Assert.Equal(new Uri("https://example.com/api/v1/test"), handler.Request!.RequestUri);
+    }
+
+    [Fact]
     public async Task AddsBearerHeaderWhenTokenPresent() {
         var config = new ApiConfig("https://example.com/api/", string.Empty, string.Empty, "cst1", ApiVersion.V25_4, token: "tkn");
         var handler = new TestHandler();

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -237,9 +237,7 @@ public sealed class CertificatesClient {
             throw new ArgumentException("Path cannot be null or empty.", nameof(path));
         }
 
-        var basePath = _client.HttpClient.BaseAddress?.AbsolutePath.Trim('/') ?? string.Empty;
-        var segments = new[] { basePath, "ssl", "v1", "collect", certificateId.ToString() };
-        var endpoint = string.Join("/", segments.Where(s => !string.IsNullOrEmpty(s)));
+        var endpoint = $"ssl/v1/collect/{certificateId}";
         var url = $"{endpoint}?format={Uri.EscapeDataString(format)}";
         var response = await _client.GetAsync(url, cancellationToken).ConfigureAwait(false);
         var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);

--- a/SectigoCertificateManager/SectigoClient.cs
+++ b/SectigoCertificateManager/SectigoClient.cs
@@ -52,7 +52,11 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
         }
 
         _client = httpClient;
-        _client.BaseAddress = new Uri(config.BaseUrl);
+        string baseUrl = config.BaseUrl;
+        if (!baseUrl.EndsWith("/", StringComparison.Ordinal)) {
+            baseUrl += "/";
+        }
+        _client.BaseAddress = new Uri(baseUrl);
         _refreshToken = config.RefreshToken;
         _token = config.Token;
         _tokenExpiresAt = config.TokenExpiresAt;


### PR DESCRIPTION
## Summary
- ensure `SectigoClient` adds a trailing slash to `BaseAddress`
- adjust `CertificatesClient` download path generation
- test base URL handling without a trailing slash

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6878a59ec29c832ea0ce31a8ea2f99a5