### PR TITLE
Add IssuerDn filter to certificate search

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/SearchCertificatesExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/SearchCertificatesExample.cs
@@ -21,6 +21,7 @@ public static class SearchCertificatesExample {
 
         var request = new CertificateSearchRequest {
             CommonName = "example.com",
+            IssuerDn = "CN=Sectigo" ,
             DateFrom = DateTime.UtcNow.AddDays(-7),
             DateTo = DateTime.UtcNow
         };

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -218,6 +218,7 @@ public sealed class CertificatesClientTests {
             Status = CertificateStatus.Issued,
             SslTypeId = 2,
             Issuer = "A&B",
+            IssuerDn = "CN=te st",
             KeyAlgorithm = "RSA/DSA",
             DateFrom = new DateTime(2023, 7, 1),
             DateTo = new DateTime(2023, 7, 31)
@@ -225,7 +226,7 @@ public sealed class CertificatesClientTests {
         await certificates.SearchAsync(request);
 
         Assert.NotNull(handler.Request);
-        Assert.Equal("https://example.com/v1/certificate?size=10&position=5&commonName=te%20st&status=Issued&sslTypeId=2&issuer=A%26B&keyAlgorithm=RSA%2FDSA&dateFrom=2023-07-01&dateTo=2023-07-31", handler.Request!.RequestUri!.AbsoluteUri);
+        Assert.Equal("https://example.com/v1/certificate?size=10&position=5&commonName=te%20st&status=Issued&sslTypeId=2&issuer=A%26B&issuerDN=CN%3Dte%20st&keyAlgorithm=RSA%2FDSA&dateFrom=2023-07-01&dateTo=2023-07-31", handler.Request!.RequestUri!.AbsoluteUri);
     }
 
     [Fact]

--- a/SectigoCertificateManager/Clients/CertificatesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.cs
@@ -427,6 +427,7 @@ public sealed class CertificatesClient {
         Append("installStatus", request.InstallStatus);
         Append("renewalStatus", request.RenewalStatus);
         Append("issuer", request.Issuer);
+        Append("issuerDN", request.IssuerDn);
         Append("serialNumber", request.SerialNumber);
         Append("requester", request.Requester);
         Append("externalRequester", request.ExternalRequester);

--- a/SectigoCertificateManager/Requests/CertificateSearchRequest.cs
+++ b/SectigoCertificateManager/Requests/CertificateSearchRequest.cs
@@ -40,6 +40,9 @@ public sealed class CertificateSearchRequest {
     /// <summary>Gets or sets the issuer name filter.</summary>
     public string? Issuer { get; set; }
 
+    /// <summary>Gets or sets the issuer distinguished name filter.</summary>
+    public string? IssuerDn { get; set; }
+
     /// <summary>Gets or sets the certificate serial number filter.</summary>
     public string? SerialNumber { get; set; }
 


### PR DESCRIPTION
## Summary
- extend `CertificateSearchRequest` with `IssuerDn`
- include `issuerDN` parameter when building query
- show usage in `SearchCertificatesExample`
- adjust unit tests for new parameter

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687a69c773ec832e854bc5b40abe6645