### PR TITLE
Adjust download buffer size

### DIFF
--- a/SectigoCertificateManager/Clients/CertificatesClient.Download.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Download.cs
@@ -57,7 +57,7 @@ public sealed partial class CertificatesClient : BaseClient {
         using (stream) {
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             using var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
-            var buffer = new byte[81920];
+            var buffer = new byte[65536];
             long total = response.Content.Headers.ContentLength ?? (stream.CanSeek ? stream.Length : -1);
             long copied = 0;
             int count;


### PR DESCRIPTION
## Summary
- tweak buffer in `CertificatesClient.DownloadAsync` after benchmarking

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687ea7f83470832e87daa17f7858bed4