### PR TITLE
Add custom field management

### DIFF
--- a/SectigoCertificateManager.Tests/CustomFieldsClientTests.cs
+++ b/SectigoCertificateManager.Tests/CustomFieldsClientTests.cs
@@ -1,0 +1,95 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Requests;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="CustomFieldsClient"/>.
+/// </summary>
+public sealed class CustomFieldsClientTests {
+    private sealed class TestHandler : HttpMessageHandler {
+        private readonly HttpResponseMessage _response;
+        public HttpRequestMessage? Request { get; private set; }
+        public string? Body { get; private set; }
+
+        public TestHandler(HttpResponseMessage response) => _response = response;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            Request = request;
+            if (request.Content is not null) {
+                Body = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+            return _response;
+        }
+    }
+
+    [Fact]
+    public async Task CreateAsync_SendsPayloadAndReturnsField() {
+        var field = new CustomField { Id = 3, Name = "field" };
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create(field)
+        };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var fields = new CustomFieldsClient(client);
+
+        var request = new CreateCustomFieldRequest { Name = "field", Mandatory = true, CertType = "ssl", State = "ACTIVE" };
+        var result = await fields.CreateAsync(request);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/v1/customfield", handler.Request!.RequestUri!.ToString());
+        Assert.NotNull(handler.Body);
+        Assert.Contains("\"name\":\"field\"", handler.Body);
+        Assert.NotNull(result);
+        Assert.Equal(3, result!.Id);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SendsPayload() {
+        var field = new CustomField { Id = 5, Name = "new" };
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create(field)
+        };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var fields = new CustomFieldsClient(client);
+
+        var request = new UpdateCustomFieldRequest { Id = 5, Name = "new", Mandatory = false, CertType = "ssl", State = "ACTIVE" };
+        var result = await fields.UpdateAsync(request);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal(HttpMethod.Put, handler.Request!.Method);
+        Assert.Equal("https://example.com/v1/customfield", handler.Request.RequestUri!.ToString());
+        Assert.NotNull(handler.Body);
+        Assert.Contains("\"id\":5", handler.Body);
+        Assert.NotNull(result);
+        Assert.Equal("new", result!.Name);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SendsDeleteRequest() {
+        var response = new HttpResponseMessage(HttpStatusCode.NoContent);
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var fields = new CustomFieldsClient(client);
+
+        await fields.DeleteAsync(7);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal(HttpMethod.Delete, handler.Request!.Method);
+        Assert.Equal("https://example.com/v1/customfield/7", handler.Request.RequestUri!.ToString());
+    }
+}

--- a/SectigoCertificateManager/Clients/CustomFieldsClient.cs
+++ b/SectigoCertificateManager/Clients/CustomFieldsClient.cs
@@ -1,0 +1,86 @@
+namespace SectigoCertificateManager.Clients;
+
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Requests;
+using SectigoCertificateManager.Utilities;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+/// <summary>
+/// Provides access to custom field endpoints.
+/// </summary>
+public sealed class CustomFieldsClient {
+    private readonly ISectigoClient _client;
+    private static readonly JsonSerializerOptions s_json = new() {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CustomFieldsClient"/> class.
+    /// </summary>
+    /// <param name="client">HTTP client wrapper.</param>
+    public CustomFieldsClient(ISectigoClient client) => _client = client;
+
+    /// <summary>
+    /// Creates a new custom field.
+    /// </summary>
+    /// <param name="request">Payload describing the field to create.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<CustomField?> CreateAsync(
+        CreateCustomFieldRequest request,
+        CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var response = await _client.PostAsync(
+            "v1/customfield",
+            JsonContent.Create(request, options: s_json),
+            cancellationToken).ConfigureAwait(false);
+
+        return await response.Content
+            .ReadFromJsonAsyncSafe<CustomField>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Updates an existing custom field.
+    /// </summary>
+    /// <param name="request">Payload describing updated field properties.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<CustomField?> UpdateAsync(
+        UpdateCustomFieldRequest request,
+        CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+        if (request.Id <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(request.Id));
+        }
+
+        var response = await _client.PutAsync(
+            "v1/customfield",
+            JsonContent.Create(request, options: s_json),
+            cancellationToken).ConfigureAwait(false);
+
+        return await response.Content
+            .ReadFromJsonAsyncSafe<CustomField>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes a custom field by identifier.
+    /// </summary>
+    /// <param name="customFieldId">Identifier of the custom field to delete.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task DeleteAsync(int customFieldId, CancellationToken cancellationToken = default) {
+        if (customFieldId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(customFieldId));
+        }
+
+        var response = await _client.DeleteAsync(
+            $"v1/customfield/{customFieldId}",
+            cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/SectigoCertificateManager/Models/CustomField.cs
+++ b/SectigoCertificateManager/Models/CustomField.cs
@@ -1,0 +1,37 @@
+namespace SectigoCertificateManager.Models;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents a custom field definition.
+/// </summary>
+public sealed class CustomField {
+    /// <summary>Gets or sets the custom field identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the custom field name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets a value indicating whether the field is mandatory.</summary>
+    public bool Mandatory { get; set; }
+
+    /// <summary>Gets or sets the certificate type this field applies to.</summary>
+    public string? CertType { get; set; }
+
+    /// <summary>Gets or sets the field state.</summary>
+    public string? State { get; set; }
+
+    /// <summary>Gets or sets input properties for this field.</summary>
+    public CustomFieldInput? Input { get; set; }
+}
+
+/// <summary>
+/// Represents input configuration for a custom field.
+/// </summary>
+public sealed class CustomFieldInput {
+    /// <summary>Gets or sets the input type.</summary>
+    public string? Type { get; set; }
+
+    /// <summary>Gets or sets allowed options for option fields.</summary>
+    public IReadOnlyList<string>? Options { get; set; }
+}

--- a/SectigoCertificateManager/Requests/CreateCustomFieldRequest.cs
+++ b/SectigoCertificateManager/Requests/CreateCustomFieldRequest.cs
@@ -1,0 +1,18 @@
+namespace SectigoCertificateManager.Requests;
+
+/// <summary>
+/// Request payload used to create a custom field.
+/// </summary>
+public sealed class CreateCustomFieldRequest {
+    /// <summary>Gets or sets the custom field name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets a value indicating whether the field is mandatory.</summary>
+    public bool Mandatory { get; set; }
+
+    /// <summary>Gets or sets the certificate type this field applies to.</summary>
+    public string CertType { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the field state.</summary>
+    public string State { get; set; } = string.Empty;
+}

--- a/SectigoCertificateManager/Requests/UpdateCustomFieldRequest.cs
+++ b/SectigoCertificateManager/Requests/UpdateCustomFieldRequest.cs
@@ -1,0 +1,21 @@
+namespace SectigoCertificateManager.Requests;
+
+/// <summary>
+/// Request payload used to update a custom field.
+/// </summary>
+public sealed class UpdateCustomFieldRequest {
+    /// <summary>Gets or sets the custom field identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the custom field name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets a value indicating whether the field is mandatory.</summary>
+    public bool Mandatory { get; set; }
+
+    /// <summary>Gets or sets the certificate type this field applies to.</summary>
+    public string CertType { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the field state.</summary>
+    public string State { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- add `CustomFieldsClient` to manage custom fields
- add model and requests for custom fields
- add tests for `CustomFieldsClient`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687a69767140832eae77687773eeff4a