### PR TITLE
Add certificate type upsert method

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/UpsertCertificateTypeExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/UpsertCertificateTypeExample.cs
@@ -1,0 +1,29 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Models;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates creating or updating a certificate type using <see cref="CertificateTypesClient"/>.
+/// </summary>
+public static class UpsertCertificateTypeExample {
+    /// <summary>
+    /// Executes the example that upserts a certificate type.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var types = new CertificateTypesClient(client);
+
+        var type = new CertificateType { Name = "My Custom Type" };
+        var result = await types.UpsertAsync(type);
+        Console.WriteLine($"Created certificate type with ID: {result?.Id}");
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -9,5 +9,6 @@ await UploadOrdersExample.RunAsync();
 await GetCertificateRevocationExample.RunAsync();
 await ImportCertificatesExample.RunAsync();
 await ListCertificateTypesExample.RunAsync();
+await UpsertCertificateTypeExample.RunAsync();
 await WatchOrdersExample.RunAsync();
 CsrGeneratorExample.Run();

--- a/SectigoCertificateManager.Tests/CertificateTypesClientWireMockTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateTypesClientWireMockTests.cs
@@ -1,0 +1,56 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Models;
+using System.Net.Http;
+using System.Threading.Tasks;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+#if !NET472
+/// <summary>
+/// Integration tests for <see cref="CertificateTypesClient"/> using WireMock.
+/// </summary>
+public sealed class CertificateTypesClientWireMockTests {
+    [Fact]
+    public async Task UpsertAsync_PostsWhenIdMissing() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/v1/certificate/type").UsingPost())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("{\"id\":8}"));
+
+        var config = new ApiConfig(server.Url!, "user", "pass", "cst1", ApiVersion.V25_4);
+        var client = new SectigoClient(config, new HttpClient());
+        var types = new CertificateTypesClient(client);
+
+        var result = await types.UpsertAsync(new CertificateType { Name = "new" });
+
+        Assert.NotNull(result);
+        Assert.Equal(8, result!.Id);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_PutsWhenIdPresent() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/v1/certificate/type/3").UsingPut())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("{\"id\":3,\"name\":\"upd\"}"));
+
+        var config = new ApiConfig(server.Url!, "user", "pass", "cst1", ApiVersion.V25_4);
+        var client = new SectigoClient(config, new HttpClient());
+        var types = new CertificateTypesClient(client);
+
+        var result = await types.UpsertAsync(new CertificateType { Id = 3, Name = "upd" });
+
+        Assert.NotNull(result);
+        Assert.Equal("upd", result!.Name);
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add `UpsertAsync` to `CertificateTypesClient`
- show how to use upsert in example project
- exercise upsert via WireMock integration tests

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687a9a6e16dc832e851e0a9534fc8069