### PR TITLE
Update PowerShell defaults for API v25.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ Import the module and call the cmdlets:
 ```powershell
 Import-Module ./SectigoCertificateManager.PowerShell.dll
 
-Get-SectigoCertificate -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CertificateId 123
+Get-SectigoCertificate -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CertificateId 123 -ApiVersion V25_6
 
-Get-SectigoProfile -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -ProfileId 2
+Get-SectigoProfile -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -ProfileId 2 -ApiVersion V25_6
 
-New-SectigoOrder -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CommonName "example.com" -ProfileId 1 -SubjectAlternativeNames "www.example.com","admin.example.com"
+New-SectigoOrder -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CommonName "example.com" -ProfileId 1 -SubjectAlternativeNames "www.example.com","admin.example.com" -ApiVersion V25_6
 
-Get-SectigoOrders -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1"
+Get-SectigoOrders -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -ApiVersion V25_6
 
-Update-SectigoCertificate -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CertificateId 123 -Csr "<csr>" -DcvMode "EMAIL" -DcvEmail "admin@example.com"
+Update-SectigoCertificate -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CertificateId 123 -Csr "<csr>" -DcvMode "EMAIL" -DcvEmail "admin@example.com" -ApiVersion V25_6
 ```
 
 Use `-SubjectAlternativeNames` to specify multiple SAN values when placing an order.

--- a/SectigoCertificateManager.PowerShell/Examples/CreateOrganizationExample.ps1
+++ b/SectigoCertificateManager.PowerShell/Examples/CreateOrganizationExample.ps1
@@ -1,2 +1,2 @@
 # Demonstrates creating an organization.
-New-SectigoOrganization -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -Name "My Org"
+New-SectigoOrganization -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -Name "My Org" -ApiVersion V25_6

--- a/SectigoCertificateManager.PowerShell/Examples/GetCertificateStatusExample.ps1
+++ b/SectigoCertificateManager.PowerShell/Examples/GetCertificateStatusExample.ps1
@@ -1,2 +1,2 @@
 # Demonstrates retrieving certificate status.
-Get-SectigoCertificateStatus -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CertificateId 10
+Get-SectigoCertificateStatus -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -CertificateId 10 -ApiVersion V25_6

--- a/SectigoCertificateManager.PowerShell/Examples/GetOrderHistoryExample.ps1
+++ b/SectigoCertificateManager.PowerShell/Examples/GetOrderHistoryExample.ps1
@@ -1,2 +1,2 @@
 # Demonstrates retrieving history for an order.
-Get-SectigoOrderHistory -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -OrderId 10
+Get-SectigoOrderHistory -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -OrderId 10 -ApiVersion V25_6

--- a/SectigoCertificateManager.PowerShell/Examples/StreamOrdersExample.ps1
+++ b/SectigoCertificateManager.PowerShell/Examples/StreamOrdersExample.ps1
@@ -1,2 +1,2 @@
 # Demonstrates streaming orders using the Sectigo module.
-Get-SectigoOrders -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1"
+Get-SectigoOrders -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -ApiVersion V25_6

--- a/SectigoCertificateManager.PowerShell/GetSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoCertificateCommand.cs
@@ -29,7 +29,7 @@ public sealed class GetSectigoCertificateCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>The certificate identifier.</summary>
     [Parameter(Mandatory = true, Position = 0)]

--- a/SectigoCertificateManager.PowerShell/GetSectigoCertificateRevocationCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoCertificateRevocationCommand.cs
@@ -30,7 +30,7 @@ public sealed class GetSectigoCertificateRevocationCommand : PSCmdlet
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>The certificate identifier.</summary>
     [Parameter(Mandatory = true, Position = 0)]

--- a/SectigoCertificateManager.PowerShell/GetSectigoCertificateStatusCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoCertificateStatusCommand.cs
@@ -28,7 +28,7 @@ public sealed class GetSectigoCertificateStatusCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>The certificate identifier.</summary>
     [Parameter(Mandatory = true, Position = 0)]

--- a/SectigoCertificateManager.PowerShell/GetSectigoCertificateTypesCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoCertificateTypesCommand.cs
@@ -29,7 +29,7 @@ public sealed class GetSectigoCertificateTypesCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>Optional organization identifier used to filter results.</summary>
     [Parameter]

--- a/SectigoCertificateManager.PowerShell/GetSectigoOrderHistoryCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoOrderHistoryCommand.cs
@@ -29,7 +29,7 @@ public sealed class GetSectigoOrderHistoryCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>The identifier of the order.</summary>
     [Parameter(Mandatory = true, Position = 0)]

--- a/SectigoCertificateManager.PowerShell/GetSectigoOrdersCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoOrdersCommand.cs
@@ -30,7 +30,7 @@ public sealed class GetSectigoOrdersCommand : AsyncPSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>Optional cancellation token.</summary>
     [Parameter]

--- a/SectigoCertificateManager.PowerShell/GetSectigoOrganizationsCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoOrganizationsCommand.cs
@@ -28,7 +28,7 @@ public sealed class GetSectigoOrganizationsCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>Optional cancellation token.</summary>
     [Parameter]

--- a/SectigoCertificateManager.PowerShell/GetSectigoProfileCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoProfileCommand.cs
@@ -29,7 +29,7 @@ public sealed class GetSectigoProfileCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>The profile identifier.</summary>
     [Parameter(Mandatory = true, Position = 0)]

--- a/SectigoCertificateManager.PowerShell/GetSectigoProfilesCommand.cs
+++ b/SectigoCertificateManager.PowerShell/GetSectigoProfilesCommand.cs
@@ -29,7 +29,7 @@ public sealed class GetSectigoProfilesCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>Optional cancellation token.</summary>
     [Parameter]

--- a/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/NewSectigoOrderCommand.cs
@@ -30,7 +30,7 @@ public sealed class NewSectigoOrderCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>The certificate common name.</summary>
     [Parameter(Mandatory = true)]

--- a/SectigoCertificateManager.PowerShell/NewSectigoOrganizationCommand.cs
+++ b/SectigoCertificateManager.PowerShell/NewSectigoOrganizationCommand.cs
@@ -31,7 +31,7 @@ public sealed class NewSectigoOrganizationCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>The organization name.</summary>
     [Parameter(Mandatory = true, Position = 0)]

--- a/SectigoCertificateManager.PowerShell/RemoveSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/RemoveSectigoCertificateCommand.cs
@@ -29,7 +29,7 @@ public sealed class RemoveSectigoCertificateCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>The identifier of the certificate to delete.</summary>
     [Parameter(Mandatory = true, Position = 0)]

--- a/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/StopSectigoOrderCommand.cs
@@ -29,7 +29,7 @@ public sealed class StopSectigoOrderCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>The identifier of the order to cancel.</summary>
     [Parameter(Mandatory = true, Position = 0)]

--- a/SectigoCertificateManager.PowerShell/UpdateSectigoCertificateCommand.cs
+++ b/SectigoCertificateManager.PowerShell/UpdateSectigoCertificateCommand.cs
@@ -31,7 +31,7 @@ public sealed class UpdateSectigoCertificateCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>The identifier of the certificate to renew.</summary>
     [Parameter(Mandatory = true, Position = 0)]

--- a/SectigoCertificateManager.PowerShell/WaitSectigoOrderCommand.cs
+++ b/SectigoCertificateManager.PowerShell/WaitSectigoOrderCommand.cs
@@ -29,7 +29,7 @@ public sealed class WaitSectigoOrderCommand : PSCmdlet {
 
     /// <summary>The API version to use.</summary>
     [Parameter]
-    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_4;
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
 
     /// <summary>The identifier of the order to wait on.</summary>
     [Parameter(Mandatory = true, Position = 0)]


### PR DESCRIPTION
## Summary
- default `ApiVersion` in PowerShell cmdlets to `V25_6`
- show `-ApiVersion V25_6` usage in help examples

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release`
- `dotnet test SectigoCertificateManager.sln -c Release`
- `Invoke-Pester -Path ./SectigoCertificateManager.Tests/Pester -CI`
- `Invoke-Pester -Path ./Module/Tests -CI`


------
https://chatgpt.com/codex/tasks/task_e_687f3352b8c0832ea9afb166586806b4