### PR TITLE
Add certificate download helper

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/DownloadCertificateObjectExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/DownloadCertificateObjectExample.cs
@@ -1,0 +1,28 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates downloading an issued certificate as an X509Certificate2 instance.
+/// </summary>
+public static class DownloadCertificateObjectExample {
+    /// <summary>
+    /// Executes the example that downloads a certificate as an object.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+
+        Console.WriteLine("Downloading certificate...");
+        using var cert = await certificates.DownloadAsync(12345);
+        Console.WriteLine($"Thumbprint: {cert.Thumbprint}");
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -3,6 +3,7 @@ using SectigoCertificateManager.Examples.Examples;
 await BasicApiExample.RunAsync();
 await SearchCertificatesExample.RunAsync();
 await DownloadCertificateExample.RunAsync();
+await DownloadCertificateObjectExample.RunAsync();
 await DeleteCertificateExample.RunAsync();
 await UploadOrdersExample.RunAsync();
 await GetCertificateRevocationExample.RunAsync();

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -41,6 +41,8 @@ public sealed class CertificatesClientTests {
         public void Report(double value) => Value = value;
     }
 
+    private const string Base64Cert = "MIIC/zCCAeegAwIBAgIULTQw6ATwfRI/1hVSQooJNHPEit8wDQYJKoZIhvcNAQELBQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yNTA3MDQxMzE2NDRaFw0yNTA3MDUxMzE2NDRaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDiO8kIwsJLCi3d8bX31IIISKSoA24iCcfV7m+uMm8CMdJlY2NGf8ThiF3suG2lHQCxESQacUrPFMN/J3cM7L+5R8p24CCnrmAP2WhMuO2IwFhgfjo4PsmnmCGNx5fDAPI+lnSS6pnHfZfAPw3dbPT2/cgbeil0q2ByFR6C2YXU+mFdOg7cJJ1f2GXbUL3QYRBuaDYCHRrDAym4e/8DkKjjaroDxw1BPD6sjvzrDdEDusJANDCp8K6Cr99nvG+YCLjueN+xvUXHbsp9gUfLI39X73p+M9zGcYGAeYyD/i+VM/+Kde5CEfS34eOKfRIJX6DHAbVu1SrJPNFFvQV0keb/AgMBAAGjUzBRMB0GA1UdDgQWBBQ8PwJEkQsHvU7i5i45XLLyJUi4eTAfBgNVHSMEGDAWgBQ8PwJEkQsHvU7i5i45XLLyJUi4eTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAjWADB2IC5xBHKOROcXZDa8mp3DaasUwL5mWjG7Ppr4LHrY1uCEojstJCg6s2FLBjGTs+0DTQ5UiBqSVJDK1GVhYG02xJSPoXNS4wNTp4a56NtbkDT96lO0BrH91lclMNXHU9NpMUFea0tt7h5tUeVtZ2CVK0nuy5MOifMdURVyhWsFgQVemmTNTYisVD5sNRvBJEq0M+3+JSjFYvRZVqfRSM3z1K4XcZJfhxv7Gq1ebb93R1QunIdGC0HiFnBZxpxhDCbcVOpbdbQOJ22dLSe5/4f+1V+D/bPCZJx5kF0yvM0jEhuQNxNV3H/DasvBhH/24JIjpe+WfKPw0jx7vR6";
+
     /// <summary>Parses search results.</summary>
     [Fact]
     public async Task SearchAsync_BuildsQueryAndParsesResponse() {
@@ -648,5 +650,35 @@ public sealed class CertificatesClientTests {
         var certificates = new CertificatesClient(client);
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => certificates.ValidateCertificateRequestAsync(null!));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_ReturnsCertificate() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new StringContent(Base64Cert)
+        };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var certificates = new CertificatesClient(client);
+
+        using var cert = await certificates.DownloadAsync(5);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/ssl/v1/collect/5?format=base64", handler.Request!.RequestUri!.ToString());
+        Assert.Equal("51A908D14C9C984231B7E2F6C37ABB1368A57F1F", cert.Thumbprint);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-4)]
+    public async Task DownloadAsync_InvalidCertificateId_Throws(int certificateId) {
+        var handler = new TestHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var certificates = new CertificatesClient(client);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => certificates.DownloadAsync(certificateId));
     }
 }


### PR DESCRIPTION
## Summary
- add `CertificatesClient.DownloadAsync` overload returning an `X509Certificate2`
- test certificate parsing
- show usage in examples and program

## Testing
- `dotnet test SectigoCertificateManager.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687a90714364832e95e086b013a7c9ac