### PR TITLE
Add CancellationToken parameter

### DIFF
--- a/Module/Tests/GetSectigoOrdersCancellation.Tests.ps1
+++ b/Module/Tests/GetSectigoOrdersCancellation.Tests.ps1
@@ -1,0 +1,20 @@
+Describe 'Get-SectigoOrders supports cancellation' -Tag 'Cmdlet' {
+    It 'Stops when cancellation token is cancelled' {
+        $cts = [System.Threading.CancellationTokenSource]::new()
+        $timer = [System.Timers.Timer]::new(50)
+        Register-ObjectEvent -InputObject $timer -EventName Elapsed -SourceIdentifier 'cancel' -MessageData $cts -Action { $Event.MessageData.Cancel() } | Out-Null
+        $timer.AutoReset = $false
+        $timer.Enabled = $true
+
+        $params = @{
+            BaseUrl  = 'https://example.com'
+            Username = 'user'
+            Password = 'pass'
+            CustomerUri = 'cust'
+            CancellationToken = $cts.Token
+        }
+        { Get-SectigoOrders @params } | Should -Throw
+        $timer.Dispose()
+        Unregister-Event -SourceIdentifier 'cancel'
+    }
+}

--- a/SectigoCertificateManager.PowerShell/GetSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoCertificateCommand.cs
@@ -1,6 +1,7 @@
 using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
 using System.Management.Automation;
+using System.Threading;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -34,13 +35,19 @@ public sealed class GetSectigoCertificateCommand : PSCmdlet {
     [Parameter(Mandatory = true, Position = 0)]
     public int CertificateId { get; set; }
 
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Executes the cmdlet.</summary>
     /// <para>Creates an API client and retrieves the certificate.</para>
     protected override void ProcessRecord() {
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var certificates = new CertificatesClient(client);
-        var certificate = certificates.GetAsync(CertificateId).GetAwaiter().GetResult();
+        var certificate = certificates.GetAsync(CertificateId, CancellationToken)
+            .GetAwaiter()
+            .GetResult();
         WriteObject(certificate);
     }
 }

--- a/SectigoCertificateManager.PowerShell/GetSectigoCertificateRevocationCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoCertificateRevocationCommand.cs
@@ -1,6 +1,7 @@
 using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
 using System.Management.Automation;
+using System.Threading;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -35,6 +36,10 @@ public sealed class GetSectigoCertificateRevocationCommand : PSCmdlet
     [Parameter(Mandatory = true, Position = 0)]
     public int CertificateId { get; set; }
 
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Executes the cmdlet.</summary>
     /// <para>Creates an API client and retrieves certificate revocation details.</para>
     protected override void ProcessRecord()
@@ -42,7 +47,9 @@ public sealed class GetSectigoCertificateRevocationCommand : PSCmdlet
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var certificates = new CertificatesClient(client);
-        var revocation = certificates.GetRevocationAsync(CertificateId).GetAwaiter().GetResult();
+        var revocation = certificates.GetRevocationAsync(CertificateId, CancellationToken)
+            .GetAwaiter()
+            .GetResult();
         WriteObject(revocation);
     }
 }

--- a/SectigoCertificateManager.PowerShell/GetSectigoCertificateStatusCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoCertificateStatusCommand.cs
@@ -1,6 +1,7 @@
 using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
 using System.Management.Automation;
+using System.Threading;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -33,13 +34,19 @@ public sealed class GetSectigoCertificateStatusCommand : PSCmdlet {
     [Parameter(Mandatory = true, Position = 0)]
     public int CertificateId { get; set; }
 
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Executes the cmdlet.</summary>
     /// <para>Creates an API client and retrieves certificate status.</para>
     protected override void ProcessRecord() {
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var certificates = new CertificatesClient(client);
-        var status = certificates.GetStatusAsync(CertificateId).GetAwaiter().GetResult();
+        var status = certificates.GetStatusAsync(CertificateId, CancellationToken)
+            .GetAwaiter()
+            .GetResult();
         WriteObject(status);
     }
 }

--- a/SectigoCertificateManager.PowerShell/GetSectigoOrderHistoryCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoOrderHistoryCommand.cs
@@ -1,6 +1,7 @@
 using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
 using System.Management.Automation;
+using System.Threading;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -34,6 +35,10 @@ public sealed class GetSectigoOrderHistoryCommand : PSCmdlet {
     [Parameter(Mandatory = true, Position = 0)]
     public int OrderId { get; set; }
 
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Executes the cmdlet.</summary>
     /// <para>Creates an API client and retrieves the history for the specified order.</para>
     protected override void ProcessRecord() {
@@ -46,7 +51,9 @@ public sealed class GetSectigoOrderHistoryCommand : PSCmdlet {
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var orders = new OrdersClient(client);
-        var history = orders.GetHistoryAsync(OrderId).GetAwaiter().GetResult();
+        var history = orders.GetHistoryAsync(OrderId, CancellationToken)
+            .GetAwaiter()
+            .GetResult();
         WriteObject(history, true);
     }
 }

--- a/SectigoCertificateManager.PowerShell/GetSectigoOrganizationsCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoOrganizationsCommand.cs
@@ -1,6 +1,7 @@
 using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
 using System.Management.Automation;
+using System.Threading;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -29,13 +30,19 @@ public sealed class GetSectigoOrganizationsCommand : PSCmdlet {
     [Parameter]
     public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
 
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Executes the cmdlet.</summary>
     /// <para>Creates an API client and outputs all organizations.</para>
     protected override void ProcessRecord() {
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var organizations = new OrganizationsClient(client);
-        var list = organizations.ListOrganizationsAsync().GetAwaiter().GetResult();
+        var list = organizations.ListOrganizationsAsync(CancellationToken)
+            .GetAwaiter()
+            .GetResult();
         foreach (var org in list) {
             WriteObject(org);
         }

--- a/SectigoCertificateManager.PowerShell/GetSectigoProfileCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoProfileCommand.cs
@@ -1,6 +1,7 @@
 using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
 using System.Management.Automation;
+using System.Threading;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -34,13 +35,19 @@ public sealed class GetSectigoProfileCommand : PSCmdlet {
     [Parameter(Mandatory = true, Position = 0)]
     public int ProfileId { get; set; }
 
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Executes the cmdlet.</summary>
     /// <para>Creates an API client and retrieves the profile.</para>
     protected override void ProcessRecord() {
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var profiles = new ProfilesClient(client);
-        var profile = profiles.GetAsync(ProfileId).GetAwaiter().GetResult();
+        var profile = profiles.GetAsync(ProfileId, CancellationToken)
+            .GetAwaiter()
+            .GetResult();
         WriteObject(profile);
     }
 }

--- a/SectigoCertificateManager.PowerShell/GetSectigoProfilesCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoProfilesCommand.cs
@@ -1,6 +1,7 @@
 using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
 using System.Management.Automation;
+using System.Threading;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -30,13 +31,19 @@ public sealed class GetSectigoProfilesCommand : PSCmdlet {
     [Parameter]
     public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
 
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Executes the cmdlet.</summary>
     /// <para>Creates an API client and outputs all profiles.</para>
     protected override void ProcessRecord() {
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var profilesClient = new ProfilesClient(client);
-        var list = profilesClient.ListProfilesAsync().GetAwaiter().GetResult();
+        var list = profilesClient.ListProfilesAsync(CancellationToken)
+            .GetAwaiter()
+            .GetResult();
         foreach (var profile in list) {
             WriteObject(profile);
         }

--- a/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
@@ -2,6 +2,7 @@ using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
 using SectigoCertificateManager.Requests;
 using System.Management.Automation;
+using System.Threading;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -48,6 +49,10 @@ public sealed class NewSectigoOrderCommand : PSCmdlet {
     [Alias("SubjectAlternativeName", "San")]
     public string[] SubjectAlternativeNames { get; set; } = System.Array.Empty<string>();
 
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Issues a certificate using provided parameters.</summary>
     /// <para>Builds an API client and submits an <see cref="IssueCertificateRequest"/>.</para>
     protected override void ProcessRecord() {
@@ -74,7 +79,9 @@ public sealed class NewSectigoOrderCommand : PSCmdlet {
             Term = Term,
             SubjectAlternativeNames = SubjectAlternativeNames
         };
-        var certificate = certificates.IssueAsync(request).GetAwaiter().GetResult();
+        var certificate = certificates.IssueAsync(request, CancellationToken)
+            .GetAwaiter()
+            .GetResult();
         WriteObject(certificate);
     }
 }

--- a/SectigoCertificateManager.PowerShell/NewSectigoOrganizationCommand.cs
+++ b/SectigoCertificateManager.PowerShell/NewSectigoOrganizationCommand.cs
@@ -3,6 +3,7 @@ using SectigoCertificateManager.Clients;
 using SectigoCertificateManager.Requests;
 using System;
 using System.Management.Automation;
+using System.Threading;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -40,6 +41,10 @@ public sealed class NewSectigoOrganizationCommand : PSCmdlet {
     [Parameter]
     public string? StateOrProvince { get; set; }
 
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Executes the cmdlet.</summary>
     /// <para>Creates an organization and outputs its identifier.</para>
     protected override void ProcessRecord() {
@@ -56,7 +61,9 @@ public sealed class NewSectigoOrganizationCommand : PSCmdlet {
             Name = Name,
             StateOrProvince = StateOrProvince
         };
-        var id = organizations.CreateAsync(request).GetAwaiter().GetResult();
+        var id = organizations.CreateAsync(request, CancellationToken)
+            .GetAwaiter()
+            .GetResult();
         WriteObject(id);
     }
 }

--- a/SectigoCertificateManager.PowerShell/RemoveSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/RemoveSectigoCertificateCommand.cs
@@ -2,6 +2,7 @@ using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
 using System;
 using System.Management.Automation;
+using System.Threading;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -34,6 +35,10 @@ public sealed class RemoveSectigoCertificateCommand : PSCmdlet {
     [Parameter(Mandatory = true, Position = 0)]
     public int CertificateId { get; set; }
 
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Deletes a certificate.</summary>
     /// <para>Builds an API client and calls the delete endpoint.</para>
     protected override void ProcessRecord() {
@@ -46,6 +51,8 @@ public sealed class RemoveSectigoCertificateCommand : PSCmdlet {
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var certificates = new CertificatesClient(client);
-        certificates.DeleteAsync(CertificateId).GetAwaiter().GetResult();
+        certificates.DeleteAsync(CertificateId, CancellationToken)
+            .GetAwaiter()
+            .GetResult();
     }
 }

--- a/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
@@ -2,6 +2,7 @@ using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
 using System;
 using System.Management.Automation;
+using System.Threading;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -34,6 +35,10 @@ public sealed class StopSectigoOrderCommand : PSCmdlet {
     [Parameter(Mandatory = true, Position = 0)]
     public int OrderId { get; set; }
 
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Cancels an order.</summary>
     /// <para>Builds an API client and calls the cancel endpoint.</para>
     protected override void ProcessRecord() {
@@ -46,6 +51,8 @@ public sealed class StopSectigoOrderCommand : PSCmdlet {
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var orders = new OrdersClient(client);
-        orders.CancelAsync(OrderId).GetAwaiter().GetResult();
+        orders.CancelAsync(OrderId, CancellationToken)
+            .GetAwaiter()
+            .GetResult();
     }
 }

--- a/SectigoCertificateManager.PowerShell/UpdateSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/UpdateSectigoCertificateCommand.cs
@@ -2,6 +2,7 @@ using SectigoCertificateManager;
 using SectigoCertificateManager.Clients;
 using SectigoCertificateManager.Requests;
 using System.Management.Automation;
+using System.Threading;
 
 namespace SectigoCertificateManager.PowerShell;
 
@@ -48,6 +49,10 @@ public sealed class UpdateSectigoCertificateCommand : PSCmdlet {
     [Parameter]
     public string? DcvEmail { get; set; }
 
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
     /// <summary>Renews a certificate using provided parameters.</summary>
     /// <para>Builds an API client and submits a <see cref="RenewCertificateRequest"/>.</para>
     protected override void ProcessRecord() {
@@ -59,7 +64,9 @@ public sealed class UpdateSectigoCertificateCommand : PSCmdlet {
             DcvMode = DcvMode,
             DcvEmail = DcvEmail
         };
-        var newId = certificates.RenewAsync(CertificateId, request).GetAwaiter().GetResult();
+        var newId = certificates.RenewAsync(CertificateId, request, CancellationToken)
+            .GetAwaiter()
+            .GetResult();
         WriteObject(newId);
     }
 }


### PR DESCRIPTION
## Summary
- add `CancellationToken` parameter to cmdlets
- connect the parameter with internal CancelToken when streaming orders
- test Get-SectigoOrders cancellation using `Register-ObjectEvent`

## Testing
- `pwsh -File Module/SectigoCertificateManager.Tests.ps1`
- `dotnet build SectigoCertificateManager.sln -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_687a1cd337f8832e8b9f7caff94d2bf1