### PR TITLE
Improve performance using ArrayPool and benchmarks

### DIFF
--- a/SectigoCertificateManager.Benchmarks/CertificateFromBase64Benchmark.cs
+++ b/SectigoCertificateManager.Benchmarks/CertificateFromBase64Benchmark.cs
@@ -1,0 +1,26 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using SectigoCertificateManager.Models;
+using System.IO;
+using System.Text;
+
+namespace SectigoCertificateManager.Benchmarks;
+
+[MemoryDiagnoser]
+public class CertificateFromBase64Benchmark {
+    private byte[] _data = Encoding.ASCII.GetBytes(Base64Cert);
+
+    private const string Base64Cert = "MIIC/zCCAeegAwIBAgIULTQw6ATwfRI/1hVSQooJNHPEit8wDQYJKoZIhvcNAQELBQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yNTA3MDQxMzE2NDRaFw0yNTA3MDUxMzE2NDRaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDiO8kIwsJLCi3d8bX31IIISKSoA24iCcfV7m+uMm8CMdJlY2NGf8ThiF3suG2lHQCxESQacUrPFMN/J3cM7L+5R8p24CCnrmAP2WhMuO2IwFhgfjo4PsmnmCGNx5fDAPI+lnSS6pnHfZfAPw3dbPT2/cgbeil0q2ByFR6C2YXU+mFdOg7cJJ1f2GXbUL3QYRBuaDYCHRrDAym4e/8DkKjjaroDxw1BPD6sjvzrDdEDusJANDCp8K6Cr99nvG+YCLjueN+xvUXHbsp9gUfLI39X73p+M9zGcYGAeYyD/i+VM/+Kde5CEfS34eOKfRIJX6DHAbVu1SrJPNFFvQV0keb/AgMBAAGjUzBRMB0GA1UdDgQWBBQ8PwJEkQsHvU7i5i45XLLyJUi4eTAfBgNVHSMEGDAWgBQ8PwJEkQsHvU7i5i45XLLyJUi4eTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAjWADB2IC5xBHKOROcXZDa8mp3DaasUwL5mWjG7Ppr4LHrY1uCEojstJCg6s2FLBjGTs+0DTQ5UiBqSVJDK1GVhYG02xJSPoXNS4wNTp4a56NtbkDT96lO0BrH91lclMNXHU9NpMUFea0tt7h5tUeVtZ2CVK0nuy5MOifMdURVyhWsFgQVemmTNTYisVD5sNRvBJEq0M+3+JSjFYvRZVqfRSM3z1K4XcZJfhxv7Gq1ebb93R1QunIdGC0HiFnBZxpxhDCbcVOpbdbQOJ22dLSe5/4f+1V+D/bPCZJx5kF0yvM0jEhuQNxNV3H/DasvBhH/24JIjpe+WfKPw0jx7vR6";
+
+    [Benchmark]
+    public void FromStream() {
+        using var stream = new MemoryStream(_data, writable: false);
+        using var _ = Certificate.FromBase64(stream);
+    }
+}
+
+public class Program {
+    public static void Main(string[] args) {
+        BenchmarkRunner.Run<CertificateFromBase64Benchmark>();
+    }
+}

--- a/SectigoCertificateManager.Benchmarks/SectigoCertificateManager.Benchmarks.csproj
+++ b/SectigoCertificateManager.Benchmarks/SectigoCertificateManager.Benchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SectigoCertificateManager\SectigoCertificateManager.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SectigoCertificateManager.sln
+++ b/SectigoCertificateManager.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SectigoCertificateManager.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SectigoCertificateManager.Examples", "SectigoCertificateManager.Examples\SectigoCertificateManager.Examples.csproj", "{3B853C6C-B03F-4B62-8DD0-819119A61BEC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SectigoCertificateManager.Benchmarks", "SectigoCertificateManager.Benchmarks\SectigoCertificateManager.Benchmarks.csproj", "{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +85,18 @@ Global
 		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Release|x64.Build.0 = Release|Any CPU
 		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Release|x86.ActiveCfg = Release|Any CPU
 		{3B853C6C-B03F-4B62-8DD0-819119A61BEC}.Release|x86.Build.0 = Release|Any CPU
+		{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}.Debug|x64.Build.0 = Debug|Any CPU
+		{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}.Debug|x86.Build.0 = Debug|Any CPU
+		{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}.Release|x64.ActiveCfg = Release|Any CPU
+		{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}.Release|x64.Build.0 = Release|Any CPU
+		{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}.Release|x86.ActiveCfg = Release|Any CPU
+		{C0611FC0-DBAF-40AC-AEE3-FD42B6855BD3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SectigoCertificateManager/Clients/InventoryClient.cs
+++ b/SectigoCertificateManager/Clients/InventoryClient.cs
@@ -89,6 +89,7 @@ public sealed class InventoryClient : BaseClient {
         StringBuilder builder) {
         values.Clear();
         builder.Clear();
+        var vsb = new ValueStringBuilder(stackalloc char[64]);
         var inQuotes = false;
         for (var i = 0; i < line.Length; i++) {
             var ch = line[i];
@@ -97,13 +98,15 @@ public sealed class InventoryClient : BaseClient {
                 continue;
             }
             if (ch == ',' && !inQuotes) {
-                values.Add(builder.ToString());
+                values.Add(vsb.ToString());
                 builder.Clear();
+                vsb.Clear();
                 continue;
             }
-            builder.Append(ch);
+            vsb.Append(ch);
         }
-        values.Add(builder.ToString());
+        values.Add(vsb.ToString());
+        vsb.Dispose();
         return values.ToArray();
     }
 

--- a/SectigoCertificateManager/Models/Certificate.cs
+++ b/SectigoCertificateManager/Models/Certificate.cs
@@ -4,6 +4,7 @@ using SectigoCertificateManager;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Buffers;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using SectigoCertificateManager.Utilities;
@@ -111,14 +112,14 @@ public sealed class Certificate {
         }
 
         using var reader = new StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
-        var builder = new StringBuilder();
-        var buffer = new char[4096];
+        var rented = ArrayPool<char>.Shared.Rent(4096);
+        var vsb = new ValueStringBuilder(stackalloc char[256]);
         long read = 0;
         long total = stream.CanSeek ? stream.Length : -1;
 
         int count;
-        while ((count = reader.Read(buffer, 0, buffer.Length)) > 0) {
-            builder.Append(buffer, 0, count);
+        while ((count = reader.Read(rented, 0, rented.Length)) > 0) {
+            vsb.Append(rented.AsSpan(0, count));
             read += count;
             if (progress is not null && total > 0) {
                 progress.Report((double)read / total);
@@ -128,7 +129,9 @@ public sealed class Certificate {
         if (progress is not null && total > 0) {
             progress.Report(1d);
         }
-
-        return FromBase64(builder.ToString());
+        var result = FromBase64(vsb.ToString());
+        vsb.Dispose();
+        ArrayPool<char>.Shared.Return(rented);
+        return result;
     }
 }

--- a/SectigoCertificateManager/Utilities/ValueStringBuilder.cs
+++ b/SectigoCertificateManager/Utilities/ValueStringBuilder.cs
@@ -1,0 +1,78 @@
+namespace SectigoCertificateManager.Utilities;
+
+using System;
+using System.Buffers;
+
+/// <summary>
+/// Provides a minimal growable string builder that uses <see cref="ArrayPool{T}"/>.
+/// </summary>
+internal ref struct ValueStringBuilder {
+    private char[]? _array;
+    private Span<char> _span;
+    private int _pos;
+
+    /// <summary>Initializes a new instance with the given initial buffer.</summary>
+    /// <param name="initialBuffer">Buffer used until growth is required.</param>
+    public ValueStringBuilder(Span<char> initialBuffer) {
+        _array = null;
+        _span = initialBuffer;
+        _pos = 0;
+    }
+
+    /// <summary>Gets the current length.</summary>
+    public int Length => _pos;
+
+    /// <summary>Appends a single character to the builder.</summary>
+    /// <param name="c">Character to append.</param>
+    public void Append(char c) {
+        if (_pos >= _span.Length) {
+            Grow(1);
+        }
+
+        _span[_pos] = c;
+        _pos++;
+    }
+
+    /// <summary>Appends the provided span to the builder.</summary>
+    /// <param name="value">Characters to append.</param>
+    public void Append(ReadOnlySpan<char> value) {
+        if (_pos > _span.Length - value.Length) {
+            Grow(value.Length);
+        }
+
+        value.CopyTo(_span.Slice(_pos));
+        _pos += value.Length;
+    }
+
+    /// <summary>Clears the builder.</summary>
+    public void Clear() => _pos = 0;
+
+    private void Grow(int additionalCapacity) {
+        var newSize = Math.Max(_pos + additionalCapacity, _span.Length * 2);
+        var newArray = ArrayPool<char>.Shared.Rent(newSize);
+        _span.Slice(0, _pos).CopyTo(newArray);
+        var toReturn = _array;
+        _span = _array = newArray;
+        if (toReturn is not null) {
+            ArrayPool<char>.Shared.Return(toReturn);
+        }
+    }
+
+    /// <summary>Returns the accumulated string.</summary>
+    public override string ToString() {
+#if NETSTANDARD2_0 || NET472
+        return new string(_span.Slice(0, _pos).ToArray());
+#else
+        return new string(_span.Slice(0, _pos));
+#endif
+    }
+
+    /// <summary>Returns the rented array to the pool.</summary>
+    public void Dispose() {
+        var toReturn = _array;
+        this = default;
+        if (toReturn is not null) {
+            ArrayPool<char>.Shared.Return(toReturn);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- optimize certificate parsing loops with `ArrayPool<char>` and `ValueStringBuilder`
- add a minimal `ValueStringBuilder` implementation
- tune CSV parsing to reuse pooled buffers
- add benchmark project for measuring `Certificate.FromBase64`

## Testing
- `dotnet build`
- `dotnet test --no-build`
- `dotnet run -c Release -f net8.0 --project SectigoCertificateManager.Benchmarks`

------
https://chatgpt.com/codex/tasks/task_e_687ea7ee5408832e8dca92967a3d8768