### PR TITLE
Introduce BaseClient for shared options

### DIFF
--- a/SectigoCertificateManager/Clients/AdminTemplatesClient.cs
+++ b/SectigoCertificateManager/Clients/AdminTemplatesClient.cs
@@ -14,17 +14,14 @@ using SectigoCertificateManager.Utilities;
 /// <summary>
 /// Provides access to IdP template endpoints.
 /// </summary>
-public sealed class AdminTemplatesClient {
-    private readonly ISectigoClient _client;
-    private static readonly JsonSerializerOptions s_json = new() {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
+public sealed class AdminTemplatesClient : BaseClient {
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AdminTemplatesClient"/> class.
     /// </summary>
     /// <param name="client">HTTP client wrapper.</param>
-    public AdminTemplatesClient(ISectigoClient client) => _client = client;
+    public AdminTemplatesClient(ISectigoClient client) : base(client) {
+    }
 
     /// <summary>Retrieves template details by identifier.</summary>
     public async Task<IdpTemplate?> GetAsync(int templateId, CancellationToken cancellationToken = default) {

--- a/SectigoCertificateManager/Clients/BaseClient.cs
+++ b/SectigoCertificateManager/Clients/BaseClient.cs
@@ -1,0 +1,29 @@
+namespace SectigoCertificateManager.Clients;
+
+using System;
+using System.Text.Json;
+
+/// <summary>
+/// Base class for API clients.
+/// </summary>
+public abstract class BaseClient {
+    /// <summary>
+    /// HTTP client wrapper used for requests.
+    /// </summary>
+    protected readonly ISectigoClient _client;
+
+    /// <summary>
+    /// JSON options with camel case naming policy.
+    /// </summary>
+    protected static readonly JsonSerializerOptions s_json = new() {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseClient"/> class.
+    /// </summary>
+    /// <param name="client">HTTP client wrapper.</param>
+    protected BaseClient(ISectigoClient client) {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+}

--- a/SectigoCertificateManager/Clients/CertificateTypesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificateTypesClient.cs
@@ -9,17 +9,14 @@ using SectigoCertificateManager.Utilities;
 /// <summary>
 /// Provides access to certificate type information.
 /// </summary>
-public sealed class CertificateTypesClient {
-    private readonly ISectigoClient _client;
-    private static readonly JsonSerializerOptions s_json = new() {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
+public sealed class CertificateTypesClient : BaseClient {
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CertificateTypesClient"/> class.
     /// </summary>
     /// <param name="client">HTTP client wrapper.</param>
-    public CertificateTypesClient(ISectigoClient client) => _client = client;
+    public CertificateTypesClient(ISectigoClient client) : base(client) {
+    }
 
     /// <summary>
     /// Retrieves available certificate types.

--- a/SectigoCertificateManager/Clients/CertificatesClient.Core.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Core.cs
@@ -15,17 +15,14 @@ using SectigoCertificateManager.Utilities;
 /// <summary>
 /// Provides access to certificate related endpoints.
 /// </summary>
-public sealed partial class CertificatesClient {
-    private readonly ISectigoClient _client;
-    private static readonly JsonSerializerOptions s_json = new() {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
+public sealed partial class CertificatesClient : BaseClient {
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CertificatesClient"/> class.
     /// </summary>
     /// <param name="client">HTTP client wrapper.</param>
-    public CertificatesClient(ISectigoClient client) => _client = client;
+    public CertificatesClient(ISectigoClient client) : base(client) {
+    }
 
     /// <summary>
     /// Retrieves a certificate by identifier.

--- a/SectigoCertificateManager/Clients/CertificatesClient.Download.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Download.cs
@@ -5,7 +5,7 @@ using SectigoCertificateManager.Utilities;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 
-public sealed partial class CertificatesClient {
+public sealed partial class CertificatesClient : BaseClient {
     /// <summary>
     /// Downloads an issued certificate and returns an <see cref="X509Certificate2"/> instance.
     /// </summary>

--- a/SectigoCertificateManager/Clients/CertificatesClient.Search.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Search.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using SectigoCertificateManager.Utilities;
 
-public sealed partial class CertificatesClient {
+public sealed partial class CertificatesClient : BaseClient {
     /// <summary>
     /// Searches for certificates using the provided filter.
     /// </summary>

--- a/SectigoCertificateManager/Clients/CustomFieldsClient.cs
+++ b/SectigoCertificateManager/Clients/CustomFieldsClient.cs
@@ -9,17 +9,14 @@ using System.Text.Json;
 /// <summary>
 /// Provides access to custom field endpoints.
 /// </summary>
-public sealed class CustomFieldsClient {
-    private readonly ISectigoClient _client;
-    private static readonly JsonSerializerOptions s_json = new() {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
+public sealed class CustomFieldsClient : BaseClient {
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CustomFieldsClient"/> class.
     /// </summary>
     /// <param name="client">HTTP client wrapper.</param>
-    public CustomFieldsClient(ISectigoClient client) => _client = client;
+    public CustomFieldsClient(ISectigoClient client) : base(client) {
+    }
 
     /// <summary>
     /// Creates a new custom field.

--- a/SectigoCertificateManager/Clients/InventoryClient.cs
+++ b/SectigoCertificateManager/Clients/InventoryClient.cs
@@ -7,14 +7,14 @@ using System.Text;
 /// <summary>
 /// Provides access to inventory related endpoints.
 /// </summary>
-public sealed class InventoryClient {
-    private readonly ISectigoClient _client;
+public sealed class InventoryClient : BaseClient {
 
     /// <summary>
     /// Initializes a new instance of the <see cref="InventoryClient"/> class.
     /// </summary>
     /// <param name="client">HTTP client wrapper.</param>
-    public InventoryClient(ISectigoClient client) => _client = client;
+    public InventoryClient(ISectigoClient client) : base(client) {
+    }
 
     /// <summary>
     /// Downloads certificate inventory in CSV format.

--- a/SectigoCertificateManager/Clients/OrderStatusClient.cs
+++ b/SectigoCertificateManager/Clients/OrderStatusClient.cs
@@ -7,17 +7,14 @@ using SectigoCertificateManager.Utilities;
 /// <summary>
 /// Provides access to order status information.
 /// </summary>
-public sealed class OrderStatusClient {
-    private readonly ISectigoClient _client;
-    private static readonly JsonSerializerOptions s_json = new() {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
+public sealed class OrderStatusClient : BaseClient {
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrderStatusClient"/> class.
     /// </summary>
     /// <param name="client">HTTP client wrapper.</param>
-    public OrderStatusClient(ISectigoClient client) => _client = client;
+    public OrderStatusClient(ISectigoClient client) : base(client) {
+    }
 
     /// <summary>
     /// Retrieves the status of an order by identifier.

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -11,17 +11,14 @@ using System.Text.Json;
 /// <summary>
 /// Provides access to order related endpoints.
 /// </summary>
-public sealed class OrdersClient {
-    private readonly ISectigoClient _client;
-    private static readonly JsonSerializerOptions s_json = new() {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
+public sealed class OrdersClient : BaseClient {
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrdersClient"/> class.
     /// </summary>
     /// <param name="client">HTTP client wrapper.</param>
-    public OrdersClient(ISectigoClient client) => _client = client;
+    public OrdersClient(ISectigoClient client) : base(client) {
+    }
 
     /// <summary>
     /// Retrieves an order by identifier.

--- a/SectigoCertificateManager/Clients/OrganizationsClient.cs
+++ b/SectigoCertificateManager/Clients/OrganizationsClient.cs
@@ -10,17 +10,14 @@ using SectigoCertificateManager.Utilities;
 /// <summary>
 /// Provides access to organization related endpoints.
 /// </summary>
-public sealed class OrganizationsClient {
-    private readonly ISectigoClient _client;
-    private static readonly JsonSerializerOptions s_json = new() {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
+public sealed class OrganizationsClient : BaseClient {
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrganizationsClient"/> class.
     /// </summary>
     /// <param name="client">HTTP client wrapper.</param>
-    public OrganizationsClient(ISectigoClient client) => _client = client;
+    public OrganizationsClient(ISectigoClient client) : base(client) {
+    }
 
     /// <summary>
     /// Retrieves an organization by identifier.

--- a/SectigoCertificateManager/Clients/ProfilesClient.cs
+++ b/SectigoCertificateManager/Clients/ProfilesClient.cs
@@ -8,17 +8,14 @@ using System.Text.Json;
 /// <summary>
 /// Provides access to profile related endpoints.
 /// </summary>
-public sealed class ProfilesClient {
-    private readonly ISectigoClient _client;
-    private static readonly JsonSerializerOptions s_json = new() {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
+public sealed class ProfilesClient : BaseClient {
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProfilesClient"/> class.
     /// </summary>
     /// <param name="client">HTTP client wrapper.</param>
-    public ProfilesClient(ISectigoClient client) => _client = client;
+    public ProfilesClient(ISectigoClient client) : base(client) {
+    }
 
     /// <summary>
     /// Retrieves a profile by identifier.

--- a/SectigoCertificateManager/Clients/UsersClient.cs
+++ b/SectigoCertificateManager/Clients/UsersClient.cs
@@ -10,17 +10,14 @@ using SectigoCertificateManager.Utilities;
 /// <summary>
 /// Provides access to user related endpoints.
 /// </summary>
-public sealed class UsersClient {
-    private readonly ISectigoClient _client;
-    private static readonly JsonSerializerOptions s_json = new() {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
+public sealed class UsersClient : BaseClient {
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UsersClient"/> class.
     /// </summary>
     /// <param name="client">HTTP client wrapper.</param>
-    public UsersClient(ISectigoClient client) => _client = client;
+    public UsersClient(ISectigoClient client) : base(client) {
+    }
 
     /// <summary>
     /// Retrieves a user by identifier.


### PR DESCRIPTION
## Summary
- create `BaseClient` with shared constructor and JSON options
- derive all client classes from `BaseClient`
- update constructors accordingly

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687e128fa1d0832e8829b0beb308180e