### PR TITLE
Add token cache support to ApiConfigLoader

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/TokenCacheExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/TokenCacheExample.cs
@@ -1,0 +1,33 @@
+using SectigoCertificateManager;
+using System;
+using System.IO;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates storing and loading authentication tokens from a cache file.
+/// </summary>
+public static class TokenCacheExample {
+    /// <summary>Runs the example.</summary>
+    public static void Run() {
+        var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".sectigo", "token.json");
+        var info = new TokenInfo("<token>", DateTimeOffset.UtcNow.AddHours(1));
+        ApiConfigLoader.WriteToken(info, path);
+
+        var cached = ApiConfigLoader.ReadToken(path);
+        if (cached is null) {
+            Console.WriteLine("No cached token available.");
+            return;
+        }
+
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCustomerUri("<customer uri>")
+            .WithToken(cached.Token)
+            .WithTokenExpiration(cached.ExpiresAt)
+            .Build();
+
+        using var client = new SectigoClient(config);
+        Console.WriteLine($"Loaded token expires at {cached.ExpiresAt:u}");
+    }
+}

--- a/SectigoCertificateManager/ApiConfigLoader.cs
+++ b/SectigoCertificateManager/ApiConfigLoader.cs
@@ -8,6 +8,10 @@ using System.Text.Json;
 /// Provides helpers for loading <see cref="ApiConfig"/> from environment variables or a JSON file.
 /// </summary>
 public static class ApiConfigLoader {
+    private sealed class TokenFileModel {
+        public string Token { get; set; } = string.Empty;
+        public DateTimeOffset ExpiresAt { get; set; }
+    }
     private sealed class FileModel {
         /// <summary>Gets or sets the base URL.</summary>
         public string BaseUrl { get; set; } = string.Empty;
@@ -28,11 +32,58 @@ public static class ApiConfigLoader {
         public string ApiVersion { get; set; } = "V25_6";
     }
 
+    private static string GetTokenPath(string? path) {
+        if (!string.IsNullOrEmpty(path)) {
+            return path;
+        }
+
+        var env = Environment.GetEnvironmentVariable("SECTIGO_TOKEN_CACHE_PATH");
+        if (!string.IsNullOrEmpty(env)) {
+            return env;
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".sectigo", "token.json");
+    }
+
+    public static TokenInfo? ReadToken(string? path = null) {
+        var tokenPath = GetTokenPath(path);
+        if (!File.Exists(tokenPath)) {
+            return null;
+        }
+
+        using var stream = File.OpenRead(tokenPath);
+        using var reader = new StreamReader(stream);
+        var json = reader.ReadToEnd();
+        var model = JsonSerializer.Deserialize<TokenFileModel>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return model is null ? null : new TokenInfo(model.Token, model.ExpiresAt);
+    }
+
+    public static void WriteToken(TokenInfo info, string? path = null) {
+        var tokenPath = GetTokenPath(path);
+        var dir = Path.GetDirectoryName(tokenPath);
+        if (!string.IsNullOrEmpty(dir)) {
+            Directory.CreateDirectory(dir);
+        }
+
+        var json = JsonSerializer.Serialize(new TokenFileModel { Token = info.Token, ExpiresAt = info.ExpiresAt });
+        using (var stream = new FileStream(tokenPath, FileMode.Create, FileAccess.Write, FileShare.None)) {
+            using var writer = new StreamWriter(stream);
+            writer.Write(json);
+        }
+#if NET6_0_OR_GREATER
+        if (!OperatingSystem.IsWindows()) {
+            File.SetUnixFileMode(tokenPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+#endif
+    }
+
     /// <summary>
     /// Loads configuration from environment variables or a JSON file.
     /// </summary>
     /// <param name="path">Optional path to the JSON file. If not provided, defaults are used.</param>
-    public static ApiConfig Load(string? path = null) {
+    /// <param name="tokenPath">Optional path to the token cache file.</param>
+    public static ApiConfig Load(string? path = null, string? tokenPath = null) {
         string? baseUrl = Environment.GetEnvironmentVariable("SECTIGO_BASE_URL");
         string? username = Environment.GetEnvironmentVariable("SECTIGO_USERNAME");
         string? password = Environment.GetEnvironmentVariable("SECTIGO_PASSWORD");
@@ -42,6 +93,12 @@ public static class ApiConfigLoader {
 
         if (baseUrl is not null && token is not null && customerUri is not null) {
             return new ApiConfig(baseUrl, string.Empty, string.Empty, customerUri, ApiVersionHelper.Parse(version), token: token);
+        }
+
+        var cached = ReadToken(tokenPath);
+
+        if (baseUrl is not null && cached is not null && customerUri is not null) {
+            return new ApiConfig(baseUrl, string.Empty, string.Empty, customerUri, ApiVersionHelper.Parse(version), token: cached.Token, tokenExpiresAt: cached.ExpiresAt);
         }
 
         if (baseUrl is not null && username is not null && password is not null && customerUri is not null) {
@@ -68,6 +125,18 @@ public static class ApiConfigLoader {
         var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
         var model = JsonSerializer.Deserialize<FileModel>(json, options)
                     ?? throw new InvalidOperationException("Invalid configuration file.");
-        return new ApiConfig(model.BaseUrl, model.Username, model.Password, model.CustomerUri, ApiVersionHelper.Parse(model.ApiVersion), token: model.Token);
+
+        var cache = ReadToken(tokenPath);
+        var tokenValue = model.Token ?? cache?.Token;
+        DateTimeOffset? expires = cache?.ExpiresAt;
+
+        return new ApiConfig(
+            model.BaseUrl,
+            model.Username,
+            model.Password,
+            model.CustomerUri,
+            ApiVersionHelper.Parse(model.ApiVersion),
+            token: tokenValue,
+            tokenExpiresAt: expires);
     }
 }


### PR DESCRIPTION
## Summary
- extend `ApiConfigLoader` with token cache methods
- support loading token information from cache when building config
- add round-trip tests and config loader test using token cache
- add example demonstrating token caching

## Testing
- `dotnet build --no-restore`
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj --framework net8.0 --no-build`
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj --framework net472 --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687b383e77b0832ea840ac4ac77e71f2