### PR TITLE
Use ThrowTerminatingError for cancellation

### DIFF
--- a/Module/Tests/NewSectigoOrderCommand.Tests.ps1
+++ b/Module/Tests/NewSectigoOrderCommand.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'New-SectigoOrder parameter validation' -Tag 'Cmdlet' {
             ProfileId = 1
             SubjectAlternativeNames = @('valid', '')
         }
-        { New-SectigoOrder @params } | Should -Throw
+        { New-SectigoOrder @params } | Should -Throw -ErrorId 'InvalidSubjectAlternativeName,SectigoCertificateManager.PowerShell.NewSectigoOrderCommand'
     }
 
     It 'Throws when CommonName is null or whitespace' {
@@ -21,6 +21,6 @@ Describe 'New-SectigoOrder parameter validation' -Tag 'Cmdlet' {
             CommonName = ' '
             ProfileId = 1
         }
-        { New-SectigoOrder @params } | Should -Throw
+        { New-SectigoOrder @params } | Should -Throw -ErrorId 'InvalidCommonName,SectigoCertificateManager.PowerShell.NewSectigoOrderCommand'
     }
 }

--- a/Module/Tests/WaitSectigoOrder.Tests.ps1
+++ b/Module/Tests/WaitSectigoOrder.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'Wait-SectigoOrder validation' -Tag 'Cmdlet' {
     It 'Throws on invalid OrderId' {
         $params = @{ BaseUrl='https://example.com'; Username='u'; Password='p'; CustomerUri='c'; OrderId=0 }
-        { Wait-SectigoOrder @params } | Should -Throw
+        { Wait-SectigoOrder @params } | Should -Throw -ErrorId 'InvalidOrderId,SectigoCertificateManager.PowerShell.WaitSectigoOrderCommand'
     }
 }

--- a/SectigoCertificateManager.PowerShell/Communication/AsyncPSCmdlet.cs
+++ b/SectigoCertificateManager.PowerShell/Communication/AsyncPSCmdlet.cs
@@ -228,7 +228,9 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
     /// </summary>
     internal void ThrowIfStopped() {
         if (_cancelSource.IsCancellationRequested) {
-            throw new PipelineStoppedException();
+            var ex = new PipelineStoppedException("Cmdlet execution was canceled.");
+            var record = new ErrorRecord(ex, "CmdletCancelled", ErrorCategory.OperationStopped, null);
+            ThrowTerminatingError(record);
         }
     }
 

--- a/SectigoCertificateManager.Tests/Pester/NewSectigoOrganizationCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/NewSectigoOrganizationCommand.Tests.ps1
@@ -11,6 +11,6 @@ Describe "New-SectigoOrganization" {
     }
 
     It "throws when Name is empty" {
-        { New-SectigoOrganization -BaseUrl 'b' -Username 'u' -Password 'p' -CustomerUri 'c' -Name '' } | Should -Throw
+        { New-SectigoOrganization -BaseUrl 'b' -Username 'u' -Password 'p' -CustomerUri 'c' -Name ' ' } | Should -Throw -ErrorId 'InvalidName,SectigoCertificateManager.PowerShell.NewSectigoOrganizationCommand'
     }
 }

--- a/SectigoCertificateManager.Tests/Pester/RemoveSectigoCertificateCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/RemoveSectigoCertificateCommand.Tests.ps1
@@ -6,7 +6,7 @@ Describe "Remove-SectigoCertificate" {
     }
 
     It "throws when CertificateId is less than or equal to zero" {
-        { Remove-SectigoCertificate -BaseUrl 'b' -Username 'u' -Password 'p' -CustomerUri 'c' -CertificateId 0 } | Should -Throw
+        { Remove-SectigoCertificate -BaseUrl 'b' -Username 'u' -Password 'p' -CustomerUri 'c' -CertificateId 0 } | Should -Throw -ErrorId 'InvalidCertificateId,SectigoCertificateManager.PowerShell.RemoveSectigoCertificateCommand'
     }
 
     It "supports ShouldProcess" {

--- a/SectigoCertificateManager.Tests/Pester/StopSectigoOrderCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/StopSectigoOrderCommand.Tests.ps1
@@ -6,7 +6,7 @@ Describe "Stop-SectigoOrder" {
     }
 
     It "throws when OrderId is less than or equal to zero" {
-        { Stop-SectigoOrder -BaseUrl 'b' -Username 'u' -Password 'p' -CustomerUri 'c' -OrderId 0 } | Should -Throw
+        { Stop-SectigoOrder -BaseUrl 'b' -Username 'u' -Password 'p' -CustomerUri 'c' -OrderId 0 } | Should -Throw -ErrorId 'InvalidOrderId,SectigoCertificateManager.PowerShell.StopSectigoOrderCommand'
     }
 
     It "supports ShouldProcess" {


### PR DESCRIPTION
## Summary
- replace direct throw in `AsyncPSCmdlet` with `ThrowTerminatingError`
- verify specific error ids in Pester tests

## Testing
- `pwsh -NoLogo -NoProfile -File Module/SectigoCertificateManager.Tests.ps1`
- `dotnet test SectigoCertificateManager.Tests`
- `pwsh -NoLogo -NoProfile -c Invoke-Pester ./SectigoCertificateManager.Tests/Pester -Output Detailed`
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688bd53734c8832e9ef8f253f62d4fc3