### PR TITLE
fix(requests): 🐛 reset stream position before reading CSR

### DIFF
--- a/SectigoCertificateManager.Tests/RenewCertificateRequestTests.cs
+++ b/SectigoCertificateManager.Tests/RenewCertificateRequestTests.cs
@@ -39,4 +39,16 @@ public sealed class RenewCertificateRequestTests {
 
         Assert.Equal(1d, progress.Value, 3);
     }
+
+    [Fact]
+    public void SetCsr_SeeksToBeginning() {
+        var bytes = Encoding.ASCII.GetBytes(Base64Csr);
+        using var stream = new MemoryStream(bytes);
+        stream.Seek(2, SeekOrigin.Begin);
+        var request = new RenewCertificateRequest();
+
+        request.SetCsr(stream);
+
+        Assert.Equal(Base64Csr, request.Csr);
+    }
 }

--- a/SectigoCertificateManager/Requests/RenewCertificateRequest.cs
+++ b/SectigoCertificateManager/Requests/RenewCertificateRequest.cs
@@ -26,6 +26,10 @@ public sealed class RenewCertificateRequest {
     public void SetCsr(Stream stream, IProgress<double>? progress = null) {
         Guard.AgainstNull(stream, nameof(stream));
 
+        if (stream.CanSeek) {
+            stream.Seek(0, SeekOrigin.Begin);
+        }
+
         using var reader = new StreamReader(stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
         var rented = ArrayPool<char>.Shared.Rent(4096);
         var vsb = new ValueStringBuilder(stackalloc char[256]);


### PR DESCRIPTION
## Summary
- ensure CSR streams seek to the beginning before reading
- add unit test verifying stream repositioning

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687f33736e64832eafa9b1771dd056f8