### PR TITLE
Implement async enumerator for Get-SectigoOrders

### DIFF
--- a/SectigoCertificateManager.PowerShell/GetSectigoOrdersCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoOrdersCommand.cs
@@ -1,6 +1,7 @@
 using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
 using System.Management.Automation;
+using System.Threading.Tasks;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -8,7 +9,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <para>Creates an API client and lists all orders for the account.</para>
 [Cmdlet(VerbsCommon.Get, "SectigoOrders")]
 [OutputType(typeof(Models.Order))]
-public sealed class GetSectigoOrdersCommand : PSCmdlet {
+public sealed class GetSectigoOrdersCommand : AsyncPSCmdlet {
     /// <summary>The API base URL.</summary>
     [Parameter(Mandatory = true)]
     public string BaseUrl { get; set; } = string.Empty;
@@ -31,18 +32,13 @@ public sealed class GetSectigoOrdersCommand : PSCmdlet {
 
     /// <summary>Executes the cmdlet.</summary>
     /// <para>Creates an API client and outputs all orders.</para>
-    protected override void ProcessRecord() {
+    protected override async Task ProcessRecordAsync() {
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var orders = new OrdersClient(client);
-        var enumerator = orders.EnumerateOrdersAsync().GetAsyncEnumerator();
 
-        try {
-            while (enumerator.MoveNextAsync().GetAwaiter().GetResult()) {
-                WriteObject(enumerator.Current);
-            }
-        } finally {
-            enumerator.DisposeAsync().GetAwaiter().GetResult();
+        await foreach (var order in orders.EnumerateOrdersAsync(cancellationToken: CancelToken).ConfigureAwait(false)) {
+            WriteObject(order);
         }
     }
 }

--- a/SectigoCertificateManager.Tests/Pester/GetSectigoOrdersCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/GetSectigoOrdersCommand.Tests.ps1
@@ -1,0 +1,17 @@
+Describe "Get-SectigoOrders" {
+    BeforeAll {
+        dotnet build "$PSScriptRoot/../../SectigoCertificateManager.PowerShell" -c Release | Out-Null
+        $dll = Join-Path $PSScriptRoot '../../SectigoCertificateManager.PowerShell/bin/Release/net8.0/SectigoCertificateManager.PowerShell.dll'
+        Import-Module $dll
+    }
+
+    It "exports the cmdlet" {
+        $cmd = Get-Command Get-SectigoOrders -ErrorAction Stop
+        $cmd | Should -Not -BeNullOrEmpty
+    }
+
+    It "inherits from AsyncPSCmdlet" {
+        $cmd = Get-Command Get-SectigoOrders -ErrorAction Stop
+        $cmd.ImplementingType.BaseType.FullName | Should -Be 'SectigoCertificateManager.PowerShell.AsyncPSCmdlet'
+    }
+}


### PR DESCRIPTION
## Summary
- switch Get-SectigoOrders command to AsyncPSCmdlet
- enumerate orders with `await foreach`
- add Pester tests verifying the async implementation

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release`
- `pwsh -Command "Invoke-Pester -Script 'SectigoCertificateManager.Tests/Pester/GetSectigoOrdersCommand.Tests.ps1' -Output Detailed"`
- `pwsh ./Module/SectigoCertificateManager.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6878a576f6a4832e91241b0b7e1dca9c