### PR TITLE
Add streaming overloads for certificates

### DIFF
--- a/SectigoCertificateManager.Benchmarks/CertificateFromBase64Benchmark.cs
+++ b/SectigoCertificateManager.Benchmarks/CertificateFromBase64Benchmark.cs
@@ -9,6 +9,20 @@ namespace SectigoCertificateManager.Benchmarks;
 [MemoryDiagnoser]
 public class CertificateFromBase64Benchmark {
     private byte[] _data = Encoding.ASCII.GetBytes(Base64Cert);
+    private string? _path;
+
+    [GlobalSetup]
+    public void Setup() {
+        _path = Path.GetTempFileName();
+        File.WriteAllBytes(_path, _data);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() {
+        if (_path is not null && File.Exists(_path)) {
+            File.Delete(_path);
+        }
+    }
 
     private const string Base64Cert = "MIIC/zCCAeegAwIBAgIULTQw6ATwfRI/1hVSQooJNHPEit8wDQYJKoZIhvcNAQELBQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yNTA3MDQxMzE2NDRaFw0yNTA3MDUxMzE2NDRaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDiO8kIwsJLCi3d8bX31IIISKSoA24iCcfV7m+uMm8CMdJlY2NGf8ThiF3suG2lHQCxESQacUrPFMN/J3cM7L+5R8p24CCnrmAP2WhMuO2IwFhgfjo4PsmnmCGNx5fDAPI+lnSS6pnHfZfAPw3dbPT2/cgbeil0q2ByFR6C2YXU+mFdOg7cJJ1f2GXbUL3QYRBuaDYCHRrDAym4e/8DkKjjaroDxw1BPD6sjvzrDdEDusJANDCp8K6Cr99nvG+YCLjueN+xvUXHbsp9gUfLI39X73p+M9zGcYGAeYyD/i+VM/+Kde5CEfS34eOKfRIJX6DHAbVu1SrJPNFFvQV0keb/AgMBAAGjUzBRMB0GA1UdDgQWBBQ8PwJEkQsHvU7i5i45XLLyJUi4eTAfBgNVHSMEGDAWgBQ8PwJEkQsHvU7i5i45XLLyJUi4eTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAjWADB2IC5xBHKOROcXZDa8mp3DaasUwL5mWjG7Ppr4LHrY1uCEojstJCg6s2FLBjGTs+0DTQ5UiBqSVJDK1GVhYG02xJSPoXNS4wNTp4a56NtbkDT96lO0BrH91lclMNXHU9NpMUFea0tt7h5tUeVtZ2CVK0nuy5MOifMdURVyhWsFgQVemmTNTYisVD5sNRvBJEq0M+3+JSjFYvRZVqfRSM3z1K4XcZJfhxv7Gq1ebb93R1QunIdGC0HiFnBZxpxhDCbcVOpbdbQOJ22dLSe5/4f+1V+D/bPCZJx5kF0yvM0jEhuQNxNV3H/DasvBhH/24JIjpe+WfKPw0jx7vR6";
 
@@ -16,6 +30,12 @@ public class CertificateFromBase64Benchmark {
     public void FromStream() {
         using var stream = new MemoryStream(_data, writable: false);
         using var _ = Certificate.FromBase64(stream);
+    }
+
+    [Benchmark]
+    public void FromDisk() {
+        using var file = File.OpenRead(_path!);
+        using var _ = Certificate.FromBase64(file);
     }
 }
 

--- a/SectigoCertificateManager.Examples/Examples/StreamCertificatesBytesExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/StreamCertificatesBytesExample.cs
@@ -1,0 +1,32 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using System.IO;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates streaming certificates as byte arrays and writing them to disk.
+/// </summary>
+public static class StreamCertificatesBytesExample {
+    /// <summary>
+    /// Executes the example that streams certificate bytes.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+
+        var index = 0;
+        await foreach (var bytes in certificates.StreamCertificatesAsync<byte[]>(pageSize: 50)) {
+            var path = Path.Combine("certs", $"certificate{index++}.cer");
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            await File.WriteAllBytesAsync(path, bytes);
+        }
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -15,3 +15,4 @@ CsrGeneratorExample.Run();
 HttpClientPropertyExample.Run();
 GuardExample.Run();
 CombineCertKeyToPfxExample.Run();
+await StreamCertificatesBytesExample.RunAsync();


### PR DESCRIPTION
## Summary
- add `DownloadBytesAsync` and `DownloadStreamAsync`
- add generic `StreamCertificatesAsync<T>`
- update benchmark to compare disk reads
- include example for streaming certificate bytes
- cover new API with unit tests

## Testing
- `dotnet test`
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688bd3b69560832e8428aa3f370a6b20