### PR TITLE
Add validation test for WatchAsync orderId

### DIFF
--- a/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrderStatusClientTests.cs
@@ -97,4 +97,16 @@ public sealed class OrderStatusClientTests {
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => statuses.GetStatusAsync(orderId));
     }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task WatchAsync_InvalidOrderId_Throws(int orderId) {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var statuses = new OrderStatusClient(client);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => statuses.WatchAsync(orderId, TimeSpan.Zero));
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `OrderStatusClient.WatchAsync` rejects invalid orderId
- add unit test verifying the new validation

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6878e9e9dd9c832ebc539d4cb07e0182