### PR TITLE
feat(powershell): add CSR validation cmdlet

### DIFF
--- a/Module/SectigoCertificateManager.psd1
+++ b/Module/SectigoCertificateManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Get-SectigoCertificate', 'Get-SectigoOrders', 'Get-SectigoOrdersPage', 'Get-SectigoOrganizations', 'Get-SectigoProfile', 'Get-SectigoProfiles', 'New-SectigoOrder', 'Stop-SectigoOrder', 'Update-SectigoCertificate', 'Remove-SectigoCertificate', 'Wait-SectigoOrder')
+    CmdletsToExport      = @('Get-SectigoCertificate', 'Get-SectigoOrders', 'Get-SectigoOrdersPage', 'Get-SectigoOrganizations', 'Get-SectigoProfile', 'Get-SectigoProfiles', 'New-SectigoOrder', 'Stop-SectigoOrder', 'Update-SectigoCertificate', 'Remove-SectigoCertificate', 'Wait-SectigoOrder', 'Test-SectigoCsr')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/Tests/TestSectigoCsr.Tests.ps1
+++ b/Module/Tests/TestSectigoCsr.Tests.ps1
@@ -1,0 +1,10 @@
+Describe 'Test-SectigoCsr' -Tag 'Cmdlet' {
+    It 'returns true for valid CSR' {
+        $valid = 'MIICVDCCATwCAQAwDzENMAsGA1UEAwwEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMwJzo64p670+fpPa/aEdbFBZJj1BBhOwhw7hHYrPp64mriZFjRfd7mIHaXpoXJ1ZqZm2wjovwh/ZSKv25LD8FaN83RrM175fAl1h3VAs31UE0yl56AUjs2mpMZXiU8E65wmfTdTuy6MhcDziGVmniasL9FC6gt05j2dSaNCZjTEUhP3Nv7abWU1eDuMZ0QdDqrMZXmiS6FaOIZfW4zg0X+oHLFoiy8hF2wa0yg5OcwxtTcrmQhCQxn3GxkZUQFZavhJUGydCFrtOyFULUCZHnDvfCyxZ8duwQCS/2ilOar1SrZ7AGcypV0yXH19LX/WjORdHb7CagDsPCzMQjsvhAECAwEAAaAAMA0GCSqGSIb3DQEBCwUAA4IBAQBWX3mWclTQvnak1cb2LR56QLsTCr9BmRLv9OatWcYG7P7aAJnpIJn57EJj16yBcukvQhmNz6TMMMnWPe6PeUmxB5FIvN7xhcvwVqGGB37SS6GBJOOQb70OAmuwe3plHMNR7Wk6bb/9S2+NYA8KNNXKymGSFhBFDSjC1cU3n7dqE5Smx1Gt2MMcNhidPeJWuxYUugEBtNglqO3sjRRVPV1Ybj1egVSbqxMw2bsGQBAsdSmPTkD0T61nkpVotexRmnts/8D30t744FGJeW1GoCREsy3/c9XJLQPkfJVKWCmLXfKo7p8HjgvbQcDqqmH3yv9vF97dDKAStz/mxxVzsEpr'
+        Test-SectigoCsr -Csr $valid | Should -BeTrue
+    }
+    It 'returns false for invalid CSR' {
+        $invalid = 'MIICVDCCATwCAQAwDzENMAsGA1UEAwwEVGVzdA=='
+        Test-SectigoCsr -Csr $invalid | Should -BeFalse
+    }
+}

--- a/SectigoCertificateManager.Examples/Examples/CsrValidatorExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/CsrValidatorExample.cs
@@ -1,0 +1,17 @@
+using System;
+using SectigoCertificateManager.Utilities;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates validating certificate signing requests.
+/// </summary>
+public static class CsrValidatorExample {
+    /// <summary>Executes the example.</summary>
+    public static void Run() {
+        var (csr, key) = CsrGenerator.GenerateRsa("CN=example.com");
+        var valid = CsrValidator.IsValid(csr);
+        Console.WriteLine($"CSR valid: {valid}");
+        key.Dispose();
+    }
+}

--- a/SectigoCertificateManager.PowerShell/TestSectigoCsrCommand.cs
+++ b/SectigoCertificateManager.PowerShell/TestSectigoCsrCommand.cs
@@ -1,0 +1,28 @@
+using SectigoCertificateManager.Utilities;
+using System.Management.Automation;
+
+namespace SectigoCertificateManager.PowerShell;
+
+/// <summary>Validates a certificate signing request.</summary>
+/// <para>Determines whether the provided CSR is structurally valid.</para>
+/// <example>
+///   <summary>Validate a CSR</summary>
+///   <prefix>PS> </prefix>
+///   <code>Test-SectigoCsr -Csr $csr</code>
+///   <para>Returns <c>$true</c> when the CSR is valid.</para>
+/// </example>
+[Cmdlet(VerbsDiagnostic.Test, "SectigoCsr")]
+[CmdletBinding()]
+[OutputType(typeof(bool))]
+public sealed class TestSectigoCsrCommand : PSCmdlet {
+    /// <summary>The base64-encoded certificate signing request.</summary>
+    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    public string Csr { get; set; } = string.Empty;
+
+    /// <summary>Executes the cmdlet.</summary>
+    /// <para>Outputs <c>true</c> if the CSR is valid; otherwise, <c>false</c>.</para>
+    protected override void ProcessRecord() {
+        var result = CsrValidator.IsValid(Csr);
+        WriteObject(result);
+    }
+}

--- a/SectigoCertificateManager.Tests/CsrValidatorTests.cs
+++ b/SectigoCertificateManager.Tests/CsrValidatorTests.cs
@@ -1,0 +1,24 @@
+using SectigoCertificateManager.Utilities;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="CsrValidator"/> helpers.
+/// </summary>
+public sealed class CsrValidatorTests {
+    private const string ValidCsr = "MIICVDCCATwCAQAwDzENMAsGA1UEAwwEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMwJzo64p670+fpPa/aEdbFBZJj1BBhOwhw7hHYrPp64mriZFjRfd7mIHaXpoXJ1ZqZm2wjovwh/ZSKv25LD8FaN83RrM175fAl1h3VAs31UE0yl56AUjs2mpMZXiU8E65wmfTdTuy6MhcDziGVmniasL9FC6gt05j2dSaNCZjTEUhP3Nv7abWU1eDuMZ0QdDqrMZXmiS6FaOIZfW4zg0X+oHLFoiy8hF2wa0yg5OcwxtTcrmQhCQxn3GxkZUQFZavhJUGydCFrtOyFULUCZHnDvfCyxZ8duwQCS/2ilOar1SrZ7AGcypV0yXH19LX/WjORdHb7CagDsPCzMQjsvhAECAwEAAaAAMA0GCSqGSIb3DQEBCwUAA4IBAQBWX3mWclTQvnak1cb2LR56QLsTCr9BmRLv9OatWcYG7P7aAJnpIJn57EJj16yBcukvQhmNz6TMMMnWPe6PeUmxB5FIvN7xhcvwVqGGB37SS6GBJOOQb70OAmuwe3plHMNR7Wk6bb/9S2+NYA8KNNXKymGSFhBFDSjC1cU3n7dqE5Smx1Gt2MMcNhidPeJWuxYUugEBtNglqO3sjRRVPV1Ybj1egVSbqxMw2bsGQBAsdSmPTkD0T61nkpVotexRmnts/8D30t744FGJeW1GoCREsy3/c9XJLQPkfJVKWCmLXfKo7p8HjgvbQcDqqmH3yv9vF97dDKAStz/mxxVzsEpr";
+    private const string InvalidCsr = "MIICVDCCATwCAQAwDzENMAsGA1UEAwwEVGVzdA==";
+
+    /// <summary>Returns true for valid CSR.</summary>
+    [Fact]
+    public void IsValid_ReturnsTrue_ForValidCsr() {
+        Assert.True(CsrValidator.IsValid(ValidCsr));
+    }
+
+    /// <summary>Returns false for invalid CSR.</summary>
+    [Fact]
+    public void IsValid_ReturnsFalse_ForInvalidCsr() {
+        Assert.False(CsrValidator.IsValid(InvalidCsr));
+    }
+}

--- a/SectigoCertificateManager/Utilities/CsrValidator.cs
+++ b/SectigoCertificateManager/Utilities/CsrValidator.cs
@@ -1,0 +1,34 @@
+namespace SectigoCertificateManager.Utilities;
+
+using System;
+using System.Formats.Asn1;
+using System.Security.Cryptography;
+
+/// <summary>
+/// Provides helpers for validating certificate signing requests.
+/// </summary>
+public static class CsrValidator {
+    /// <summary>
+    /// Determines whether the specified CSR is structurally valid.
+    /// </summary>
+    /// <param name="csr">Base64-encoded certificate signing request.</param>
+    /// <returns><c>true</c> when the CSR is valid; otherwise, <c>false</c>.</returns>
+    public static bool IsValid(string csr) {
+        Guard.AgainstNullOrWhiteSpace(csr, nameof(csr));
+        try {
+            var data = Convert.FromBase64String(csr);
+            var reader = new AsnReader(data, AsnEncodingRules.DER);
+            var sequence = reader.ReadSequence();
+            sequence.ReadSequence();
+            sequence.ReadSequence();
+            sequence.ReadBitString(out _);
+            return !sequence.HasData && !reader.HasData;
+        } catch (FormatException) {
+            return false;
+        } catch (AsnContentException) {
+            return false;
+        } catch (CryptographicException) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add CSR validator utility
- expose Test-SectigoCsr cmdlet
- cover CSR validation with unit and Pester tests

## Testing
- `dotnet build SectigoCertificateManager/SectigoCertificateManager.csproj`
- `dotnet build SectigoCertificateManager.PowerShell/SectigoCertificateManager.PowerShell.csproj`
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj` *(fails: xUnit1024 duplicate test names)*
- `pwsh -NoLogo -File Module/SectigoCertificateManager.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_688e77afc5e4832eb109efd0b89128e8