### PR TITLE
Add Get-SectigoToken cmdlet

### DIFF
--- a/Module/SectigoCertificateManager.psd1
+++ b/Module/SectigoCertificateManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Get-SectigoCertificate', 'Get-SectigoOrders', 'Get-SectigoOrganizations', 'Get-SectigoProfile', 'Get-SectigoProfiles', 'New-SectigoOrder', 'Stop-SectigoOrder', 'Update-SectigoCertificate', 'Remove-SectigoCertificate', 'Wait-SectigoOrder')
+    CmdletsToExport      = @('Get-SectigoCertificate', 'Get-SectigoOrders', 'Get-SectigoOrganizations', 'Get-SectigoProfile', 'Get-SectigoProfiles', 'Get-SectigoToken', 'New-SectigoOrder', 'Stop-SectigoOrder', 'Update-SectigoCertificate', 'Remove-SectigoCertificate', 'Wait-SectigoOrder')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/Tests/GetSectigoTokenCommand.Tests.ps1
+++ b/Module/Tests/GetSectigoTokenCommand.Tests.ps1
@@ -1,0 +1,7 @@
+Describe 'Get-SectigoToken behavior' -Tag 'Cmdlet' {
+    It 'Returns nothing when token file is missing' {
+        $temp = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.Guid]::NewGuid().ToString(), 'missing.json')
+        $result = Get-SectigoToken -Path $temp
+        $result | Should -BeNullOrEmpty
+    }
+}

--- a/SectigoCertificateManager.PowerShell/Examples/GetTokenCacheExample.ps1
+++ b/SectigoCertificateManager.PowerShell/Examples/GetTokenCacheExample.ps1
@@ -1,0 +1,2 @@
+# Demonstrates reading cached token information.
+Get-SectigoToken -Path "$HOME/.sectigo/token.json"

--- a/SectigoCertificateManager.PowerShell/GetSectigoTokenCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoTokenCommand.cs
@@ -1,0 +1,23 @@
+using SectigoCertificateManager;
+using System.Management.Automation;
+
+namespace SectigoCertificateManager.PowerShell;
+
+/// <summary>Retrieves cached token information.</summary>
+/// <para>Reads the token cache using <see cref="ApiConfigLoader"/>.</para>
+[Cmdlet(VerbsCommon.Get, "SectigoToken")]
+[CmdletBinding()]
+[OutputType(typeof(TokenInfo))]
+public sealed class GetSectigoTokenCommand : PSCmdlet {
+    /// <summary>Optional path to the token file.</summary>
+    [Parameter]
+    public string? Path { get; set; }
+
+    /// <summary>Reads the token cache.</summary>
+    protected override void ProcessRecord() {
+        var info = ApiConfigLoader.ReadToken(Path);
+        if (info is not null) {
+            WriteObject(info);
+        }
+    }
+}

--- a/SectigoCertificateManager.Tests/Pester/GetSectigoTokenCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/GetSectigoTokenCommand.Tests.ps1
@@ -1,0 +1,23 @@
+Describe "Get-SectigoToken" {
+    BeforeAll {
+        dotnet build "$PSScriptRoot/../../SectigoCertificateManager.PowerShell" -c Release | Out-Null
+        $dll = Join-Path $PSScriptRoot '../../SectigoCertificateManager.PowerShell/bin/Release/net8.0/SectigoCertificateManager.PowerShell.dll'
+        Import-Module $dll
+    }
+
+    It "exports the cmdlet" {
+        $cmd = Get-Command Get-SectigoToken -ErrorAction Stop
+        $cmd | Should -Not -BeNullOrEmpty
+    }
+
+    It "reads a token file" {
+        $tempDir = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.Guid]::NewGuid().ToString())
+        [System.IO.Directory]::CreateDirectory($tempDir) | Out-Null
+        $path = [System.IO.Path]::Combine($tempDir, 'token.json')
+        $info = [SectigoCertificateManager.TokenInfo]::new('tok', [System.DateTimeOffset]::UtcNow.AddMinutes(5))
+        [SectigoCertificateManager.ApiConfigLoader]::WriteToken($info, $path)
+        $result = Get-SectigoToken -Path $path
+        $result.Token | Should -Be 'tok'
+        Remove-Item -Path $tempDir -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary
- add `Get-SectigoToken` cmdlet to read token cache
- update module manifest to export new cmdlet
- add PowerShell example for token cache
- test `Get-SectigoToken` behaviour
- verify cmdlet export via Pester

## Testing
- `dotnet test SectigoCertificateManager.sln`
- `pwsh ./Module/SectigoCertificateManager.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_687ea7d526e0832eb08103cedc9ef301