### PR TITLE
Add CmdletBinding attribute

### DIFF
--- a/SectigoCertificateManager.PowerShell/GetSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoCertificateCommand.cs
@@ -7,6 +7,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>Retrieves certificate details.</summary>
 /// <para>Builds an API client and returns the certificate for the specified identifier.</para>
 [Cmdlet(VerbsCommon.Get, "SectigoCertificate")]
+[CmdletBinding()]
 [OutputType(typeof(Models.Certificate))]
 public sealed class GetSectigoCertificateCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>

--- a/SectigoCertificateManager.PowerShell/GetSectigoCertificateRevocationCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoCertificateRevocationCommand.cs
@@ -7,6 +7,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>Retrieves certificate revocation information.</summary>
 /// <para>Creates an API client and returns revocation details for the specified certificate.</para>
 [Cmdlet(VerbsCommon.Get, "SectigoCertificateRevocation")]
+[CmdletBinding()]
 [OutputType(typeof(Models.CertificateRevocation))]
 public sealed class GetSectigoCertificateRevocationCommand : PSCmdlet
 {

--- a/SectigoCertificateManager.PowerShell/GetSectigoCertificateStatusCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoCertificateStatusCommand.cs
@@ -7,6 +7,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>Retrieves certificate status.</summary>
 /// <para>Creates an API client and returns the status of a certificate.</para>
 [Cmdlet(VerbsCommon.Get, "SectigoCertificateStatus")]
+[CmdletBinding()]
 public sealed class GetSectigoCertificateStatusCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>
     [Parameter(Mandatory = true)]

--- a/SectigoCertificateManager.PowerShell/GetSectigoOrderHistoryCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoOrderHistoryCommand.cs
@@ -7,6 +7,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>Retrieves order history.</summary>
 /// <para>Creates an API client and returns history entries for an order.</para>
 [Cmdlet(VerbsCommon.Get, "SectigoOrderHistory")]
+[CmdletBinding()]
 [OutputType(typeof(Models.OrderHistoryEntry))]
 public sealed class GetSectigoOrderHistoryCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>

--- a/SectigoCertificateManager.PowerShell/GetSectigoOrdersCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoOrdersCommand.cs
@@ -8,6 +8,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>Retrieves certificate orders.</summary>
 /// <para>Creates an API client and lists all orders for the account.</para>
 [Cmdlet(VerbsCommon.Get, "SectigoOrders")]
+[CmdletBinding()]
 [OutputType(typeof(Models.Order))]
 public sealed class GetSectigoOrdersCommand : AsyncPSCmdlet {
     /// <summary>The API base URL.</summary>

--- a/SectigoCertificateManager.PowerShell/GetSectigoProfileCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoProfileCommand.cs
@@ -7,6 +7,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>Retrieves a profile.</summary>
 /// <para>Creates an API client and returns profile details using the identifier.</para>
 [Cmdlet(VerbsCommon.Get, "SectigoProfile")]
+[CmdletBinding()]
 [OutputType(typeof(Models.Profile))]
 public sealed class GetSectigoProfileCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>

--- a/SectigoCertificateManager.PowerShell/GetSectigoProfilesCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoProfilesCommand.cs
@@ -7,6 +7,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>Retrieves profiles.</summary>
 /// <para>Creates an API client and lists all profiles for the account.</para>
 [Cmdlet(VerbsCommon.Get, "SectigoProfiles")]
+[CmdletBinding()]
 [OutputType(typeof(Models.Profile))]
 public sealed class GetSectigoProfilesCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>

--- a/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
@@ -8,6 +8,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>Creates a new certificate order.</summary>
 /// <para>Builds an API client and submits an <see cref="IssueCertificateRequest"/>.</para>
 [Cmdlet(VerbsCommon.New, "SectigoOrder")]
+[CmdletBinding()]
 [OutputType(typeof(Models.Certificate))]
 public sealed class NewSectigoOrderCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>

--- a/SectigoCertificateManager.PowerShell/NewSectigoOrganizationCommand.cs
+++ b/SectigoCertificateManager.PowerShell/NewSectigoOrganizationCommand.cs
@@ -9,6 +9,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>Creates a new organization.</summary>
 /// <para>Builds an API client and submits a <see cref="CreateOrganizationRequest"/>.</para>
 [Cmdlet(VerbsCommon.New, "SectigoOrganization")]
+[CmdletBinding()]
 [OutputType(typeof(int))]
 public sealed class NewSectigoOrganizationCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>

--- a/SectigoCertificateManager.PowerShell/RemoveSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/RemoveSectigoCertificateCommand.cs
@@ -8,6 +8,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>Deletes a certificate.</summary>
 /// <para>Builds an API client and calls the delete endpoint.</para>
 [Cmdlet(VerbsCommon.Remove, "SectigoCertificate")]
+[CmdletBinding()]
 public sealed class RemoveSectigoCertificateCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>
     [Parameter(Mandatory = true)]

--- a/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
@@ -8,6 +8,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>Cancels an order.</summary>
 /// <para>Creates an API client and calls the cancel endpoint.</para>
 [Cmdlet(VerbsLifecycle.Stop, "SectigoOrder")]
+[CmdletBinding()]
 public sealed class StopSectigoOrderCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>
     [Parameter(Mandatory = true)]

--- a/SectigoCertificateManager.PowerShell/UpdateSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/UpdateSectigoCertificateCommand.cs
@@ -9,6 +9,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// Updates an existing certificate using the renew endpoint.
 /// </summary>
 [Cmdlet(VerbsData.Update, "SectigoCertificate")]
+[CmdletBinding()]
 [OutputType(typeof(int))]
 public sealed class UpdateSectigoCertificateCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>


### PR DESCRIPTION
## Summary
- add `[CmdletBinding()]` attribute to all C# cmdlet classes so advanced features can be used

## Testing
- `dotnet test --no-build`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Script ./Module/Tests/NewSectigoOrderCommand.Tests.ps1"` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e9f19994832e83f253ad577223b9