### PR TITLE
Add AuthorityInfoAccess parser

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/AuthorityInfoAccessExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/AuthorityInfoAccessExample.cs
@@ -1,0 +1,40 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Utilities;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates parsing the AuthorityInfoAccess extension.
+/// </summary>
+public static class AuthorityInfoAccessExample
+{
+    /// <summary>
+    /// Executes the example showing how to read OCSP and CA issuer URLs.
+    /// </summary>
+    public static async Task RunAsync()
+    {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+
+        Console.WriteLine("Downloading certificate...");
+        using var certificate = await certificates.DownloadAsync(12345);
+
+        var aia = certificate.GetAuthorityInfoAccess();
+        foreach (var url in aia.OcspUris)
+        {
+            Console.WriteLine($"OCSP: {url}");
+        }
+        foreach (var url in aia.CaIssuerUris)
+        {
+            Console.WriteLine($"CA Issuer: {url}");
+        }
+    }
+}

--- a/SectigoCertificateManager.Tests/AuthorityInfoAccessTests.cs
+++ b/SectigoCertificateManager.Tests/AuthorityInfoAccessTests.cs
@@ -1,0 +1,64 @@
+using SectigoCertificateManager.Utilities;
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+#if !NET8_0_OR_GREATER
+using System.Formats.Asn1;
+#endif
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="X509Certificate2Extensions.GetAuthorityInfoAccess"/>.
+/// </summary>
+public sealed class AuthorityInfoAccessTests
+{
+    private static X509Certificate2 CreateCertificate()
+    {
+        using var key = RSA.Create(2048);
+#if NET472
+        var req = new CertificateRequest(
+            new X500DistinguishedName("CN=Test"),
+            key,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+#else
+        var req = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+#endif
+#if NET8_0_OR_GREATER
+        var ext = new X509AuthorityInformationAccessExtension(
+            new[] { "http://ocsp.test" },
+            new[] { "http://ca.test" },
+            false);
+        req.CertificateExtensions.Add(ext);
+#else
+        var writer = new AsnWriter(AsnEncodingRules.DER);
+        writer.PushSequence();
+        writer.PushSequence();
+        writer.WriteObjectIdentifier("1.3.6.1.5.5.7.48.1");
+        writer.WriteCharacterString(UniversalTagNumber.IA5String, "http://ocsp.test", new Asn1Tag(TagClass.ContextSpecific, 6));
+        writer.PopSequence();
+        writer.PushSequence();
+        writer.WriteObjectIdentifier("1.3.6.1.5.5.7.48.2");
+        writer.WriteCharacterString(UniversalTagNumber.IA5String, "http://ca.test", new Asn1Tag(TagClass.ContextSpecific, 6));
+        writer.PopSequence();
+        writer.PopSequence();
+        var data = writer.Encode();
+        req.CertificateExtensions.Add(new X509Extension("1.3.6.1.5.5.7.1.1", data, false));
+#endif
+        return req.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+    }
+
+    /// <summary>Parses AuthorityInfoAccess extension.</summary>
+    [Fact]
+    public void GetAuthorityInfoAccess_ReturnsUris()
+    {
+        using var cert = CreateCertificate();
+
+        var aia = cert.GetAuthorityInfoAccess();
+
+        Assert.Contains("http://ocsp.test", aia.OcspUris);
+        Assert.Contains("http://ca.test", aia.CaIssuerUris);
+    }
+}

--- a/SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj
+++ b/SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.2" />
     <PackageReference Include="WireMock.Net" Version="1.8.14" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.7" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,6 +28,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Compile Remove="CertificateExportTests.cs" />
     <Compile Remove="CsrGeneratorTests.cs" />
+    <Compile Remove="AuthorityInfoAccessTests.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/SectigoCertificateManager/SectigoCertificateManager.csproj
+++ b/SectigoCertificateManager/SectigoCertificateManager.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="System.Net.Http.Json" Version="9.0.7" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.7" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.7" />
   </ItemGroup>
 
 </Project>

--- a/SectigoCertificateManager/Utilities/AuthorityInfoAccess.cs
+++ b/SectigoCertificateManager/Utilities/AuthorityInfoAccess.cs
@@ -1,0 +1,15 @@
+namespace SectigoCertificateManager.Utilities;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents the AuthorityInfoAccess extension data.
+/// </summary>
+public sealed class AuthorityInfoAccess
+{
+    /// <summary>Gets OCSP URLs from the extension.</summary>
+    public IReadOnlyList<string> OcspUris { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>Gets CA issuer URLs from the extension.</summary>
+    public IReadOnlyList<string> CaIssuerUris { get; set; } = System.Array.Empty<string>();
+}

--- a/SectigoCertificateManager/Utilities/X509Certificate2Extensions.cs
+++ b/SectigoCertificateManager/Utilities/X509Certificate2Extensions.cs
@@ -1,0 +1,67 @@
+namespace SectigoCertificateManager.Utilities;
+
+using System;
+using System.Collections.Generic;
+using System.Formats.Asn1;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+/// <summary>
+/// Extension methods for <see cref="X509Certificate2"/>.
+/// </summary>
+public static class X509Certificate2Extensions
+{
+    private const string AuthorityInfoAccessOid = "1.3.6.1.5.5.7.1.1";
+    private const string OcspOid = "1.3.6.1.5.5.7.48.1";
+    private const string CaIssuersOid = "1.3.6.1.5.5.7.48.2";
+
+    /// <summary>Gets AuthorityInfoAccess data from the certificate.</summary>
+    public static AuthorityInfoAccess GetAuthorityInfoAccess(this X509Certificate2 certificate)
+    {
+        if (certificate is null)
+        {
+            throw new ArgumentNullException(nameof(certificate));
+        }
+#if NET8_0_OR_GREATER
+        if (certificate.Extensions[AuthorityInfoAccessOid] is X509AuthorityInformationAccessExtension aia)
+        {
+            return new AuthorityInfoAccess
+            {
+                OcspUris = aia.EnumerateOcspUris().ToArray(),
+                CaIssuerUris = aia.EnumerateCAIssuersUris().ToArray()
+            };
+        }
+        return new AuthorityInfoAccess();
+#else
+        var ext = certificate.Extensions[AuthorityInfoAccessOid];
+        if (ext is null)
+        {
+            return new AuthorityInfoAccess();
+        }
+        var ocsp = new List<string>();
+        var issuers = new List<string>();
+        var reader = new AsnReader(ext.RawData, AsnEncodingRules.DER);
+        var seq = reader.ReadSequence();
+        while (seq.HasData)
+        {
+            var ad = seq.ReadSequence();
+            var method = ad.ReadObjectIdentifier();
+            var uri = ad.ReadCharacterString(UniversalTagNumber.IA5String, new Asn1Tag(TagClass.ContextSpecific, 6));
+            if (method == OcspOid)
+            {
+                ocsp.Add(uri);
+            }
+            else if (method == CaIssuersOid)
+            {
+                issuers.Add(uri);
+            }
+        }
+        return new AuthorityInfoAccess
+        {
+            OcspUris = ocsp.ToArray(),
+            CaIssuerUris = issuers.ToArray()
+        };
+#endif
+    }
+}


### PR DESCRIPTION
## Summary
- add helper to parse AuthorityInfoAccess extension
- include sample example
- add unit test for the helper
- install System.Formats.Asn1 for all frameworks

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687a9a654894832ea7d8bdbc5594df95