### PR TITLE
Ensure SectigoClient disposal in cmdlets

### DIFF
--- a/SectigoCertificateManager.PowerShell/TestHooks.cs
+++ b/SectigoCertificateManager.PowerShell/TestHooks.cs
@@ -1,0 +1,15 @@
+namespace SectigoCertificateManager.PowerShell;
+
+using SectigoCertificateManager;
+using System;
+
+/// <summary>
+/// Provides hooks for testing internal operations.
+/// </summary>
+public static class TestHooks {
+    /// <summary>Optional factory used to create a custom client.</summary>
+    public static Func<ApiConfig, ISectigoClient>? ClientFactory { get; set; }
+
+    /// <summary>Stores the most recently created client instance.</summary>
+    public static ISectigoClient? CreatedClient { get; set; }
+}

--- a/SectigoCertificateManager.Tests/Pester/ClientDisposal.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/ClientDisposal.Tests.ps1
@@ -1,0 +1,37 @@
+Describe "Client disposal" {
+    BeforeAll {
+        dotnet build "$PSScriptRoot/../../SectigoCertificateManager.PowerShell" -c Release | Out-Null
+        $psModule = Join-Path $PSScriptRoot '../../SectigoCertificateManager.PowerShell/bin/Release/net8.0/SectigoCertificateManager.PowerShell.dll'
+        Import-Module $psModule
+        $lib = Join-Path $PSScriptRoot '../../SectigoCertificateManager/bin/Release/net8.0/SectigoCertificateManager.dll'
+        Add-Type -Path $lib
+        Add-Type -AssemblyName System.Net.Http
+        Add-Type -TypeDefinition @'
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+public sealed class NullHandler : HttpMessageHandler {
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new StringContent("[]") });
+}
+'@
+        [SectigoCertificateManager.PowerShell.TestHooks]::ClientFactory = [System.Func[SectigoCertificateManager.ApiConfig,SectigoCertificateManager.ISectigoClient]]{
+            param($cfg)
+            $handler = [NullHandler]::new()
+            $http = [System.Net.Http.HttpClient]::new($handler)
+            [SectigoCertificateManager.SectigoClient]::new($cfg, $http)
+        }
+    }
+    AfterAll {
+        [SectigoCertificateManager.PowerShell.TestHooks]::ClientFactory = $null
+        Remove-Module SectigoCertificateManager.PowerShell
+    }
+    It "disposes the client" {
+        [SectigoCertificateManager.PowerShell.TestHooks]::CreatedClient = $null
+        Get-SectigoCertificateTypes -BaseUrl 'https://example.com' -Username 'u' -Password 'p' -CustomerUri 'c'
+        $client = [SectigoCertificateManager.PowerShell.TestHooks]::CreatedClient
+        $client | Should -Not -BeNullOrEmpty
+        $field = $client.GetType().GetField('_disposed', [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance)
+        $field.GetValue($client) | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- dispose SectigoClient instances in all PowerShell cmdlets
- expose `TestHooks` for testing and add a Pester test verifying disposal

## Testing
- `dotnet build SectigoCertificateManager.sln -c Release --no-restore`
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj -c Release --no-build --verbosity minimal`
- `pwsh -NoProfile ./Module/SectigoCertificateManager.Tests.ps1`
- `pwsh -NoProfile -Command Invoke-Pester -Script ./SectigoCertificateManager.Tests/Pester -Output Detailed`

------
https://chatgpt.com/codex/tasks/task_e_688bd539df24832e9e5a565bd931c88d