### PR TITLE
Add IdP template endpoints

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/ListIdpTemplatesExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/ListIdpTemplatesExample.cs
@@ -1,0 +1,26 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates listing IdP templates using <see cref="AdminTemplatesClient"/>.
+/// </summary>
+public static class ListIdpTemplatesExample {
+    /// <summary>Executes the example.</summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var templates = new AdminTemplatesClient(client);
+
+        foreach (var template in await templates.ListAsync()) {
+            Console.WriteLine($"Template: {template.Name}");
+        }
+    }
+}

--- a/SectigoCertificateManager.Tests/AdminTemplatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/AdminTemplatesClientTests.cs
@@ -1,0 +1,100 @@
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Requests;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="AdminTemplatesClient"/>.
+/// </summary>
+public sealed class AdminTemplatesClientTests {
+    private sealed class TestHandler : HttpMessageHandler {
+        private readonly HttpResponseMessage _response;
+        public HttpRequestMessage? Request { get; private set; }
+        public string? Body { get; private set; }
+
+        public TestHandler(HttpResponseMessage response) => _response = response;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            Request = request;
+            if (request.Content is not null) {
+                Body = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+            return _response;
+        }
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsTemplate() {
+        var template = new IdpTemplate { Id = 5, Name = "t" };
+        var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(template) };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var templates = new AdminTemplatesClient(client);
+
+        var result = await templates.GetAsync(5);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/admin-template/v1/5", handler.Request!.RequestUri!.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(5, result!.Id);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ReturnsId() {
+        var response = new HttpResponseMessage(HttpStatusCode.Created);
+        response.Headers.Location = new System.Uri("https://example.com/admin-template/v1/7");
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var templates = new AdminTemplatesClient(client);
+
+        var id = await templates.CreateAsync(new CreateIdpTemplateRequest { Name = "t" });
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/admin-template/v1/", handler.Request!.RequestUri!.ToString());
+        Assert.Equal(7, id);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SendsPayload() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var templates = new AdminTemplatesClient(client);
+
+        var request = new UpdateIdpTemplateRequest { Name = "n" };
+        await templates.UpdateAsync(9, request);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal(HttpMethod.Put, handler.Request!.Method);
+        Assert.Equal("https://example.com/admin-template/v1/9", handler.Request.RequestUri!.ToString());
+        Assert.NotNull(handler.Body);
+        Assert.Contains("\"name\":\"n\"", handler.Body);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SendsRequest() {
+        var response = new HttpResponseMessage(HttpStatusCode.NoContent);
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var templates = new AdminTemplatesClient(client);
+
+        await templates.DeleteAsync(4, RelatedAdminsAction.Delete, 3);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal(HttpMethod.Delete, handler.Request!.Method);
+        Assert.Equal("https://example.com/admin-template/v1/4?relatedAdminsAction=Delete&replacingRequesterId=3", handler.Request.RequestUri!.ToString());
+    }
+}

--- a/SectigoCertificateManager/Clients/AdminTemplatesClient.cs
+++ b/SectigoCertificateManager/Clients/AdminTemplatesClient.cs
@@ -1,0 +1,157 @@
+namespace SectigoCertificateManager.Clients;
+
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Requests;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using SectigoCertificateManager.Utilities;
+
+/// <summary>
+/// Provides access to IdP template endpoints.
+/// </summary>
+public sealed class AdminTemplatesClient {
+    private readonly ISectigoClient _client;
+    private static readonly JsonSerializerOptions s_json = new() {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AdminTemplatesClient"/> class.
+    /// </summary>
+    /// <param name="client">HTTP client wrapper.</param>
+    public AdminTemplatesClient(ISectigoClient client) => _client = client;
+
+    /// <summary>Retrieves template details by identifier.</summary>
+    public async Task<IdpTemplate?> GetAsync(int templateId, CancellationToken cancellationToken = default) {
+        if (templateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(templateId));
+        }
+
+        var response = await _client.GetAsync($"admin-template/v1/{templateId}", cancellationToken).ConfigureAwait(false);
+        return await response.Content.ReadFromJsonAsyncSafe<IdpTemplate>(s_json, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Retrieves templates using the provided filter.</summary>
+    public async Task<IReadOnlyList<IdpTemplate>> ListAsync(
+        int? size = null,
+        int? position = null,
+        string? name = null,
+        int? orgId = null,
+        int? identityProviderId = null,
+        CancellationToken cancellationToken = default) {
+        var query = BuildQuery(size, position, name, orgId, identityProviderId);
+        var response = await _client.GetAsync($"admin-template/v1{query}", cancellationToken).ConfigureAwait(false);
+        var list = await response.Content.ReadFromJsonAsyncSafe<IReadOnlyList<IdpTemplate>>(s_json, cancellationToken).ConfigureAwait(false);
+        return list ?? Array.Empty<IdpTemplate>();
+    }
+
+    /// <summary>Streams templates page by page.</summary>
+    public async IAsyncEnumerable<IdpTemplate> EnumerateAsync(
+        int pageSize = 200,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+        var position = 0;
+        while (true) {
+            var list = await ListAsync(pageSize, position, null, null, null, cancellationToken).ConfigureAwait(false);
+            if (list.Count == 0) {
+                yield break;
+            }
+
+            foreach (var item in list) {
+                yield return item;
+            }
+
+            if (list.Count < pageSize) {
+                yield break;
+            }
+
+            position += pageSize;
+        }
+    }
+
+    /// <summary>Creates a new template.</summary>
+    public async Task<int> CreateAsync(CreateIdpTemplateRequest request, CancellationToken cancellationToken = default) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var response = await _client.PostAsync("admin-template/v1/", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        var location = response.Headers.Location;
+        if (location is not null) {
+            var url = location.ToString().Trim().TrimEnd('/');
+            var segments = url.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length > 0 && int.TryParse(segments[segments.Length - 1], out var id)) {
+                return id;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>Updates an existing template.</summary>
+    public async Task UpdateAsync(int templateId, UpdateIdpTemplateRequest request, CancellationToken cancellationToken = default) {
+        if (templateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(templateId));
+        }
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var response = await _client.PutAsync($"admin-template/v1/{templateId}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>Deletes a template.</summary>
+    public async Task DeleteAsync(
+        int templateId,
+        RelatedAdminsAction action = RelatedAdminsAction.Unlink,
+        int? replacingRequesterId = null,
+        CancellationToken cancellationToken = default) {
+        if (templateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(templateId));
+        }
+
+        var builder = new StringBuilder();
+        builder.Append("?").Append("relatedAdminsAction=").Append(action);
+        if (replacingRequesterId.HasValue) {
+            builder.Append("&replacingRequesterId=").Append(replacingRequesterId.Value);
+        }
+
+        var response = await _client.DeleteAsync($"admin-template/v1/{templateId}{builder}", cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    private static string BuildQuery(int? size, int? position, string? name, int? orgId, int? idpId) {
+        var builder = new StringBuilder();
+
+        void Append(string n, string? value) {
+            if (string.IsNullOrEmpty(value)) {
+                return;
+            }
+
+            _ = builder.Length == 0 ? builder.Append('?') : builder.Append('&');
+            builder.Append(n).Append('=').Append(Uri.EscapeDataString(value));
+        }
+
+        void AppendInt(string n, int? value) {
+            if (!value.HasValue) {
+                return;
+            }
+
+            _ = builder.Length == 0 ? builder.Append('?') : builder.Append('&');
+            builder.Append(n).Append('=').Append(value.Value);
+        }
+
+        AppendInt("size", size);
+        AppendInt("position", position);
+        Append("name", name);
+        AppendInt("orgId", orgId);
+        AppendInt("identityProviderId", idpId);
+
+        return builder.ToString();
+    }
+}

--- a/SectigoCertificateManager/Models/IdpMappingRule.cs
+++ b/SectigoCertificateManager/Models/IdpMappingRule.cs
@@ -1,0 +1,17 @@
+namespace SectigoCertificateManager.Models;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents an IdP attribute mapping rule.
+/// </summary>
+public sealed class IdpMappingRule {
+    /// <summary>Gets or sets the attribute name.</summary>
+    public string Attribute { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the match type.</summary>
+    public MatchType MatchType { get; set; } = MatchType.Matches;
+
+    /// <summary>Gets or sets allowed values.</summary>
+    public IReadOnlyList<string> Values { get; set; } = [];
+}

--- a/SectigoCertificateManager/Models/IdpTemplate.cs
+++ b/SectigoCertificateManager/Models/IdpTemplate.cs
@@ -1,0 +1,26 @@
+namespace SectigoCertificateManager.Models;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents an IdP administrator template.
+/// </summary>
+public sealed class IdpTemplate {
+    /// <summary>Gets or sets the template identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the template name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the identity provider identifier.</summary>
+    public int IdentityProviderId { get; set; }
+
+    /// <summary>Gets or sets assigned privileges.</summary>
+    public IReadOnlyList<string> Privileges { get; set; } = [];
+
+    /// <summary>Gets or sets credentials to assign.</summary>
+    public IReadOnlyList<IdpTemplateCredential> Credentials { get; set; } = [];
+
+    /// <summary>Gets or sets attribute mapping rules.</summary>
+    public IReadOnlyList<IdpMappingRule> IdpMappingRules { get; set; } = [];
+}

--- a/SectigoCertificateManager/Models/IdpTemplateCredential.cs
+++ b/SectigoCertificateManager/Models/IdpTemplateCredential.cs
@@ -1,0 +1,12 @@
+namespace SectigoCertificateManager.Models;
+
+/// <summary>
+/// Represents a credential used in an IdP template.
+/// </summary>
+public sealed class IdpTemplateCredential {
+    /// <summary>Gets or sets the role.</summary>
+    public string Role { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the organization identifier.</summary>
+    public int OrgId { get; set; }
+}

--- a/SectigoCertificateManager/Models/MatchType.cs
+++ b/SectigoCertificateManager/Models/MatchType.cs
@@ -1,0 +1,15 @@
+namespace SectigoCertificateManager.Models;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Specifies the match type used in IdP mapping rules.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum MatchType {
+    /// <summary>Attribute value must match completely.</summary>
+    Matches,
+
+    /// <summary>Attribute value must contain the specified text.</summary>
+    Contains
+}

--- a/SectigoCertificateManager/Models/RelatedAdminsAction.cs
+++ b/SectigoCertificateManager/Models/RelatedAdminsAction.cs
@@ -1,0 +1,15 @@
+namespace SectigoCertificateManager.Models;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Specifies action for administrators related to a template.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum RelatedAdminsAction {
+    /// <summary>Unlink administrators from the template.</summary>
+    Unlink,
+
+    /// <summary>Delete administrators with the template.</summary>
+    Delete
+}

--- a/SectigoCertificateManager/Requests/CreateIdpTemplateRequest.cs
+++ b/SectigoCertificateManager/Requests/CreateIdpTemplateRequest.cs
@@ -1,0 +1,24 @@
+namespace SectigoCertificateManager.Requests;
+
+using System.Collections.Generic;
+using SectigoCertificateManager.Models;
+
+/// <summary>
+/// Request payload used to create an IdP template.
+/// </summary>
+public sealed class CreateIdpTemplateRequest {
+    /// <summary>Gets or sets the template name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets assigned privileges.</summary>
+    public IReadOnlyList<string> Privileges { get; set; } = [];
+
+    /// <summary>Gets or sets credentials to assign.</summary>
+    public IReadOnlyList<IdpTemplateCredential> Credentials { get; set; } = [];
+
+    /// <summary>Gets or sets the identity provider identifier.</summary>
+    public int IdentityProviderId { get; set; }
+
+    /// <summary>Gets or sets attribute mapping rules.</summary>
+    public IReadOnlyList<IdpMappingRule> IdpMappingRules { get; set; } = [];
+}

--- a/SectigoCertificateManager/Requests/UpdateIdpTemplateRequest.cs
+++ b/SectigoCertificateManager/Requests/UpdateIdpTemplateRequest.cs
@@ -1,0 +1,15 @@
+namespace SectigoCertificateManager.Requests;
+
+using System.Collections.Generic;
+using SectigoCertificateManager.Models;
+
+/// <summary>
+/// Request payload used to update an IdP template.
+/// </summary>
+public sealed class UpdateIdpTemplateRequest {
+    public string? Name { get; set; }
+    public IReadOnlyList<string>? Privileges { get; set; }
+    public IReadOnlyList<IdpTemplateCredential>? Credentials { get; set; }
+    public int? IdentityProviderId { get; set; }
+    public IReadOnlyList<IdpMappingRule>? IdpMappingRules { get; set; }
+}


### PR DESCRIPTION
## Summary
- implement `AdminTemplatesClient` with CRUD methods
- add supporting models and request types for templates
- add example demonstrating how to list IdP templates
- cover new client with unit tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687a69a30144832e9d53bb45016f4eaa