### PR TITLE
feat(orders): add updated-after filter

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/IncrementalOrderSyncExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/IncrementalOrderSyncExample.cs
@@ -1,0 +1,37 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+using SectigoCertificateManager.Requests;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates incremental synchronization of orders.
+/// </summary>
+public static class IncrementalOrderSyncExample {
+    /// <summary>Executes the example.</summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var orders = new OrdersClient(client);
+
+        var lastSync = DateTime.UtcNow.AddDays(-1);
+        var request = new OrderSearchRequest {
+            Size = 10,
+            UpdatedAfter = lastSync
+        };
+
+        await foreach (var order in orders.EnumerateSearchAsync(request)) {
+            Console.WriteLine($"Processing order {order.Id}");
+        }
+
+        lastSync = DateTime.UtcNow;
+        Console.WriteLine($"Next sync should use {lastSync:s}");
+    }
+}
+

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -11,6 +11,7 @@ await ImportCertificatesExample.RunAsync();
 await ListCertificateTypesExample.RunAsync();
 await UpsertCertificateTypeExample.RunAsync();
 await WatchOrdersExample.RunAsync();
+await IncrementalOrderSyncExample.RunAsync();
 CsrGeneratorExample.Run();
 HttpClientPropertyExample.Run();
 GuardExample.Run();

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -113,7 +113,7 @@ public sealed class CertificatesClientTests {
     }
 
     [Fact]
-    public async Task SearchAsync_UsesInvariantCulture() {
+    public async Task SearchAsync_UsesInvariantCulture_DefaultCulture() {
         var certificate = new Certificate { Id = 1, CommonName = "test" };
         var response = new HttpResponseMessage(HttpStatusCode.OK) {
             Content = JsonContent.Create(new[] { certificate })

--- a/SectigoCertificateManager.Tests/InventoryClientTests.cs
+++ b/SectigoCertificateManager.Tests/InventoryClientTests.cs
@@ -48,7 +48,7 @@ public sealed class InventoryClientTests {
     }
 
     [Fact]
-    public async Task DownloadCsvAsync_UsesInvariantCulture() {
+    public async Task DownloadCsvAsync_UsesInvariantCulture_DefaultCulture() {
         const string csv = "id,commonName\n1,example.com";
         var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(csv) };
 

--- a/SectigoCertificateManager.Tests/OrdersClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrdersClientTests.cs
@@ -231,13 +231,14 @@ public sealed class OrdersClientTests {
             Position = 5,
             Status = OrderStatus.Submitted,
             OrderNumber = 2,
-            BackendCertId = "abc"
+            BackendCertId = "abc",
+            UpdatedAfter = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc)
         };
 
         var result = await orders.SearchAsync(request);
 
         Assert.NotNull(handler.Request);
-        Assert.Equal("https://example.com/v1/order?size=10&position=5&status=Submitted&orderNumber=2&backendCertId=abc", handler.Request!.RequestUri!.ToString());
+        Assert.Equal("https://example.com/v1/order?size=10&position=5&status=Submitted&orderNumber=2&backendCertId=abc&updatedAfter=2023-01-01T00:00:00", handler.Request!.RequestUri!.ToString());
         Assert.NotNull(result);
         Assert.Single(result!.Orders);
         Assert.Equal(4, result.Orders[0].Id);
@@ -260,16 +261,16 @@ public sealed class OrdersClientTests {
         var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
         var orders = new OrdersClient(client);
 
-        var request = new OrderSearchRequest { Size = 1 };
+        var request = new OrderSearchRequest { Size = 1, UpdatedAfter = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
         var results = new List<Order>();
         await foreach (var o in orders.EnumerateSearchAsync(request)) {
             results.Add(o);
         }
 
         Assert.Equal(3, handler.Requests.Count);
-        Assert.Equal("https://example.com/v1/order?size=1", handler.Requests[0].RequestUri!.ToString());
-        Assert.Equal("https://example.com/v1/order?size=1&position=1", handler.Requests[1].RequestUri!.ToString());
-        Assert.Equal("https://example.com/v1/order?size=1&position=2", handler.Requests[2].RequestUri!.ToString());
+        Assert.Equal("https://example.com/v1/order?size=1&updatedAfter=2023-01-01T00:00:00", handler.Requests[0].RequestUri!.ToString());
+        Assert.Equal("https://example.com/v1/order?size=1&position=1&updatedAfter=2023-01-01T00:00:00", handler.Requests[1].RequestUri!.ToString());
+        Assert.Equal("https://example.com/v1/order?size=1&position=2&updatedAfter=2023-01-01T00:00:00", handler.Requests[2].RequestUri!.ToString());
         Assert.Equal(2, results.Count);
     }
 

--- a/SectigoCertificateManager/Clients/OrdersClient.Search.cs
+++ b/SectigoCertificateManager/Clients/OrdersClient.Search.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using SectigoCertificateManager.Utilities;
+using System.Globalization;
 
 public sealed partial class OrdersClient {
     /// <summary>
@@ -108,6 +109,11 @@ public sealed partial class OrdersClient {
         }
         if (!string.IsNullOrEmpty(request.BackendCertId)) {
             query.Add($"backendCertId={Uri.EscapeDataString(request.BackendCertId)}");
+        }
+        if (request.UpdatedAfter.HasValue) {
+            var updated = request.UpdatedAfter.Value.ToUniversalTime()
+                .ToString("s", CultureInfo.InvariantCulture);
+            query.Add($"updatedAfter={updated}");
         }
         return query.Count == 0 ? string.Empty : "?" + string.Join("&", query);
     }

--- a/SectigoCertificateManager/Requests/OrderSearchRequest.cs
+++ b/SectigoCertificateManager/Requests/OrderSearchRequest.cs
@@ -18,4 +18,7 @@ public sealed class OrderSearchRequest {
 
     /// <summary>Gets or sets the backend certificate identifier filter.</summary>
     public string? BackendCertId { get; set; }
+
+    /// <summary>Gets or sets the filter for orders updated after the specified date.</summary>
+    public DateTime? UpdatedAfter { get; set; }
 }


### PR DESCRIPTION
## Summary
- extend `OrderSearchRequest` with `UpdatedAfter`
- include `updatedAfter` in `OrdersClient.SearchAsync`
- add incremental order sync example

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688e77dc11f0832e98b08db3eaa7a356