### PR TITLE
Fix culture-specific date formatting

### DIFF
--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -11,6 +11,7 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -73,6 +74,38 @@ public sealed class CertificatesClientTests {
         var actualResult = result!;
         Assert.Single(actualResult.Certificates);
         Assert.Equal(1, actualResult.Certificates[0].Id);
+    }
+
+    [Fact]
+    public async Task SearchAsync_UsesInvariantCulture() {
+        var certificate = new Certificate { Id = 1, CommonName = "test" };
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create(new[] { certificate })
+        };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var certificates = new CertificatesClient(client);
+
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+        try {
+            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+            CultureInfo.CurrentUICulture = new CultureInfo("fr-FR");
+
+            var request = new CertificateSearchRequest {
+                DateFrom = new DateTime(2023, 1, 1),
+                DateTo = new DateTime(2023, 1, 31)
+            };
+            await certificates.SearchAsync(request);
+
+            Assert.NotNull(handler.Request);
+            Assert.Equal("https://example.com/v1/certificate?dateFrom=2023-01-01&dateTo=2023-01-31", handler.Request!.RequestUri!.ToString());
+        } finally {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
     }
 
     [Fact]

--- a/SectigoCertificateManager.Tests/InventoryClientTests.cs
+++ b/SectigoCertificateManager.Tests/InventoryClientTests.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Globalization;
 using Xunit;
 
 namespace SectigoCertificateManager.Tests;
@@ -43,6 +44,35 @@ public sealed class InventoryClientTests {
         Assert.Single(result);
         Assert.Equal(1, result[0].Id);
         Assert.Equal("example.com", result[0].CommonName);
+    }
+
+    [Fact]
+    public async Task DownloadCsvAsync_UsesInvariantCulture() {
+        const string csv = "id,commonName\n1,example.com";
+        var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(csv) };
+
+        var handler = new TestHandler(response);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), new HttpClient(handler));
+        var inventory = new InventoryClient(client);
+
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+        try {
+            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+            CultureInfo.CurrentUICulture = new CultureInfo("fr-FR");
+
+            var request = new InventoryCsvRequest {
+                DateFrom = new DateTime(2023, 1, 1),
+                DateTo = new DateTime(2023, 1, 31)
+            };
+            await inventory.DownloadCsvAsync(request);
+
+            Assert.NotNull(handler.Request);
+            Assert.Equal("https://example.com/v1/inventory.csv?from=2023-01-01&to=2023-01-31", handler.Request!.RequestUri!.ToString());
+        } finally {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
     }
 
     [Fact]

--- a/SectigoCertificateManager/Clients/CertificatesClient.Core.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Core.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
+using System.Globalization;
 using System.Text.Json;
 using System.Security.Cryptography.X509Certificates;
 using SectigoCertificateManager.Utilities;
@@ -225,7 +226,8 @@ public sealed partial class CertificatesClient : BaseClient {
             }
 
             AppendSeparator();
-            builder.Append(name).Append('=').Append(value.Value.ToString("yyyy-MM-dd"));
+            builder.Append(name).Append('=')
+                .Append(value.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
         }
 
         if (request.Size.HasValue) {

--- a/SectigoCertificateManager/Clients/InventoryClient.cs
+++ b/SectigoCertificateManager/Clients/InventoryClient.cs
@@ -3,6 +3,7 @@ namespace SectigoCertificateManager.Clients;
 using SectigoCertificateManager.Models;
 using SectigoCertificateManager.Requests;
 using SectigoCertificateManager.Utilities;
+using System.Globalization;
 using System.Text;
 
 /// <summary>
@@ -130,7 +131,7 @@ public sealed class InventoryClient : BaseClient {
 
             AppendSeparator();
             builder.Append(name).Append('=')
-                .Append(value.Value.ToString("yyyy-MM-dd"));
+                .Append(value.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
         }
 
         if (request.Size.HasValue) {


### PR DESCRIPTION
## Summary
- ensure date formatting uses `InvariantCulture`
- verify inventory and certificate queries remain culture-neutral

## Testing
- `dotnet test -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688bd3c09e8c832e800f7faa300c87ef