### PR TITLE
Add order status watcher example

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/WatchOrdersExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/WatchOrdersExample.cs
@@ -1,0 +1,25 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates polling order status until completion.
+/// </summary>
+public static class WatchOrdersExample {
+    /// <summary>Executes the example.</summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var statuses = new OrderStatusClient(client);
+
+        var result = await statuses.WatchAsync(12345, TimeSpan.FromSeconds(5));
+        Console.WriteLine($"Final status: {result}");
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -8,3 +8,4 @@ await UploadOrdersExample.RunAsync();
 await GetCertificateRevocationExample.RunAsync();
 await ImportCertificatesExample.RunAsync();
 await ListCertificateTypesExample.RunAsync();
+await WatchOrdersExample.RunAsync();

--- a/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
@@ -46,6 +46,40 @@ public sealed class OrderStatusClientTests {
         Assert.Equal(expected, result);
     }
 
+    private sealed class SequenceHandler : HttpMessageHandler {
+        private readonly Queue<HttpResponseMessage> _responses;
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        public SequenceHandler(IEnumerable<HttpResponseMessage> responses) => _responses = new Queue<HttpResponseMessage>(responses);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            Requests.Add(request);
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+
+    [Fact]
+    public async Task WatchAsync_PollsUntilTerminal() {
+        var responses = new[] {
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(new { Status = "Submitted" }) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(new { Status = "Submitted" }) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(new { Status = "Completed" }) }
+        };
+
+        var handler = new SequenceHandler(responses);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var statuses = new OrderStatusClient(client);
+
+        var result = await statuses.WatchAsync(3, TimeSpan.Zero);
+
+        Assert.Equal(3, handler.Requests.Count);
+        foreach (var req in handler.Requests) {
+            Assert.Equal("https://example.com/v1/order/3/status", req.RequestUri!.ToString());
+        }
+        Assert.Equal(OrderStatus.Completed, result);
+    }
+
     public static IEnumerable<object[]> StatusCases() {
         foreach (OrderStatus status in Enum.GetValues(typeof(OrderStatus))) {
             yield return new object[] { status.ToString(), status };


### PR DESCRIPTION
## Summary
- add `WatchAsync` helper to `OrderStatusClient` to poll order status
- provide usage example in `WatchOrdersExample`
- call the new example from the examples entry point
- add unit test for status watching

## Testing
- `dotnet test --verbosity minimal`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6878a63247f4832eaaa39332e5bfe0a2