### PR TITLE
Add Guard helper and replace validations

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/GuardExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/GuardExample.cs
@@ -1,0 +1,18 @@
+using SectigoCertificateManager.Utilities;
+using System;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates basic usage of <see cref="Guard"/> helpers.
+/// </summary>
+public static class GuardExample {
+    /// <summary>Executes the example.</summary>
+    public static void Run() {
+        try {
+            Guard.AgainstNull<string>(null, "value");
+        } catch (ArgumentNullException ex) {
+            Console.WriteLine($"Caught {ex.GetType().Name} for {ex.ParamName}");
+        }
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -13,3 +13,4 @@ await UpsertCertificateTypeExample.RunAsync();
 await WatchOrdersExample.RunAsync();
 CsrGeneratorExample.Run();
 HttpClientPropertyExample.Run();
+GuardExample.Run();

--- a/SectigoCertificateManager.Tests/GuardTests.cs
+++ b/SectigoCertificateManager.Tests/GuardTests.cs
@@ -1,0 +1,49 @@
+using SectigoCertificateManager.Utilities;
+using System;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="Guard"/> helpers.
+/// </summary>
+public sealed class GuardTests {
+    [Fact]
+    public void AgainstNull_ThrowsForNull() {
+        var ex = Assert.Throws<ArgumentNullException>(() => Guard.AgainstNull<string>(null, "value"));
+        Assert.Equal("value", ex.ParamName);
+    }
+
+    [Fact]
+    public void AgainstNull_ReturnsValue() {
+        var result = Guard.AgainstNull("test", "value");
+        Assert.Equal("test", result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void AgainstNullOrEmpty_Throws(string? input) {
+        Assert.Throws<ArgumentException>(() => Guard.AgainstNullOrEmpty(input, "value"));
+    }
+
+    [Fact]
+    public void AgainstNullOrEmpty_ReturnsValue() {
+        var result = Guard.AgainstNullOrEmpty("ok", "value");
+        Assert.Equal("ok", result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" \t\n")]
+    public void AgainstNullOrWhiteSpace_Throws(string? input) {
+        Assert.Throws<ArgumentException>(() => Guard.AgainstNullOrWhiteSpace(input, "value"));
+    }
+
+    [Fact]
+    public void AgainstNullOrWhiteSpace_ReturnsValue() {
+        var result = Guard.AgainstNullOrWhiteSpace("good", "value");
+        Assert.Equal("good", result);
+    }
+}

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using SectigoCertificateManager.Utilities;
 
 /// <summary>
 /// Provides a builder for creating instances of <see cref="ApiConfig"/> using a fluent API.
@@ -37,13 +38,8 @@ public sealed class ApiConfigBuilder {
     /// <param name="username">User name for API authentication.</param>
     /// <param name="password">Password associated with <paramref name="username"/>.</param>
     public ApiConfigBuilder WithCredentials(string username, string password) {
-        if (string.IsNullOrWhiteSpace(username)) {
-            throw new ArgumentException("Username must not be null or empty.", nameof(username));
-        }
-
-        if (string.IsNullOrWhiteSpace(password)) {
-            throw new ArgumentException("Password must not be null or empty.", nameof(password));
-        }
+        Guard.AgainstNullOrWhiteSpace(username, nameof(username), "Username must not be null or empty.");
+        Guard.AgainstNullOrWhiteSpace(password, nameof(password), "Password must not be null or empty.");
 
         _username = username;
         _password = password;
@@ -119,7 +115,7 @@ public sealed class ApiConfigBuilder {
     /// <summary>Allows configuration of the <see cref="HttpClientHandler"/> used by <see cref="SectigoClient"/>.</summary>
     /// <param name="configure">Delegate used to configure the handler.</param>
     public ApiConfigBuilder WithHttpClientHandler(Action<HttpClientHandler> configure) {
-        _configureHandler = configure ?? throw new ArgumentNullException(nameof(configure));
+        _configureHandler = Guard.AgainstNull(configure, nameof(configure));
         return this;
     }
 
@@ -136,9 +132,7 @@ public sealed class ApiConfigBuilder {
 
     /// <summary>Builds a new <see cref="ApiConfig"/> instance using configured values.</summary>
     public ApiConfig Build() {
-        if (string.IsNullOrWhiteSpace(_baseUrl)) {
-            throw new ArgumentException("Base URL is required.", "baseUrl");
-        }
+        Guard.AgainstNullOrWhiteSpace(_baseUrl, "baseUrl", "Base URL is required.");
 
         var hasToken = !string.IsNullOrWhiteSpace(_token);
         var hasCredentials = !string.IsNullOrWhiteSpace(_username) && !string.IsNullOrWhiteSpace(_password);
@@ -148,18 +142,11 @@ public sealed class ApiConfigBuilder {
         }
 
         if (!hasToken) {
-            if (string.IsNullOrWhiteSpace(_username)) {
-                throw new ArgumentException("User name is required.", "username");
-            }
-
-            if (string.IsNullOrWhiteSpace(_password)) {
-                throw new ArgumentException("Password is required.", "password");
-            }
+            Guard.AgainstNullOrWhiteSpace(_username, "username", "User name is required.");
+            Guard.AgainstNullOrWhiteSpace(_password, "password", "Password is required.");
         }
 
-        if (string.IsNullOrWhiteSpace(_customerUri)) {
-            throw new ArgumentException("Customer URI is required.", "customerUri");
-        }
+        Guard.AgainstNullOrWhiteSpace(_customerUri, "customerUri", "Customer URI is required.");
 
         return new ApiConfig(
             _baseUrl,

--- a/SectigoCertificateManager/Clients/AdminTemplatesClient.cs
+++ b/SectigoCertificateManager/Clients/AdminTemplatesClient.cs
@@ -72,9 +72,7 @@ public sealed class AdminTemplatesClient : BaseClient {
 
     /// <summary>Creates a new template.</summary>
     public async Task<int> CreateAsync(CreateIdpTemplateRequest request, CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var response = await _client.PostAsync("admin-template/v1/", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         var location = response.Headers.Location;
@@ -94,9 +92,7 @@ public sealed class AdminTemplatesClient : BaseClient {
         if (templateId <= 0) {
             throw new ArgumentOutOfRangeException(nameof(templateId));
         }
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var response = await _client.PutAsync($"admin-template/v1/{templateId}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();

--- a/SectigoCertificateManager/Clients/BaseClient.cs
+++ b/SectigoCertificateManager/Clients/BaseClient.cs
@@ -2,6 +2,7 @@ namespace SectigoCertificateManager.Clients;
 
 using System;
 using System.Text.Json;
+using SectigoCertificateManager.Utilities;
 
 /// <summary>
 /// Base class for API clients.
@@ -24,6 +25,6 @@ public abstract class BaseClient {
     /// </summary>
     /// <param name="client">HTTP client wrapper.</param>
     protected BaseClient(ISectigoClient client) {
-        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _client = Guard.AgainstNull(client, nameof(client));
     }
 }

--- a/SectigoCertificateManager/Clients/CertificateTypesClient.cs
+++ b/SectigoCertificateManager/Clients/CertificateTypesClient.cs
@@ -46,9 +46,7 @@ public sealed class CertificateTypesClient : BaseClient {
     public async Task<CertificateType?> UpsertAsync(
         CertificateType type,
         CancellationToken cancellationToken = default) {
-        if (type is null) {
-            throw new ArgumentNullException(nameof(type));
-        }
+        Guard.AgainstNull(type, nameof(type));
 
         var content = JsonContent.Create(type, options: s_json);
         HttpResponseMessage response;

--- a/SectigoCertificateManager/Clients/CertificatesClient.Core.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Core.cs
@@ -79,9 +79,7 @@ public sealed partial class CertificatesClient : BaseClient {
     /// <param name="request">Payload describing the certificate to issue.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task<Certificate?> IssueAsync(IssueCertificateRequest request, CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         if (request.Term <= 0) {
             throw new ArgumentOutOfRangeException(nameof(request.Term));
@@ -99,9 +97,7 @@ public sealed partial class CertificatesClient : BaseClient {
     /// <param name="request">Payload describing the certificate to revoke.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task RevokeAsync(RevokeCertificateRequest request, CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var response = await _client.PostAsync("v1/certificate/revoke", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
@@ -115,9 +111,7 @@ public sealed partial class CertificatesClient : BaseClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>The identifier of the newly issued certificate.</returns>
     public async Task<int> RenewAsync(int certificateId, RenewCertificateRequest request, CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var response = await _client.PostAsync($"v1/certificate/renewById/{certificateId}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         var result = await response.Content
@@ -134,9 +128,7 @@ public sealed partial class CertificatesClient : BaseClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>The identifier of the newly issued certificate.</returns>
     public async Task<int> RenewByOrderNumberAsync(long orderNumber, RenewCertificateRequest request, CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var response = await _client.PostAsync($"v1/certificate/renew/{orderNumber}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         var result = await response.Content
@@ -167,9 +159,7 @@ public sealed partial class CertificatesClient : BaseClient {
     public async Task<ValidateCertificateResponse?> ValidateCertificateRequestAsync(
         ValidateCertificateRequest request,
         CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var response = await _client
             .PostAsync("v1/certificate/validate", JsonContent.Create(request, options: s_json), cancellationToken)
@@ -194,12 +184,8 @@ public sealed partial class CertificatesClient : BaseClient {
         if (orgId <= 0) {
             throw new ArgumentOutOfRangeException(nameof(orgId));
         }
-        if (stream is null) {
-            throw new ArgumentNullException(nameof(stream));
-        }
-        if (string.IsNullOrEmpty(fileName)) {
-            throw new ArgumentException("File name cannot be null or empty.", nameof(fileName));
-        }
+        Guard.AgainstNull(stream, nameof(stream));
+        Guard.AgainstNullOrEmpty(fileName, nameof(fileName), "File name cannot be null or empty.");
 
         var content = new MultipartFormDataContent();
         var fileContent = new StreamContent(stream);

--- a/SectigoCertificateManager/Clients/CertificatesClient.Search.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Search.cs
@@ -16,9 +16,7 @@ public sealed partial class CertificatesClient : BaseClient {
     public async Task<CertificateResponse?> SearchAsync(
         CertificateSearchRequest request,
         CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var list = new List<Certificate>();
         await foreach (var certificate in EnumerateSearchAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false)) {
@@ -60,9 +58,7 @@ public sealed partial class CertificatesClient : BaseClient {
     public async IAsyncEnumerable<X509Certificate2> StreamCertificatesAsync(
         CertificateSearchRequest request,
         [EnumeratorCancellation] CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         await foreach (var certificate in EnumerateSearchAsync(request, cancellationToken).ConfigureAwait(false)) {
             yield return await DownloadAsync(certificate.Id, cancellationToken).ConfigureAwait(false);
@@ -77,9 +73,7 @@ public sealed partial class CertificatesClient : BaseClient {
     public async IAsyncEnumerable<Certificate> EnumerateSearchAsync(
         CertificateSearchRequest request,
         [EnumeratorCancellation] CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var originalSize = request.Size;
         var originalPosition = request.Position;

--- a/SectigoCertificateManager/Clients/CustomFieldsClient.cs
+++ b/SectigoCertificateManager/Clients/CustomFieldsClient.cs
@@ -26,9 +26,7 @@ public sealed class CustomFieldsClient : BaseClient {
     public async Task<CustomField?> CreateAsync(
         CreateCustomFieldRequest request,
         CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var response = await _client.PostAsync(
             "v1/customfield",
@@ -48,9 +46,7 @@ public sealed class CustomFieldsClient : BaseClient {
     public async Task<CustomField?> UpdateAsync(
         UpdateCustomFieldRequest request,
         CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
         if (request.Id <= 0) {
             throw new ArgumentOutOfRangeException(nameof(request.Id));
         }

--- a/SectigoCertificateManager/Clients/InventoryClient.cs
+++ b/SectigoCertificateManager/Clients/InventoryClient.cs
@@ -2,6 +2,7 @@ namespace SectigoCertificateManager.Clients;
 
 using SectigoCertificateManager.Models;
 using SectigoCertificateManager.Requests;
+using SectigoCertificateManager.Utilities;
 using System.Text;
 
 /// <summary>
@@ -24,9 +25,7 @@ public sealed class InventoryClient : BaseClient {
     public async Task<IReadOnlyList<InventoryRecord>> DownloadCsvAsync(
         InventoryCsvRequest request,
         CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var query = BuildQuery(request);
         var response = await _client

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -94,12 +94,8 @@ public sealed class OrdersClient : BaseClient {
         string contentType,
         IProgress<double>? progress = null,
         CancellationToken cancellationToken = default) {
-        if (stream is null) {
-            throw new ArgumentNullException(nameof(stream));
-        }
-        if (string.IsNullOrEmpty(contentType)) {
-            throw new ArgumentException("Content type cannot be null or empty.", nameof(contentType));
-        }
+        Guard.AgainstNull(stream, nameof(stream));
+        Guard.AgainstNullOrEmpty(contentType, nameof(contentType), "Content type cannot be null or empty.");
 
         using var content = new Utilities.ProgressStreamContent(stream, progress);
         content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);

--- a/SectigoCertificateManager/Clients/OrganizationsClient.cs
+++ b/SectigoCertificateManager/Clients/OrganizationsClient.cs
@@ -38,9 +38,7 @@ public sealed class OrganizationsClient : BaseClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>The identifier of the created organization.</returns>
     public async Task<int> CreateAsync(CreateOrganizationRequest request, CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var response = await _client
             .PostAsync("v1/organization", JsonContent.Create(request, options: s_json), cancellationToken)
@@ -68,9 +66,7 @@ public sealed class OrganizationsClient : BaseClient {
         if (organizationId <= 0) {
             throw new ArgumentOutOfRangeException(nameof(organizationId));
         }
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var response = await _client
             .PutAsync($"v1/organization/{organizationId}", JsonContent.Create(request, options: s_json), cancellationToken)
@@ -84,9 +80,7 @@ public sealed class OrganizationsClient : BaseClient {
     /// <param name="request">Payload describing updated fields including identifier.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public Task UpdateAsync(UpdateOrganizationRequest request, CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
         if (request.Id <= 0) {
             throw new ArgumentOutOfRangeException(nameof(request.Id));
         }

--- a/SectigoCertificateManager/Clients/UsersClient.cs
+++ b/SectigoCertificateManager/Clients/UsersClient.cs
@@ -91,9 +91,7 @@ public sealed class UsersClient : BaseClient {
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
     /// <returns>The identifier of the created user.</returns>
     public async Task<int> CreateAsync(CreateUserRequest request, CancellationToken cancellationToken = default) {
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var response = await _client.PostAsync("v1/user", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         var location = response.Headers.Location;
@@ -118,9 +116,7 @@ public sealed class UsersClient : BaseClient {
         if (userId <= 0) {
             throw new ArgumentOutOfRangeException(nameof(userId));
         }
-        if (request is null) {
-            throw new ArgumentNullException(nameof(request));
-        }
+        Guard.AgainstNull(request, nameof(request));
 
         var response = await _client.PutAsync($"v1/user/{userId}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();

--- a/SectigoCertificateManager/Models/Certificate.cs
+++ b/SectigoCertificateManager/Models/Certificate.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using SectigoCertificateManager.Utilities;
 
 /// <summary>
 /// Represents a certificate returned by the Sectigo API.
@@ -103,9 +104,7 @@ public sealed class Certificate {
     /// <param name="stream">Stream providing base64 encoded certificate bytes.</param>
     /// <param name="progress">Optional progress reporter.</param>
     public static X509Certificate2 FromBase64(Stream stream, IProgress<double>? progress = null) {
-        if (stream is null) {
-            throw new ArgumentNullException(nameof(stream));
-        }
+        Guard.AgainstNull(stream, nameof(stream));
 
         if (stream.CanSeek) {
             stream.Seek(0, SeekOrigin.Begin);

--- a/SectigoCertificateManager/Requests/IssueCertificateRequestBuilder.cs
+++ b/SectigoCertificateManager/Requests/IssueCertificateRequestBuilder.cs
@@ -3,6 +3,7 @@ namespace SectigoCertificateManager.Requests;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using SectigoCertificateManager.Utilities;
 
 /// <summary>
 /// Builds <see cref="IssueCertificateRequest"/> instances using a fluent API.
@@ -16,7 +17,7 @@ public sealed class IssueCertificateRequestBuilder {
     /// </summary>
     /// <param name="allowedTerms">List of allowed certificate terms.</param>
     public IssueCertificateRequestBuilder(IReadOnlyList<int> allowedTerms) {
-        _allowedTerms = allowedTerms ?? throw new ArgumentNullException(nameof(allowedTerms));
+        _allowedTerms = Guard.AgainstNull(allowedTerms, nameof(allowedTerms));
     }
 
     /// <summary>Sets the certificate common name.</summary>

--- a/SectigoCertificateManager/Requests/RenewCertificateRequest.cs
+++ b/SectigoCertificateManager/Requests/RenewCertificateRequest.cs
@@ -2,6 +2,7 @@ namespace SectigoCertificateManager.Requests;
 
 using System.IO;
 using System.Text;
+using SectigoCertificateManager.Utilities;
 
 /// <summary>
 /// Request payload used to renew a certificate.
@@ -22,9 +23,7 @@ public sealed class RenewCertificateRequest {
     /// <param name="stream">Stream providing CSR bytes.</param>
     /// <param name="progress">Optional progress reporter.</param>
     public void SetCsr(Stream stream, IProgress<double>? progress = null) {
-        if (stream is null) {
-            throw new ArgumentNullException(nameof(stream));
-        }
+        Guard.AgainstNull(stream, nameof(stream));
 
         using var reader = new StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
         var builder = new StringBuilder();

--- a/SectigoCertificateManager/Utilities/CertificateExport.cs
+++ b/SectigoCertificateManager/Utilities/CertificateExport.cs
@@ -29,9 +29,7 @@ public static class CertificateExport {
     /// <param name="certificate">Certificate to export.</param>
     /// <param name="path">Destination file path.</param>
     public static void SaveDer(X509Certificate2 certificate, string path) {
-        if (string.IsNullOrEmpty(path)) {
-            throw new ArgumentException("Path cannot be null or empty.", nameof(path));
-        }
+        Guard.AgainstNullOrEmpty(path, nameof(path), "Path cannot be null or empty.");
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         File.WriteAllBytes(path, certificate.Export(X509ContentType.Cert));
     }
@@ -41,9 +39,7 @@ public static class CertificateExport {
     /// <param name="path">Destination file path.</param>
     /// <param name="password">Optional password protecting the PFX.</param>
     public static void SavePfx(X509Certificate2 certificate, string path, string? password = null) {
-        if (string.IsNullOrEmpty(path)) {
-            throw new ArgumentException("Path cannot be null or empty.", nameof(path));
-        }
+        Guard.AgainstNullOrEmpty(path, nameof(path), "Path cannot be null or empty.");
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         var bytes = password is null
             ? certificate.Export(X509ContentType.Pfx)

--- a/SectigoCertificateManager/Utilities/CsrGenerator.cs
+++ b/SectigoCertificateManager/Utilities/CsrGenerator.cs
@@ -31,9 +31,7 @@ public static class CsrGenerator {
         string subjectName,
         int keySize = 2048,
         HashAlgorithmName? hashAlgorithm = null) {
-        if (string.IsNullOrWhiteSpace(subjectName)) {
-            throw new ArgumentException("Value cannot be null or empty.", nameof(subjectName));
-        }
+        Guard.AgainstNullOrWhiteSpace(subjectName, nameof(subjectName));
         var rsa = RSA.Create(keySize);
         var request = CreateRequest(subjectName, rsa, hashAlgorithm ?? HashAlgorithmName.SHA256);
         var csr = Convert.ToBase64String(request.CreateSigningRequest());
@@ -44,9 +42,7 @@ public static class CsrGenerator {
         string subjectName,
         ECCurve? curve = null,
         HashAlgorithmName? hashAlgorithm = null) {
-        if (string.IsNullOrWhiteSpace(subjectName)) {
-            throw new ArgumentException("Value cannot be null or empty.", nameof(subjectName));
-        }
+        Guard.AgainstNullOrWhiteSpace(subjectName, nameof(subjectName));
         var ecdsa = ECDsa.Create(curve ?? ECCurve.NamedCurves.nistP256);
         var request = CreateRequest(subjectName, ecdsa, hashAlgorithm ?? HashAlgorithmName.SHA256);
         var csr = Convert.ToBase64String(request.CreateSigningRequest());

--- a/SectigoCertificateManager/Utilities/Guard.cs
+++ b/SectigoCertificateManager/Utilities/Guard.cs
@@ -1,0 +1,35 @@
+namespace SectigoCertificateManager.Utilities;
+
+using System;
+
+/// <summary>
+/// Provides helper methods for validating arguments.
+/// </summary>
+public static class Guard {
+    /// <summary>Throws <see cref="ArgumentNullException"/> when the value is null.</summary>
+    public static T AgainstNull<T>(T? value, string paramName, string? message = null) where T : class {
+        if (value is null) {
+            throw new ArgumentNullException(paramName, message);
+        }
+
+        return value;
+    }
+
+    /// <summary>Throws <see cref="ArgumentException"/> when the string is null or empty.</summary>
+    public static string AgainstNullOrEmpty(string? value, string paramName, string? message = null) {
+        if (string.IsNullOrEmpty(value)) {
+            throw new ArgumentException(message ?? "Value cannot be null or empty.", paramName);
+        }
+
+        return value;
+    }
+
+    /// <summary>Throws <see cref="ArgumentException"/> when the string is null or consists only of whitespace.</summary>
+    public static string AgainstNullOrWhiteSpace(string? value, string paramName, string? message = null) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            throw new ArgumentException(message ?? "Value cannot be null or empty.", paramName);
+        }
+
+        return value;
+    }
+}

--- a/SectigoCertificateManager/Utilities/ProgressStreamContent.cs
+++ b/SectigoCertificateManager/Utilities/ProgressStreamContent.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using SectigoCertificateManager.Utilities;
 
 /// <summary>
 /// Provides an <see cref="HttpContent"/> implementation that reports upload progress.
@@ -21,7 +22,7 @@ internal sealed class ProgressStreamContent : HttpContent {
     /// <param name="progress">Optional progress reporter.</param>
     /// <param name="bufferSize">Buffer size used when reading the stream.</param>
     public ProgressStreamContent(Stream stream, IProgress<double>? progress = null, int bufferSize = 81920) {
-        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _stream = Guard.AgainstNull(stream, nameof(stream));
         _progress = progress;
         _bufferSize = bufferSize;
     }

--- a/SectigoCertificateManager/Utilities/X509Certificate2Extensions.cs
+++ b/SectigoCertificateManager/Utilities/X509Certificate2Extensions.cs
@@ -19,10 +19,7 @@ public static class X509Certificate2Extensions
     /// <summary>Gets AuthorityInfoAccess data from the certificate.</summary>
     public static AuthorityInfoAccess GetAuthorityInfoAccess(this X509Certificate2 certificate)
     {
-        if (certificate is null)
-        {
-            throw new ArgumentNullException(nameof(certificate));
-        }
+        Guard.AgainstNull(certificate, nameof(certificate));
 #if NET8_0_OR_GREATER
         if (certificate.Extensions[AuthorityInfoAccessOid] is X509AuthorityInformationAccessExtension aia)
         {


### PR DESCRIPTION
## Summary
- add `Guard` helper for argument validation
- use `Guard` across clients and utilities
- provide a Guard usage example
- test Guard behavior

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687e5e1aa35c832e90f5c47db48a269f