### PR TITLE
Fix credential header duplication

### DIFF
--- a/SectigoCertificateManager.Tests/SectigoClientTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientTests.cs
@@ -51,6 +51,25 @@ public sealed class SectigoClientTests {
     }
 
     [Fact]
+    public async Task CredentialsHeadersAreNotDuplicatedAcrossRequests() {
+        var config = new ApiConfig("https://example.com/api/", "u", "p", "c", ApiVersion.V25_4);
+        var handler = new TestHandler();
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(config, httpClient);
+
+        await client.GetAsync("v1/test");
+        await client.GetAsync("v1/test2");
+
+        var loginValues = httpClient.DefaultRequestHeaders.GetValues("login").ToList();
+        var passwordValues = httpClient.DefaultRequestHeaders.GetValues("password").ToList();
+
+        Assert.Single(loginValues);
+        Assert.Single(passwordValues);
+        Assert.Equal("u", loginValues[0]);
+        Assert.Equal("p", passwordValues[0]);
+    }
+
+    [Fact]
     public async Task AddsBearerHeaderWhenTokenPresent() {
         var config = new ApiConfig("https://example.com/api/", string.Empty, string.Empty, "cst1", ApiVersion.V25_4, token: "tkn");
         var handler = new TestHandler();

--- a/SectigoCertificateManager/SectigoClient.cs
+++ b/SectigoCertificateManager/SectigoClient.cs
@@ -149,6 +149,9 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
         _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         _client.DefaultRequestHeaders.Add("customerUri", cfg.CustomerUri);
 
+        _client.DefaultRequestHeaders.Remove("login");
+        _client.DefaultRequestHeaders.Remove("password");
+
         if (cfg.Token is not null && cfg.Token.Length > 0) {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", cfg.Token);
         } else {


### PR DESCRIPTION
## Summary
- ensure existing login/password headers are removed before adding new ones
- verify headers are not duplicated across multiple requests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6878a590009c832ea605907b5caf69c2