### PR TITLE
Handle bad config json

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
@@ -100,4 +100,17 @@ public sealed class ApiConfigLoaderTests {
         var ex = Assert.Throws<FileNotFoundException>(() => ApiConfigLoader.Load(path));
         Assert.Contains(path, ex.Message);
     }
+
+    [Fact]
+    public void Load_WithInvalidJson_Throws() {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var path = Path.Combine(tempDir, "cred.json");
+        File.WriteAllText(path, "{invalid}");
+
+        var ex = Assert.Throws<ConfigParseException>(() => ApiConfigLoader.Load(path));
+        Assert.Contains(path, ex.Message);
+
+        Directory.Delete(tempDir, true);
+    }
 }

--- a/SectigoCertificateManager/ApiConfigLoader.cs
+++ b/SectigoCertificateManager/ApiConfigLoader.cs
@@ -66,8 +66,13 @@ public static class ApiConfigLoader {
         using var reader = new StreamReader(stream);
         var json = reader.ReadToEnd();
         var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-        var model = JsonSerializer.Deserialize<FileModel>(json, options)
-                    ?? throw new InvalidOperationException("Invalid configuration file.");
+        FileModel model;
+        try {
+            model = JsonSerializer.Deserialize<FileModel>(json, options)
+                    ?? throw new InvalidOperationException();
+        } catch (Exception ex) when (ex is JsonException || ex is InvalidOperationException) {
+            throw new ConfigParseException(path!, ex);
+        }
         return new ApiConfig(model.BaseUrl, model.Username, model.Password, model.CustomerUri, ParseVersion(model.ApiVersion), token: model.Token);
     }
 

--- a/SectigoCertificateManager/ConfigParseException.cs
+++ b/SectigoCertificateManager/ConfigParseException.cs
@@ -1,0 +1,19 @@
+namespace SectigoCertificateManager;
+
+using System;
+
+/// <summary>
+/// Exception thrown when a configuration file cannot be parsed.
+/// </summary>
+public sealed class ConfigParseException : Exception {
+    /// <summary>Gets the path to the configuration file.</summary>
+    public string Path { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ConfigParseException"/> class.</summary>
+    /// <param name="path">Path to the configuration file.</param>
+    /// <param name="inner">The exception that caused the parsing failure.</param>
+    public ConfigParseException(string path, Exception inner)
+        : base($"Invalid configuration file: {path}", inner) {
+        Path = path;
+    }
+}


### PR DESCRIPTION
## Summary
- handle invalid JSON during configuration load
- raise `ConfigParseException` on deserialization problems
- test loading with invalid JSON file

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6878a56f74e0832e96ed955772ce28bc