### PR TITLE
Fix CommonName validation

### DIFF
--- a/Module/Tests/NewSectigoOrderCommand.Tests.ps1
+++ b/Module/Tests/NewSectigoOrderCommand.Tests.ps1
@@ -11,4 +11,16 @@ Describe 'New-SectigoOrder parameter validation' -Tag 'Cmdlet' {
         }
         { New-SectigoOrder @params } | Should -Throw
     }
+
+    It 'Throws when CommonName is null or whitespace' {
+        $params = @{
+            BaseUrl  = 'https://example.com'
+            Username = 'user'
+            Password = 'pass'
+            CustomerUri = 'cust'
+            CommonName = ' '
+            ProfileId = 1
+        }
+        { New-SectigoOrder @params } | Should -Throw
+    }
 }

--- a/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
@@ -59,6 +59,12 @@ public sealed class NewSectigoOrderCommand : PSCmdlet {
             }
         }
 
+        if (string.IsNullOrWhiteSpace(CommonName)) {
+            var ex = new ArgumentException("Value cannot be empty.", nameof(CommonName));
+            var record = new ErrorRecord(ex, "InvalidCommonName", ErrorCategory.InvalidArgument, CommonName);
+            ThrowTerminatingError(record);
+        }
+
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var certificates = new CertificatesClient(client);


### PR DESCRIPTION
## Summary
- validate `CommonName` parameter in `New-SectigoOrder`
- test for whitespace `CommonName`

## Testing
- `dotnet test`
- `pwsh -NoProfile -Command "Import-Module Pester; Invoke-Pester -Path Module/Tests -CI"`

------
https://chatgpt.com/codex/tasks/task_e_687a05996f30832e86e4254a33d4e2aa