### PR TITLE
ci: skip psd1 push on PRs

### DIFF
--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -40,9 +40,9 @@ jobs:
         shell: pwsh
 
       - name: Commit refreshed PSD1
+        if: ${{ github.event_name == 'push' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          HEAD_BRANCH: ${{ github.ref_name }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- avoid failing `refresh-psd1` job on pull requests by skipping push step

## Testing
- `dotnet build SectigoCertificateManager.sln`
- `dotnet test SectigoCertificateManager.sln` *(fails: 206 Failed)*
- `pwsh -NoLogo -NoProfile -Command './Module/SectigoCertificateManager.Tests.ps1'`

------
https://chatgpt.com/codex/tasks/task_e_689659bdbbe4832e92622793e0a76561