### PR TITLE
Add thread safety to builder classes

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigBuilderConcurrencyTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigBuilderConcurrencyTests.cs
@@ -1,0 +1,30 @@
+using SectigoCertificateManager;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+public sealed class ApiConfigBuilderConcurrencyTests {
+    [Fact]
+    public async Task ConcurrentBuildsAreThreadSafe() {
+        var builder = new ApiConfigBuilder()
+            .WithBaseUrl("https://example.com")
+            .WithCredentials("user", "pass")
+            .WithCustomerUri("cst1");
+
+        var tasks = Enumerable.Range(0, 10)
+            .Select(i => Task.Run(() => {
+                builder.WithToken($"tok{i}");
+                builder.WithTokenExpiration(DateTimeOffset.UtcNow.AddMinutes(i));
+                return builder.Build();
+            }));
+
+        var configs = await Task.WhenAll(tasks);
+        foreach (var cfg in configs) {
+            Assert.Equal("https://example.com", cfg.BaseUrl);
+            Assert.Equal("cst1", cfg.CustomerUri);
+        }
+    }
+}

--- a/SectigoCertificateManager.Tests/IssueCertificateRequestBuilderConcurrencyTests.cs
+++ b/SectigoCertificateManager.Tests/IssueCertificateRequestBuilderConcurrencyTests.cs
@@ -1,0 +1,28 @@
+using SectigoCertificateManager.Requests;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+public sealed class IssueCertificateRequestBuilderConcurrencyTests {
+    [Fact]
+    public async Task ConcurrentBuildsAreThreadSafe() {
+        var builder = new IssueCertificateRequestBuilder(new[] { 12, 24 });
+
+        var tasks = Enumerable.Range(0, 10)
+            .Select(i => Task.Run(() => {
+                builder.WithCommonName($"example{i}.com");
+                builder.WithProfileId(i);
+                builder.WithTerm(12);
+                builder.WithSubjectAlternativeNames(new[] { $"alt{i}.com" });
+                return builder.Build();
+            }));
+
+        var requests = await Task.WhenAll(tasks);
+        foreach (var req in requests) {
+            Assert.Equal(12, req.Term);
+            Assert.Single(req.SubjectAlternativeNames);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- protect ApiConfigBuilder with lock for thread safety
- protect IssueCertificateRequestBuilder with lock and return copy
- add concurrency tests for both builders

## Testing
- `dotnet test SectigoCertificateManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_687f333245e4832ea5dfdaab2f4debbb