### PR TITLE
Add HttpClient property tests and example

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/HttpClientPropertyExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/HttpClientPropertyExample.cs
@@ -1,0 +1,23 @@
+using SectigoCertificateManager;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates accessing the underlying <see cref="System.Net.Http.HttpClient"/>.
+/// </summary>
+public static class HttpClientPropertyExample {
+    /// <summary>Runs the example using the <see cref="SectigoClient.HttpClient"/> property.</summary>
+    public static void Run() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .Build();
+
+        using var client = new SectigoClient(config);
+
+        // Adjust timeout for long-running operations.
+        client.HttpClient.Timeout = TimeSpan.FromSeconds(30);
+    }
+}
+

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -12,3 +12,4 @@ await ListCertificateTypesExample.RunAsync();
 await UpsertCertificateTypeExample.RunAsync();
 await WatchOrdersExample.RunAsync();
 CsrGeneratorExample.Run();
+HttpClientPropertyExample.Run();

--- a/SectigoCertificateManager.Tests/SectigoClientTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientTests.cs
@@ -264,4 +264,25 @@ public sealed class SectigoClientTests {
 
         Assert.True(handler.MaxObserved <= 2);
     }
+
+    [Fact]
+    public void HttpClientProperty_ReturnsProvidedInstance() {
+        var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
+        var handler = new TestHandler();
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(config, httpClient);
+
+        Assert.Same(httpClient, client.HttpClient);
+    }
+
+    [Fact]
+    public void HttpClientProperty_ThrowsAfterDispose() {
+        var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
+        using var httpClient = new HttpClient(new TestHandler());
+        var client = new SectigoClient(config, httpClient);
+
+        client.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => _ = client.HttpClient);
+    }
 }


### PR DESCRIPTION
## Summary
- add example using `SectigoClient.HttpClient` property
- call the new example in Program
- cover `HttpClient` property with tests

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687aa89403f8832e9143c1836659355c