### PR TITLE
Add CLI import test for New-SectigoOrder

### DIFF
--- a/SectigoCertificateManager.Tests/Pester/NewSectigoOrderCommandCLITests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/NewSectigoOrderCommandCLITests.ps1
@@ -1,0 +1,19 @@
+Describe "New-SectigoOrder import via CLI" {
+    BeforeAll {
+        dotnet build "$PSScriptRoot/../../SectigoCertificateManager.PowerShell" -c Release | Out-Null
+        $dll = Join-Path $PSScriptRoot '../../SectigoCertificateManager.PowerShell/bin/Release/net8.0/SectigoCertificateManager.PowerShell.dll'
+        $cli = if (Get-Command pwsh -ErrorAction SilentlyContinue) { 'pwsh' } else { 'powershell' }
+        $scriptContent = @"
+Import-Module '$dll' -ErrorAction Stop
+if (Get-Command New-SectigoOrder -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }
+"@
+        $tempFile = New-TemporaryFile
+        Set-Content -Path $tempFile -Value $scriptContent
+        & $cli -NoProfile -File $tempFile
+        $Script:ImportExitCode = $LASTEXITCODE
+    }
+
+    It "imports module and finds New-SectigoOrder" {
+        $ImportExitCode | Should -Be 0
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester test ensuring New-SectigoOrder can be imported from a PowerShell CLI

## Testing
- `dotnet test SectigoCertificateManager.sln --verbosity minimal`
- `pwsh -NoProfile -Command ./Module/SectigoCertificateManager.Tests.ps1`
- `pwsh -NoProfile -Command ./SectigoCertificateManager.Tests/Pester/NewSectigoOrderCommandCLITests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_687aa876e060832ebd368c75e74180d8