### PR TITLE
Add helper for PFX creation

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/CombineCertKeyToPfxExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/CombineCertKeyToPfxExample.cs
@@ -1,0 +1,31 @@
+using SectigoCertificateManager.Utilities;
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates creating a PFX file from a certificate and private key.
+/// </summary>
+public static class CombineCertKeyToPfxExample {
+    /// <summary>Executes the example.</summary>
+    public static void Run() {
+        using var key = RSA.Create(2048);
+#if NET472
+        var request = new CertificateRequest(
+            new X500DistinguishedName("CN=example.com"),
+            key,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+#else
+        var request = new CertificateRequest("CN=example.com", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+#endif
+        using var certWithKey = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+        using var certificate = new X509Certificate2(certWithKey.Export(X509ContentType.Cert));
+
+        var pfx = CertificateExport.CreatePfx(certificate, key);
+        Console.WriteLine($"Generated PFX with {pfx.Length} bytes");
+    }
+}
+

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -14,3 +14,4 @@ await WatchOrdersExample.RunAsync();
 CsrGeneratorExample.Run();
 HttpClientPropertyExample.Run();
 GuardExample.Run();
+CombineCertKeyToPfxExample.Run();

--- a/SectigoCertificateManager.Tests/CertificateExportTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateExportTests.cs
@@ -252,4 +252,20 @@ public sealed class CertificateExportTests {
             }
         }
     }
+
+    [Fact]
+    public void CreatePfx_ReturnsValidBytes() {
+        using var original = CreateCertificate();
+        var certificate = new X509Certificate2(original.Export(X509ContentType.Cert));
+        using var key = RSA.Create();
+        var pkcs8 = original.GetRSAPrivateKey()!.ExportPkcs8PrivateKey();
+        key.ImportPkcs8PrivateKey(pkcs8, out _);
+        Array.Clear(pkcs8, 0, pkcs8.Length);
+
+        var bytes = CertificateExport.CreatePfx(certificate, key, "pwd");
+        using var loaded = new X509Certificate2(bytes, "pwd");
+
+        Assert.Equal(certificate.Thumbprint, loaded.Thumbprint);
+        Assert.True(loaded.HasPrivateKey);
+    }
 }


### PR DESCRIPTION
## Summary
- add `CreatePfx` helper for combining certificate with a private key
- test the new helper
- show PFX helper usage in examples

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release -nologo`
- `dotnet test SectigoCertificateManager.sln -c Release -nologo`

------
https://chatgpt.com/codex/tasks/task_e_687f338e9f90832eb06918e1be8c2e09