### PR TITLE
Fix PFX save directory handling

### DIFF
--- a/SectigoCertificateManager.Tests/CertificateExportTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateExportTests.cs
@@ -109,6 +109,20 @@ public sealed class CertificateExportTests {
     }
 
     [Fact]
+    public void SavePfx_NoDirectory_WritesFile() {
+        using var cert = CreateCertificate();
+        var path = Path.GetRandomFileName();
+        try {
+            CertificateExport.SavePfx(cert, path, "pwd");
+            Assert.True(File.Exists(path));
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
     public void SavePfxForTest_ClearsBuffer() {
         using var cert = CreateCertificate();
         var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -120,6 +134,21 @@ public sealed class CertificateExportTests {
         } finally {
             if (Directory.Exists(dir)) {
                 Directory.Delete(dir, true);
+            }
+        }
+    }
+
+    [Fact]
+    public void SavePfxForTest_NoDirectory_WritesFile() {
+        using var cert = CreateCertificate();
+        var path = Path.GetRandomFileName();
+        try {
+            var buffer = CertificateExport.SavePfxForTest(cert, path, "pwd");
+            Assert.True(File.Exists(path));
+            Assert.All(buffer, b => Assert.Equal(0, b));
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
             }
         }
     }

--- a/SectigoCertificateManager/Utilities/CertificateExport.cs
+++ b/SectigoCertificateManager/Utilities/CertificateExport.cs
@@ -40,7 +40,10 @@ public static class CertificateExport {
     /// <param name="password">Optional password protecting the PFX.</param>
     public static void SavePfx(X509Certificate2 certificate, string path, string? password = null) {
         Guard.AgainstNullOrEmpty(path, nameof(path), "Path cannot be null or empty.");
-        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory)) {
+            Directory.CreateDirectory(directory);
+        }
         var bytes = password is null
             ? certificate.Export(X509ContentType.Pfx)
             : certificate.Export(X509ContentType.Pfx, password);
@@ -99,7 +102,10 @@ public static class CertificateExport {
         var bytes = password is null
             ? certificate.Export(X509ContentType.Pfx)
             : certificate.Export(X509ContentType.Pfx, password);
-        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory)) {
+            Directory.CreateDirectory(directory);
+        }
         using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None)) {
             stream.Write(bytes, 0, bytes.Length);
         }


### PR DESCRIPTION
## Summary
- ensure SavePfx and SavePfxForTest only create directories when needed
- test saving PFX without specifying a directory

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bd53dd248832e98e295407059a5a3