### PR TITLE
Fix cancellation handling in API client

### DIFF
--- a/SectigoCertificateManager/ApiErrorHandler.cs
+++ b/SectigoCertificateManager/ApiErrorHandler.cs
@@ -3,6 +3,7 @@ namespace SectigoCertificateManager;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 /// <summary>
@@ -13,14 +14,14 @@ internal static class ApiErrorHandler {
     /// Throws an exception if the response indicates an error.
     /// </summary>
     /// <param name="response">HTTP response message.</param>
-    public static async Task ThrowIfErrorAsync(HttpResponseMessage response) {
+    public static async Task ThrowIfErrorAsync(HttpResponseMessage response, CancellationToken cancellationToken = default) {
         if (response.IsSuccessStatusCode) {
             return;
         }
 
         ApiError? error = null;
         try {
-            error = await response.Content.ReadFromJsonAsync<ApiError>().ConfigureAwait(false);
+            error = await response.Content.ReadFromJsonAsync<ApiError>(cancellationToken).ConfigureAwait(false);
         } catch {
             // ignore parsing errors
         }

--- a/SectigoCertificateManager/SectigoClient.cs
+++ b/SectigoCertificateManager/SectigoClient.cs
@@ -75,7 +75,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
         }
         try {
             var response = await _client.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
-            await ApiErrorHandler.ThrowIfErrorAsync(response).ConfigureAwait(false);
+            await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             return response;
         } finally {
             _throttle?.Release();
@@ -96,7 +96,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
         }
         try {
             var response = await _client.PostAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
-            await ApiErrorHandler.ThrowIfErrorAsync(response).ConfigureAwait(false);
+            await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             return response;
         } finally {
             _throttle?.Release();
@@ -117,7 +117,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
         }
         try {
             var response = await _client.PutAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
-            await ApiErrorHandler.ThrowIfErrorAsync(response).ConfigureAwait(false);
+            await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             return response;
         } finally {
             _throttle?.Release();
@@ -137,7 +137,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
         }
         try {
             var response = await _client.DeleteAsync(requestUri, cancellationToken).ConfigureAwait(false);
-            await ApiErrorHandler.ThrowIfErrorAsync(response).ConfigureAwait(false);
+            await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             return response;
         } finally {
             _throttle?.Release();


### PR DESCRIPTION
## Summary
- pass cancellation token to `ReadFromJsonAsync`
- forward the token from `SectigoClient`
- test enumerator cancellation behavior

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -c Release -f net8.0`
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -c Release -f net9.0`


------
https://chatgpt.com/codex/tasks/task_e_6878a573b1c4832e93ce0ad7659290f0