### PR TITLE
Fix ArgumentException parameter names

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigBuilderTests.cs
@@ -18,7 +18,8 @@ public sealed class ApiConfigBuilderTests {
             .WithCredentials("user", "pass")
             .WithCustomerUri("cst1");
 
-        Assert.Throws<ArgumentException>(() => builder.Build());
+        var ex = Assert.Throws<ArgumentException>(() => builder.Build());
+        Assert.Equal("baseUrl", ex.ParamName);
     }
 
     [Fact]
@@ -36,7 +37,8 @@ public sealed class ApiConfigBuilderTests {
             .WithBaseUrl("https://example.com")
             .WithCredentials("user", "pass");
 
-        Assert.Throws<ArgumentException>(() => builder.Build());
+        var exCust = Assert.Throws<ArgumentException>(() => builder.Build());
+        Assert.Equal("customerUri", exCust.ParamName);
     }
 
     [Fact]
@@ -55,7 +57,8 @@ public sealed class ApiConfigBuilderTests {
     public void WithBaseUrl_ThrowsForInvalidUri() {
         var builder = new ApiConfigBuilder();
 
-        Assert.Throws<ArgumentException>(() => builder.WithBaseUrl("not a url"));
+        var exInvalid = Assert.Throws<ArgumentException>(() => builder.WithBaseUrl("not a url"));
+        Assert.Equal("baseUrl", exInvalid.ParamName);
     }
 
     [Fact]
@@ -104,14 +107,16 @@ public sealed class ApiConfigBuilderTests {
     public void WithCredentials_ThrowsForNullUsername() {
         var builder = new ApiConfigBuilder();
 
-        Assert.Throws<ArgumentException>(() => builder.WithCredentials(null!, "pass"));
+        var exUser = Assert.Throws<ArgumentException>(() => builder.WithCredentials(null!, "pass"));
+        Assert.Equal("username", exUser.ParamName);
     }
 
     [Fact]
     public void WithCredentials_ThrowsForNullPassword() {
         var builder = new ApiConfigBuilder();
 
-        Assert.Throws<ArgumentException>(() => builder.WithCredentials("user", null!));
+        var exPass = Assert.Throws<ArgumentException>(() => builder.WithCredentials("user", null!));
+        Assert.Equal("password", exPass.ParamName);
     }
 
     [Fact]

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -135,7 +135,7 @@ public sealed class ApiConfigBuilder {
     /// <summary>Builds a new <see cref="ApiConfig"/> instance using configured values.</summary>
     public ApiConfig Build() {
         if (string.IsNullOrWhiteSpace(_baseUrl)) {
-            throw new ArgumentException("Base URL is required.", nameof(_baseUrl));
+            throw new ArgumentException("Base URL is required.", "baseUrl");
         }
 
         var hasToken = !string.IsNullOrWhiteSpace(_token);
@@ -147,16 +147,16 @@ public sealed class ApiConfigBuilder {
 
         if (!hasToken) {
             if (string.IsNullOrWhiteSpace(_username)) {
-                throw new ArgumentException("User name is required.", nameof(_username));
+                throw new ArgumentException("User name is required.", "username");
             }
 
             if (string.IsNullOrWhiteSpace(_password)) {
-                throw new ArgumentException("Password is required.", nameof(_password));
+                throw new ArgumentException("Password is required.", "password");
             }
         }
 
         if (string.IsNullOrWhiteSpace(_customerUri)) {
-            throw new ArgumentException("Customer URI is required.", nameof(_customerUri));
+            throw new ArgumentException("Customer URI is required.", "customerUri");
         }
 
         return new ApiConfig(


### PR DESCRIPTION
## Summary
- use explicit parameter names when ApiConfigBuilder validates values
- verify ArgumentException.ParamName in tests

## Testing
- `dotnet test --no-build`
- `dotnet test --no-build -f net8.0`
- `dotnet test --no-build -f net9.0`
- `dotnet test --no-build -f net472`


------
https://chatgpt.com/codex/tasks/task_e_687a058a5994832e9e452b4561f4ff52