### PR TITLE
feat: add order certificate renewal command

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/RenewOrderCertificateExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/RenewOrderCertificateExample.cs
@@ -1,0 +1,33 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Requests;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates renewing a certificate for an order.
+/// </summary>
+public static class RenewOrderCertificateExample {
+    /// <summary>Executes the example that renews an order's certificate.</summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var orders = new OrdersClient(client);
+
+        Console.WriteLine("Renewing certificate for order...");
+        var request = new RenewCertificateRequest {
+            Csr = "<csr>",
+            DcvMode = "EMAIL",
+            DcvEmail = "admin@example.com"
+        };
+        var newId = await orders.RenewCertificateAsync(12345, request);
+        Console.WriteLine($"New certificate id: {newId}");
+    }
+}
+

--- a/SectigoCertificateManager.PowerShell/Examples/NewRenewalExample.ps1
+++ b/SectigoCertificateManager.PowerShell/Examples/NewRenewalExample.ps1
@@ -1,0 +1,3 @@
+# Demonstrates renewing a certificate for an order.
+New-SectigoRenewal -BaseUrl "https://example.com" -Username "user" -Password "pass" -CustomerUri "cst1" -OrderId 10 -Csr "<csr>" -DcvMode "EMAIL" -DcvEmail "admin@example.com" -ApiVersion V25_6
+

--- a/SectigoCertificateManager.PowerShell/NewSectigoRenewalCommand.cs
+++ b/SectigoCertificateManager.PowerShell/NewSectigoRenewalCommand.cs
@@ -1,0 +1,80 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Requests;
+using System.Management.Automation;
+using System.Threading;
+
+namespace SectigoCertificateManager.PowerShell;
+
+/// <summary>Creates a renewal for an existing order.</summary>
+/// <para>Builds an API client and submits a <see cref="RenewCertificateRequest"/>.</para>
+[Cmdlet(VerbsCommon.New, "SectigoRenewal")]
+[CmdletBinding()]
+[OutputType(typeof(int))]
+public sealed class NewSectigoRenewalCommand : PSCmdlet {
+    /// <summary>The API base URL.</summary>
+    [Parameter(Mandatory = true)]
+    public string BaseUrl { get; set; } = string.Empty;
+
+    /// <summary>The user name for authentication.</summary>
+    [Parameter(Mandatory = true)]
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>The password for authentication.</summary>
+    [Parameter(Mandatory = true)]
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>The customer URI assigned by Sectigo.</summary>
+    [Parameter(Mandatory = true)]
+    public string CustomerUri { get; set; } = string.Empty;
+
+    /// <summary>The API version to use.</summary>
+    [Parameter]
+    public ApiVersion ApiVersion { get; set; } = ApiVersion.V25_6;
+
+    /// <summary>The identifier of the order to renew.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public int OrderId { get; set; }
+
+    /// <summary>The certificate signing request.</summary>
+    [Parameter(Mandatory = true)]
+    public string Csr { get; set; } = string.Empty;
+
+    /// <summary>The domain control validation mode.</summary>
+    [Parameter(Mandatory = true)]
+    public string DcvMode { get; set; } = string.Empty;
+
+    /// <summary>The domain control validation email address.</summary>
+    [Parameter]
+    public string? DcvEmail { get; set; }
+
+    /// <summary>Optional cancellation token.</summary>
+    [Parameter]
+    public CancellationToken CancellationToken { get; set; }
+
+    /// <summary>Creates a renewal using provided parameters.</summary>
+    /// <para>Builds an API client and submits a <see cref="RenewCertificateRequest"/>.</para>
+    protected override void ProcessRecord() {
+        var config = new ApiConfig(BaseUrl, Username, Password, CustomerUri, ApiVersion);
+        ISectigoClient? client = null;
+        try {
+            client = TestHooks.ClientFactory?.Invoke(config) ?? new SectigoClient(config);
+            TestHooks.CreatedClient = client;
+            var orders = new OrdersClient(client);
+            var request = new RenewCertificateRequest {
+                Csr = Csr,
+                DcvMode = DcvMode,
+                DcvEmail = DcvEmail
+            };
+            var newId = orders.RenewCertificateAsync(OrderId, request, CancellationToken)
+                .GetAwaiter()
+                .GetResult();
+            WriteObject(newId);
+        } finally {
+            if (client is IDisposable disposable) {
+                disposable.Dispose();
+            }
+        }
+    }
+}
+

--- a/SectigoCertificateManager.Tests/Pester/NewSectigoRenewalCommand.Tests.ps1
+++ b/SectigoCertificateManager.Tests/Pester/NewSectigoRenewalCommand.Tests.ps1
@@ -1,0 +1,13 @@
+Describe "New-SectigoRenewal" {
+    BeforeAll {
+        dotnet build "$PSScriptRoot/../../SectigoCertificateManager.PowerShell" -c Release | Out-Null
+        $dll = Join-Path $PSScriptRoot '../../SectigoCertificateManager.PowerShell/bin/Release/net8.0/SectigoCertificateManager.PowerShell.dll'
+        Import-Module $dll
+    }
+
+    It "exports the cmdlet" {
+        $cmd = Get-Command New-SectigoRenewal -ErrorAction Stop
+        $cmd | Should -Not -BeNullOrEmpty
+    }
+}
+

--- a/SectigoCertificateManager/Clients/OrdersClient.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.cs
@@ -2,6 +2,7 @@ namespace SectigoCertificateManager.Clients;
 
 using SectigoCertificateManager.Models;
 using SectigoCertificateManager.Responses;
+using SectigoCertificateManager.Requests;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
@@ -120,6 +121,27 @@ public sealed partial class OrdersClient : BaseClient {
 
         var response = await _client.PostAsync($"v1/order/{orderId}/cancel", new StringContent(string.Empty), cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>
+    /// Renews a certificate associated with an order.
+    /// </summary>
+    /// <param name="orderId">Identifier of the order.</param>
+    /// <param name="request">Payload describing renewal parameters.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The identifier of the newly issued certificate.</returns>
+    public async Task<int> RenewCertificateAsync(int orderId, RenewCertificateRequest request, CancellationToken cancellationToken = default) {
+        if (orderId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(orderId));
+        }
+
+        Guard.AgainstNull(request, nameof(request));
+
+        var response = await _client.PostAsync($"v1/order/{orderId}/renew", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        var result = await response.Content
+            .ReadFromJsonAsyncSafe<RenewCertificateResponse>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+        return result?.SslId ?? 0;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add RenewCertificateAsync to OrdersClient
- expose renew-certificate option in CLI and New-SectigoRenewal PowerShell cmdlet
- include examples and tests for order renewals

## Testing
- `dotnet test` *(fails: Test method 'DownloadCsvAsync_UsesInvariantCulture' ... has the same name as another method)*
- `pwsh -NoLogo -NoProfile -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted; Install-Module Pester -Scope CurrentUser -Force; Import-Module Pester; Invoke-Pester -Path SectigoCertificateManager.Tests/Pester"`


------
https://chatgpt.com/codex/tasks/task_e_688e77bdc6c4832ebf9ce989f69dbc8f