### PR TITLE
Add Wait-SectigoOrder cmdlet

### DIFF
--- a/Module/SectigoCertificateManager.psd1
+++ b/Module/SectigoCertificateManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Get-SectigoCertificate', 'Get-SectigoOrders', 'Get-SectigoOrganizations', 'Get-SectigoProfile', 'Get-SectigoProfiles', 'New-SectigoOrder', 'Stop-SectigoOrder', 'Update-SectigoCertificate', 'Remove-SectigoCertificate')
+    CmdletsToExport      = @('Get-SectigoCertificate', 'Get-SectigoOrders', 'Get-SectigoOrganizations', 'Get-SectigoProfile', 'Get-SectigoProfiles', 'New-SectigoOrder', 'Stop-SectigoOrder', 'Update-SectigoCertificate', 'Remove-SectigoCertificate', 'Wait-SectigoOrder')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/Tests/WaitSectigoOrder.Tests.ps1
+++ b/Module/Tests/WaitSectigoOrder.Tests.ps1
@@ -1,0 +1,6 @@
+Describe 'Wait-SectigoOrder validation' -Tag 'Cmdlet' {
+    It 'Throws on invalid OrderId' {
+        $params = @{ BaseUrl='https://example.com'; Username='u'; Password='p'; CustomerUri='c'; OrderId=0 }
+        { Wait-SectigoOrder @params } | Should -Throw
+    }
+}

--- a/SectigoCertificateManager.PowerShell/WaitSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/WaitSectigoOrderCommand.cs
@@ -1,0 +1,64 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using System.Management.Automation;
+using System.Threading;
+
+namespace SectigoCertificateManager.PowerShell;
+
+/// <summary>Waits for an order to reach a terminal status.</summary>
+/// <para>Creates an API client and polls the order status until it is completed or cancelled.</para>
+[Cmdlet(VerbsLifecycle.Wait, "SectigoOrder")]
+[CmdletBinding()]
+[OutputType(typeof(OrderStatus))]
+public sealed class WaitSectigoOrderCommand : PSCmdlet {
+    /// <summary>The API base URL.</summary>
+    [Parameter(Mandatory = true)]
+    public string BaseUrl { get; set; } = string.Empty;
+
+    /// <summary>The user name for authentication.</summary>
+    [Parameter(Mandatory = true)]
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>The password for authentication.</summary>
+    [Parameter(Mandatory = true)]
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>The customer URI assigned by Sectigo.</summary>
+    [Parameter(Mandatory = true)]
+    public string CustomerUri { get; set; } = string.Empty;
+
+    /// <summary>The API version to use.</summary>
+    [Parameter]
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+
+    /// <summary>The identifier of the order to wait on.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public int OrderId { get; set; }
+
+    /// <summary>Delay between status checks.</summary>
+    [Parameter]
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
+    /// <summary>Executes the cmdlet.</summary>
+    /// <para>Polls the order status until it reaches a terminal value.</para>
+    protected override void ProcessRecord() {
+        if (OrderId <= 0) {
+            var ex = new ArgumentOutOfRangeException(nameof(OrderId));
+            var record = new ErrorRecord(ex, "InvalidOrderId", ErrorCategory.InvalidArgument, OrderId);
+            ThrowTerminatingError(record);
+        }
+
+        var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
+        var client = new SectigoClient(config);
+        var statuses = new OrderStatusClient(client);
+        var status = statuses
+            .WatchAsync(OrderId, PollInterval, CancellationToken)
+            .GetAwaiter()
+            .GetResult();
+        WriteObject(status);
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `Wait-SectigoOrder` cmdlet to poll for order status
- export the cmdlet in module manifest
- cover parameter validation for new cmdlet with Pester

## Testing
- `pwsh -NoLogo -NoProfile -Command "& ./Module/SectigoCertificateManager.Tests.ps1"`
- `dotnet test SectigoCertificateManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_687a9a2c3b8c832e99c88b3b433ef44a