### PR TITLE
Add certificate streaming API

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/StreamCertificatesExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/StreamCertificatesExample.cs
@@ -21,8 +21,8 @@ public static class StreamCertificatesExample {
         var client = new SectigoClient(config);
         var certificates = new CertificatesClient(client);
 
-        await foreach (var certificate in certificates.EnumerateCertificatesAsync(pageSize: 50)) {
-            Console.WriteLine($"Certificate ID: {certificate.Id}");
+        await foreach (var certificate in certificates.StreamCertificatesAsync(pageSize: 50)) {
+            Console.WriteLine($"Certificate subject: {certificate.Subject}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `StreamCertificatesAsync` to download issued certificates page by page
- update streaming example
- test streaming behavior

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687b383469b4832ea0da88cba4f5a615