### PR TITLE
Add ShouldProcess support

### DIFF
--- a/SectigoCertificateManager.PowerShell/RemoveSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/RemoveSectigoCertificateCommand.cs
@@ -8,7 +8,7 @@ namespace SectigoCertificateManager.PowerShell;
 
 /// <summary>Deletes a certificate.</summary>
 /// <para>Builds an API client and calls the delete endpoint.</para>
-[Cmdlet(VerbsCommon.Remove, "SectigoCertificate")]
+[Cmdlet(VerbsCommon.Remove, "SectigoCertificate", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
 [CmdletBinding()]
 public sealed class RemoveSectigoCertificateCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>
@@ -46,6 +46,10 @@ public sealed class RemoveSectigoCertificateCommand : PSCmdlet {
             var ex = new ArgumentOutOfRangeException(nameof(CertificateId));
             var record = new ErrorRecord(ex, "InvalidCertificateId", ErrorCategory.InvalidArgument, CertificateId);
             ThrowTerminatingError(record);
+        }
+
+        if (!ShouldProcess($"Certificate {CertificateId}", "Delete")) {
+            return;
         }
 
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);

--- a/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
@@ -8,7 +8,7 @@ namespace SectigoCertificateManager.PowerShell;
 
 /// <summary>Cancels an order.</summary>
 /// <para>Creates an API client and calls the cancel endpoint.</para>
-[Cmdlet(VerbsLifecycle.Stop, "SectigoOrder")]
+[Cmdlet(VerbsLifecycle.Stop, "SectigoOrder", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
 [CmdletBinding()]
 public sealed class StopSectigoOrderCommand : PSCmdlet {
     /// <summary>The API base URL.</summary>
@@ -46,6 +46,10 @@ public sealed class StopSectigoOrderCommand : PSCmdlet {
             var ex = new ArgumentOutOfRangeException(nameof(OrderId));
             var record = new ErrorRecord(ex, "InvalidOrderId", ErrorCategory.InvalidArgument, OrderId);
             ThrowTerminatingError(record);
+        }
+
+        if (!ShouldProcess($"Order {OrderId}", "Cancel")) {
+            return;
         }
 
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);

--- a/SectigoCertificateManager.PowerShell/UpdateSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/UpdateSectigoCertificateCommand.cs
@@ -9,7 +9,7 @@ namespace SectigoCertificateManager.PowerShell;
 /// <summary>
 /// Updates an existing certificate using the renew endpoint.
 /// </summary>
-[Cmdlet(VerbsData.Update, "SectigoCertificate")]
+[Cmdlet(VerbsData.Update, "SectigoCertificate", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Medium)]
 [CmdletBinding()]
 [OutputType(typeof(int))]
 public sealed class UpdateSectigoCertificateCommand : PSCmdlet {
@@ -56,6 +56,10 @@ public sealed class UpdateSectigoCertificateCommand : PSCmdlet {
     /// <summary>Renews a certificate using provided parameters.</summary>
     /// <para>Builds an API client and submits a <see cref="RenewCertificateRequest"/>.</para>
     protected override void ProcessRecord() {
+        if (!ShouldProcess($"Certificate {CertificateId}", "Update")) {
+            return;
+        }
+
         var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
         var client = new SectigoClient(config);
         var certificates = new CertificatesClient(client);

--- a/SectigoCertificateManager.Tests/Pester/RemoveSectigoCertificateCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/RemoveSectigoCertificateCommand.Tests.ps1
@@ -8,4 +8,10 @@ Describe "Remove-SectigoCertificate" {
     It "throws when CertificateId is less than or equal to zero" {
         { Remove-SectigoCertificate -BaseUrl 'b' -Username 'u' -Password 'p' -CustomerUri 'c' -CertificateId 0 } | Should -Throw
     }
+
+    It "supports ShouldProcess" {
+        $cmd = Get-Command Remove-SectigoCertificate -ErrorAction Stop
+        $meta = [System.Management.Automation.CommandMetadata]::new($cmd.ImplementingType)
+        $meta.SupportsShouldProcess | Should -BeTrue
+    }
 }

--- a/SectigoCertificateManager.Tests/Pester/StopSectigoOrderCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/StopSectigoOrderCommand.Tests.ps1
@@ -8,4 +8,10 @@ Describe "Stop-SectigoOrder" {
     It "throws when OrderId is less than or equal to zero" {
         { Stop-SectigoOrder -BaseUrl 'b' -Username 'u' -Password 'p' -CustomerUri 'c' -OrderId 0 } | Should -Throw
     }
+
+    It "supports ShouldProcess" {
+        $cmd = Get-Command Stop-SectigoOrder -ErrorAction Stop
+        $meta = [System.Management.Automation.CommandMetadata]::new($cmd.ImplementingType)
+        $meta.SupportsShouldProcess | Should -BeTrue
+    }
 }

--- a/SectigoCertificateManager.Tests/Pester/UpdateSectigoCertificateCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/UpdateSectigoCertificateCommand.Tests.ps1
@@ -9,4 +9,10 @@ Describe "Update-SectigoCertificate" {
         $cmd = Get-Command Update-SectigoCertificate -ErrorAction Stop
         $cmd | Should -Not -BeNullOrEmpty
     }
+
+    It "supports ShouldProcess" {
+        $cmd = Get-Command Update-SectigoCertificate -ErrorAction Stop
+        $meta = [System.Management.Automation.CommandMetadata]::new($cmd.ImplementingType)
+        $meta.SupportsShouldProcess | Should -BeTrue
+    }
 }


### PR DESCRIPTION
## Summary
- enable `SupportsShouldProcess` on destructive cmdlets
- verify ShouldProcess presence in Pester tests

## Testing
- `dotnet test SectigoCertificateManager.sln --no-build` *(fails: 171 failed)*
- `Invoke-Pester -Path 'SectigoCertificateManager.Tests/Pester' -CI`

------
https://chatgpt.com/codex/tasks/task_e_687a9a22c288832eb09a5d7e48f1b47f