### PR TITLE
Add certificate enumeration helper

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/StreamCertificatesExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/StreamCertificatesExample.cs
@@ -1,0 +1,28 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates streaming certificates using <see cref="CertificatesClient"/>.
+/// </summary>
+public static class StreamCertificatesExample {
+    /// <summary>
+    /// Executes the example that streams certificate records.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+
+        await foreach (var certificate in certificates.EnumerateCertificatesAsync(pageSize: 50)) {
+            Console.WriteLine($"Certificate ID: {certificate.Id}");
+        }
+    }
+}

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -456,6 +456,32 @@ public sealed class CertificatesClientTests {
     }
 
     [Fact]
+    public async Task EnumerateCertificatesAsync_ReturnsPages() {
+        var page1 = new[] { new Certificate { Id = 1 }, new Certificate { Id = 2 } };
+        var page2 = new[] { new Certificate { Id = 3 } };
+
+        var responses = new[] {
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(page1) },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(page2) }
+        };
+
+        var handler = new SequenceHandler(responses);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var certificates = new CertificatesClient(client);
+
+        var results = new List<Certificate>();
+        await foreach (var certificate in certificates.EnumerateCertificatesAsync(pageSize: 2)) {
+            results.Add(certificate);
+        }
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("https://example.com/v1/certificate?size=2", handler.Requests[0].RequestUri!.ToString());
+        Assert.Equal("https://example.com/v1/certificate?size=2&position=2", handler.Requests[1].RequestUri!.ToString());
+        Assert.Equal(3, results.Count);
+        Assert.Equal(3, results[2].Id);
+    }
+
+    [Fact]
     public async Task SearchAsync_MultiplePages_ReturnsAllResults() {
         var page1 = new[] { new Certificate { Id = 1 }, new Certificate { Id = 2 } };
         var page2 = new[] { new Certificate { Id = 3 } };

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -154,6 +154,18 @@ public sealed class CertificatesClient {
     }
 
     /// <summary>
+    /// Streams all certificates visible to the caller.
+    /// </summary>
+    /// <param name="pageSize">Number of certificates to request per page.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public IAsyncEnumerable<Certificate> EnumerateCertificatesAsync(
+        int pageSize = 200,
+        CancellationToken cancellationToken = default) {
+        var request = new CertificateSearchRequest { Size = pageSize };
+        return EnumerateSearchAsync(request, cancellationToken);
+    }
+
+    /// <summary>
     /// Streams search results page by page.
     /// </summary>
     /// <param name="request">Filter describing certificates to retrieve.</param>


### PR DESCRIPTION
## Summary
- add `EnumerateCertificatesAsync` for streaming certificates
- test multi-page streaming
- demonstrate usage in examples

## Testing
- `dotnet test`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_687a1ce9d3f8832e9ffa5696de571345