### PR TITLE
Ensure invariant culture for date formatting

### DIFF
--- a/SectigoCertificateManager/Clients/CertificatesClient.Core.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Core.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Text.Json;
 using System.Security.Cryptography.X509Certificates;
 using SectigoCertificateManager.Utilities;
+using System.Globalization;
 
 /// <summary>
 /// Provides access to certificate related endpoints.
@@ -225,7 +226,8 @@ public sealed partial class CertificatesClient : BaseClient {
             }
 
             AppendSeparator();
-            builder.Append(name).Append('=').Append(value.Value.ToString("yyyy-MM-dd"));
+            builder.Append(name).Append('=')
+                .Append(value.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
         }
 
         if (request.Size.HasValue) {

--- a/SectigoCertificateManager/Clients/InventoryClient.cs
+++ b/SectigoCertificateManager/Clients/InventoryClient.cs
@@ -4,6 +4,7 @@ using SectigoCertificateManager.Models;
 using SectigoCertificateManager.Requests;
 using SectigoCertificateManager.Utilities;
 using System.Text;
+using System.Globalization;
 
 /// <summary>
 /// Provides access to inventory related endpoints.
@@ -130,7 +131,7 @@ public sealed class InventoryClient : BaseClient {
 
             AppendSeparator();
             builder.Append(name).Append('=')
-                .Append(value.Value.ToString("yyyy-MM-dd"));
+                .Append(value.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
         }
 
         if (request.Size.HasValue) {


### PR DESCRIPTION
## Summary
- use `CultureInfo.InvariantCulture` in certificate and inventory search queries
- test certificate query building across cultures
- test inventory query building across cultures

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj --verbosity minimal`
- `dotnet build SectigoCertificateManager.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_688bd4593048832e81e208cc5495b109