### PR TITLE
Add CSR generator utility

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/CsrGeneratorExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/CsrGeneratorExample.cs
@@ -1,0 +1,22 @@
+using System;
+using SectigoCertificateManager.Utilities;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates generating certificate signing requests.
+/// </summary>
+public static class CsrGeneratorExample {
+    /// <summary>
+    /// Executes the example generating RSA and ECDSA CSRs.
+    /// </summary>
+    public static void Run() {
+        var (rsaCsr, rsaKey) = CsrGenerator.GenerateRsa("CN=example.com");
+        Console.WriteLine($"RSA CSR:\n{rsaCsr}\n");
+        rsaKey.Dispose();
+
+        var (ecdsaCsr, ecdsaKey) = CsrGenerator.GenerateEcdsa("CN=example.com");
+        Console.WriteLine($"ECDSA CSR:\n{ecdsaCsr}\n");
+        ecdsaKey.Dispose();
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -9,3 +9,4 @@ await GetCertificateRevocationExample.RunAsync();
 await ImportCertificatesExample.RunAsync();
 await ListCertificateTypesExample.RunAsync();
 await WatchOrdersExample.RunAsync();
+CsrGeneratorExample.Run();

--- a/SectigoCertificateManager.Tests/CsrGeneratorTests.cs
+++ b/SectigoCertificateManager.Tests/CsrGeneratorTests.cs
@@ -1,0 +1,53 @@
+using SectigoCertificateManager.Utilities;
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="CsrGenerator"/> helpers.
+/// </summary>
+public sealed class CsrGeneratorTests {
+    /// <summary>Generates RSA CSR.</summary>
+    [Fact]
+    public void GenerateRsa_ReturnsValidCsr() {
+        var (csr, key) = CsrGenerator.GenerateRsa("CN=Test", 1024);
+        try {
+            Assert.Equal(1024, key.KeySize);
+            var bytes = Convert.FromBase64String(csr);
+            Assert.NotEmpty(bytes);
+#if NET8_0_OR_GREATER
+            var req = CertificateRequest.LoadSigningRequest(
+                bytes,
+                HashAlgorithmName.SHA256,
+                CertificateRequestLoadOptions.SkipSignatureValidation,
+                RSASignaturePadding.Pkcs1);
+            Assert.Equal("CN=Test", req.SubjectName.Name);
+#endif
+        } finally {
+            key.Dispose();
+        }
+    }
+
+    /// <summary>Generates ECDSA CSR.</summary>
+    [Fact]
+    public void GenerateEcdsa_ReturnsValidCsr() {
+        var (csr, key) = CsrGenerator.GenerateEcdsa("CN=Test");
+        try {
+            var bytes = Convert.FromBase64String(csr);
+            Assert.NotEmpty(bytes);
+#if NET8_0_OR_GREATER
+            var req = CertificateRequest.LoadSigningRequest(
+                bytes,
+                HashAlgorithmName.SHA256,
+                CertificateRequestLoadOptions.SkipSignatureValidation,
+                RSASignaturePadding.Pkcs1);
+            Assert.Equal("CN=Test", req.SubjectName.Name);
+#endif
+        } finally {
+            key.Dispose();
+        }
+    }
+}

--- a/SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj
+++ b/SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Compile Remove="CertificateExportTests.cs" />
+    <Compile Remove="CsrGeneratorTests.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/SectigoCertificateManager/Utilities/CsrGenerator.cs
+++ b/SectigoCertificateManager/Utilities/CsrGenerator.cs
@@ -1,0 +1,78 @@
+#if NETSTANDARD2_0
+namespace SectigoCertificateManager.Utilities;
+
+using System.Security.Cryptography;
+
+/// <summary>
+/// Provides helpers for generating certificate signing requests.
+/// </summary>
+public static class CsrGenerator {
+    public static (string Csr, RSA Key) GenerateRsa(
+        string subjectName,
+        int keySize = 2048,
+        HashAlgorithmName? hashAlgorithm = null) => throw new PlatformNotSupportedException();
+
+    public static (string Csr, ECDsa Key) GenerateEcdsa(
+        string subjectName,
+        ECCurve? curve = null,
+        HashAlgorithmName? hashAlgorithm = null) => throw new PlatformNotSupportedException();
+}
+#else
+namespace SectigoCertificateManager.Utilities;
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+/// <summary>
+/// Provides helpers for generating certificate signing requests.
+/// </summary>
+public static class CsrGenerator {
+    public static (string Csr, RSA Key) GenerateRsa(
+        string subjectName,
+        int keySize = 2048,
+        HashAlgorithmName? hashAlgorithm = null) {
+        if (string.IsNullOrWhiteSpace(subjectName)) {
+            throw new ArgumentException("Value cannot be null or empty.", nameof(subjectName));
+        }
+        var rsa = RSA.Create(keySize);
+        var request = CreateRequest(subjectName, rsa, hashAlgorithm ?? HashAlgorithmName.SHA256);
+        var csr = Convert.ToBase64String(request.CreateSigningRequest());
+        return (csr, rsa);
+    }
+
+    public static (string Csr, ECDsa Key) GenerateEcdsa(
+        string subjectName,
+        ECCurve? curve = null,
+        HashAlgorithmName? hashAlgorithm = null) {
+        if (string.IsNullOrWhiteSpace(subjectName)) {
+            throw new ArgumentException("Value cannot be null or empty.", nameof(subjectName));
+        }
+        var ecdsa = ECDsa.Create(curve ?? ECCurve.NamedCurves.nistP256);
+        var request = CreateRequest(subjectName, ecdsa, hashAlgorithm ?? HashAlgorithmName.SHA256);
+        var csr = Convert.ToBase64String(request.CreateSigningRequest());
+        return (csr, ecdsa);
+    }
+
+    private static CertificateRequest CreateRequest(
+        string subjectName,
+        AsymmetricAlgorithm key,
+        HashAlgorithmName hashAlgorithm) {
+#if NET472
+        if (key is RSA rsa) {
+            return new CertificateRequest(new X500DistinguishedName(subjectName), rsa, hashAlgorithm, RSASignaturePadding.Pkcs1);
+        }
+        if (key is ECDsa ecdsa) {
+            return new CertificateRequest(new X500DistinguishedName(subjectName), ecdsa, hashAlgorithm);
+        }
+#else
+        if (key is RSA rsa) {
+            return new CertificateRequest(subjectName, rsa, hashAlgorithm, RSASignaturePadding.Pkcs1);
+        }
+        if (key is ECDsa ecdsa) {
+            return new CertificateRequest(subjectName, ecdsa, hashAlgorithm);
+        }
+#endif
+        throw new NotSupportedException($"Unsupported key type: {key.GetType().Name}");
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add `CsrGenerator` helper for creating RSA or ECDSA CSRs
- demonstrate usage with new example
- add unit tests for CSR generation

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687a69d1288c832ea9612734d1f91b61