### PR TITLE
Add RevocationReason enum

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/RevocationReasonExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/RevocationReasonExample.cs
@@ -7,8 +7,8 @@ public static class RevocationReasonExample {
     /// Demonstrates retrieving a revocation reason description.
     /// </summary>
     public static void Run() {
-        const int code = 4;
+        const RevocationReason code = RevocationReason.Superseded;
         var description = RevocationReasons.GetRevocationReasonDescription(code);
-        Console.WriteLine($"Reason {code}: {description}");
+        Console.WriteLine($"Reason {(int)code}: {description}");
     }
 }

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -129,7 +129,11 @@ public sealed class CertificatesClientTests {
         var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var certificates = new CertificatesClient(client);
 
-        var request = new RevokeCertificateRequest { CertId = 5, ReasonCode = 4, Reason = "superseded" };
+        var request = new RevokeCertificateRequest {
+            CertId = 5,
+            ReasonCode = RevocationReason.Superseded,
+            Reason = "superseded"
+        };
         await certificates.RevokeAsync(request);
 
         Assert.NotNull(handler.Request);

--- a/SectigoCertificateManager.Tests/RevocationReasonTests.cs
+++ b/SectigoCertificateManager.Tests/RevocationReasonTests.cs
@@ -5,19 +5,19 @@ namespace SectigoCertificateManager.Tests;
 
 public sealed class RevocationReasonTests {
     [Theory]
-    [InlineData(0, "unspecified")]
-    [InlineData(1, "keyCompromise")]
-    [InlineData(3, "affiliationChanged")]
-    [InlineData(4, "superseded")]
-    [InlineData(5, "cessationOfOperation")]
-    public void GetRevocationReasonDescription_ReturnsExpected(int code, string expected) {
+    [InlineData(RevocationReason.Unspecified, "unspecified")]
+    [InlineData(RevocationReason.KeyCompromise, "keyCompromise")]
+    [InlineData(RevocationReason.AffiliationChanged, "affiliationChanged")]
+    [InlineData(RevocationReason.Superseded, "superseded")]
+    [InlineData(RevocationReason.CessationOfOperation, "cessationOfOperation")]
+    public void GetRevocationReasonDescription_ReturnsExpected(RevocationReason code, string expected) {
         var result = RevocationReasons.GetRevocationReasonDescription(code);
         Assert.Equal(expected, result);
     }
 
     [Fact]
     public void GetRevocationReasonDescription_Unknown_ReturnsNull() {
-        var result = RevocationReasons.GetRevocationReasonDescription(99);
+        var result = RevocationReasons.GetRevocationReasonDescription((RevocationReason)99);
         Assert.Null(result);
     }
 }

--- a/SectigoCertificateManager/Models/CertificateRevocation.cs
+++ b/SectigoCertificateManager/Models/CertificateRevocation.cs
@@ -18,7 +18,7 @@ public sealed class CertificateRevocation
     public DateTimeOffset? RevokeDate { get; set; }
 
     /// <summary>Gets or sets the revocation reason code.</summary>
-    public int ReasonCode { get; set; }
+    public RevocationReason ReasonCode { get; set; }
 
     /// <summary>Gets or sets the revocation reason message.</summary>
     public string? Reason { get; set; }

--- a/SectigoCertificateManager/Requests/RevokeCertificateRequest.cs
+++ b/SectigoCertificateManager/Requests/RevokeCertificateRequest.cs
@@ -17,7 +17,7 @@ public sealed class RevokeCertificateRequest {
     public DateTimeOffset? RevokeDate { get; set; }
 
     /// <summary>Gets or sets the revocation reason code.</summary>
-    public int ReasonCode { get; set; }
+    public RevocationReason ReasonCode { get; set; }
 
     /// <summary>Gets or sets the revocation reason message.</summary>
     public string? Reason { get; set; }

--- a/SectigoCertificateManager/RevocationReason.cs
+++ b/SectigoCertificateManager/RevocationReason.cs
@@ -1,0 +1,22 @@
+namespace SectigoCertificateManager;
+
+/// <summary>
+/// Enumerates certificate revocation reasons.
+/// </summary>
+
+public enum RevocationReason {
+    /// <summary>Unspecified reason.</summary>
+    Unspecified = 0,
+
+    /// <summary>Key compromise occurred.</summary>
+    KeyCompromise = 1,
+
+    /// <summary>Affiliation changed.</summary>
+    AffiliationChanged = 3,
+
+    /// <summary>Certificate was superseded.</summary>
+    Superseded = 4,
+
+    /// <summary>Operations ceased.</summary>
+    CessationOfOperation = 5
+}

--- a/SectigoCertificateManager/RevocationReasons.cs
+++ b/SectigoCertificateManager/RevocationReasons.cs
@@ -6,17 +6,17 @@ using System.Collections.Generic;
 /// Provides descriptions for revocation reason codes.
 /// </summary>
 public static class RevocationReasons {
-    private static readonly IReadOnlyDictionary<int, string> s_descriptions = new Dictionary<int, string> {
-        [0] = "unspecified",
-        [1] = "keyCompromise",
-        [3] = "affiliationChanged",
-        [4] = "superseded",
-        [5] = "cessationOfOperation"
+    private static readonly IReadOnlyDictionary<RevocationReason, string> s_descriptions = new Dictionary<RevocationReason, string> {
+        [RevocationReason.Unspecified] = "unspecified",
+        [RevocationReason.KeyCompromise] = "keyCompromise",
+        [RevocationReason.AffiliationChanged] = "affiliationChanged",
+        [RevocationReason.Superseded] = "superseded",
+        [RevocationReason.CessationOfOperation] = "cessationOfOperation"
     };
 
     /// <summary>Gets the description associated with a revocation reason code.</summary>
     /// <param name="code">Revocation reason code.</param>
     /// <returns>The matching description, or <c>null</c> if the code is unknown.</returns>
-    public static string? GetRevocationReasonDescription(int code) =>
+    public static string? GetRevocationReasonDescription(RevocationReason code) =>
         s_descriptions.TryGetValue(code, out var desc) ? desc : null;
 }


### PR DESCRIPTION
## Summary
- add `RevocationReason` enum
- use `RevocationReason` in revocation models and requests
- map enum values to descriptions
- update example and tests

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687e12a65250832ebd7b4926c8af3c73