### PR TITLE
Fix nullable warnings

### DIFF
--- a/SectigoCertificateManager.Tests/CertificateExportTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateExportTests.cs
@@ -88,7 +88,10 @@ public sealed class CertificateExportTests {
             CertificateExport.SavePfx(cert, path, "pwd");
             Assert.True(Directory.Exists(dir));
             Assert.True(File.Exists(path));
+            // X509Certificate2 constructor is obsolete on .NET 9.0 and later.
+#pragma warning disable SYSLIB0057
             using var loaded = new X509Certificate2(path, "pwd");
+#pragma warning restore SYSLIB0057
             Assert.Equal(cert.Thumbprint, loaded.Thumbprint);
         } finally {
             if (Directory.Exists(dir)) {

--- a/SectigoCertificateManager/ApiVersionHelper.cs
+++ b/SectigoCertificateManager/ApiVersionHelper.cs
@@ -13,7 +13,7 @@ public static class ApiVersionHelper {
             return ApiVersion.V25_6;
         }
 
-        var trimmed = value.Trim();
+        var trimmed = value!.Trim();
         if (trimmed.StartsWith("v", StringComparison.OrdinalIgnoreCase)) {
             trimmed = trimmed.Substring(1);
         }

--- a/SectigoCertificateManager/Models/Certificate.cs
+++ b/SectigoCertificateManager/Models/Certificate.cs
@@ -90,7 +90,11 @@ public sealed class Certificate {
             });
         }
 
+        // X509Certificate2 constructor is obsolete beginning with .NET 9.0,
+        // but remains necessary for earlier target frameworks.
+#pragma warning disable SYSLIB0057
         return new X509Certificate2(bytes);
+#pragma warning restore SYSLIB0057
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- update `ApiVersionHelper` to avoid null reference warning
- silence SYSLIB0057 warnings on older frameworks
- adjust tests for obsolete warnings

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_687aa8874e18832e88271f71215b9a50