### PR TITLE
Fix enum serialization to use camelCase

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/TokenRefreshExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/TokenRefreshExample.cs
@@ -13,6 +13,10 @@ public static class TokenRefreshExample {
     private static readonly JsonSerializerOptions s_json = new() {
         PropertyNameCaseInsensitive = true
     };
+
+    static TokenRefreshExample() {
+        s_json.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+    }
     /// <summary>Runs the example using <see cref="ApiConfigBuilder.WithTokenRefresh"/>.</summary>
     public static async Task RunAsync() {
         var builder = new ApiConfigBuilder()

--- a/SectigoCertificateManager.Tests/SerializationTests.cs
+++ b/SectigoCertificateManager.Tests/SerializationTests.cs
@@ -16,6 +16,7 @@ public sealed class SerializationTests {
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
         var obj = JsonSerializer.Deserialize<Certificate>(json, options);
         Assert.NotNull(obj);
     }
@@ -27,6 +28,7 @@ public sealed class SerializationTests {
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
         var obj = JsonSerializer.Deserialize<Profile>(json, options);
         Assert.NotNull(obj);
     }
@@ -35,6 +37,7 @@ public sealed class SerializationTests {
     public void CertificateStatus_RoundTrip_Succeeds() {
         foreach (CertificateStatus status in Enum.GetValues(typeof(CertificateStatus))) {
             var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
             var json = JsonSerializer.Serialize(status, options);
             var result = JsonSerializer.Deserialize<CertificateStatus>(json, options);
             Assert.Equal(status, result);
@@ -45,6 +48,7 @@ public sealed class SerializationTests {
     public void OrderStatus_RoundTrip_Succeeds() {
         foreach (OrderStatus status in Enum.GetValues(typeof(OrderStatus))) {
             var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
             var json = JsonSerializer.Serialize(status, options);
             var result = JsonSerializer.Deserialize<OrderStatus>(json, options);
             Assert.Equal(status, result);

--- a/SectigoCertificateManager/CertificateStatus.cs
+++ b/SectigoCertificateManager/CertificateStatus.cs
@@ -3,9 +3,6 @@ namespace SectigoCertificateManager;
 /// <summary>
 /// Enumerates statuses for certificates.
 /// </summary>
-using System.Text.Json.Serialization;
-
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum CertificateStatus {
     /// <summary>Any status.</summary>
     Any = 0,

--- a/SectigoCertificateManager/Clients/BaseClient.cs
+++ b/SectigoCertificateManager/Clients/BaseClient.cs
@@ -20,6 +20,10 @@ public abstract class BaseClient {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
+    static BaseClient() {
+        s_json.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BaseClient"/> class.
     /// </summary>

--- a/SectigoCertificateManager/Models/MatchType.cs
+++ b/SectigoCertificateManager/Models/MatchType.cs
@@ -1,11 +1,8 @@
 namespace SectigoCertificateManager.Models;
 
-using System.Text.Json.Serialization;
-
 /// <summary>
 /// Specifies the match type used in IdP mapping rules.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum MatchType {
     /// <summary>Attribute value must match completely.</summary>
     Matches,

--- a/SectigoCertificateManager/Models/RelatedAdminsAction.cs
+++ b/SectigoCertificateManager/Models/RelatedAdminsAction.cs
@@ -1,11 +1,8 @@
 namespace SectigoCertificateManager.Models;
 
-using System.Text.Json.Serialization;
-
 /// <summary>
 /// Specifies action for administrators related to a template.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum RelatedAdminsAction {
     /// <summary>Unlink administrators from the template.</summary>
     Unlink,

--- a/SectigoCertificateManager/OrderStatus.cs
+++ b/SectigoCertificateManager/OrderStatus.cs
@@ -3,9 +3,6 @@ namespace SectigoCertificateManager;
 /// <summary>
 /// Enumerates statuses for certificate orders.
 /// </summary>
-using System.Text.Json.Serialization;
-
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum OrderStatus {
     /// <summary>Order is not initiated.</summary>
     NotInitiated,


### PR DESCRIPTION
## Summary
- ensure BaseClient JSON options use JsonStringEnumConverter with camelCase
- remove enum attributes and rely on global options
- update tests for enum serialization
- adjust example serialization options

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687f33690f9c832e873c731f9b150270