### PR TITLE
Validate ProgressStreamContent buffer size

### DIFF
--- a/SectigoCertificateManager.Tests/ProgressStreamContentTests.cs
+++ b/SectigoCertificateManager.Tests/ProgressStreamContentTests.cs
@@ -1,0 +1,21 @@
+using SectigoCertificateManager.Utilities;
+using System;
+using System.IO;
+using Xunit;
+
+namespace SectigoCertificateManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="ProgressStreamContent"/>.
+/// </summary>
+public sealed class ProgressStreamContentTests {
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_InvalidBufferSize_Throws(int bufferSize) {
+        using var stream = new MemoryStream(new byte[1]);
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ProgressStreamContent(stream, progress: null, bufferSize: bufferSize));
+        Assert.Equal("bufferSize", ex.ParamName);
+    }
+}

--- a/SectigoCertificateManager/Utilities/ProgressStreamContent.cs
+++ b/SectigoCertificateManager/Utilities/ProgressStreamContent.cs
@@ -24,6 +24,10 @@ internal sealed class ProgressStreamContent : HttpContent {
     public ProgressStreamContent(Stream stream, IProgress<double>? progress = null, int bufferSize = 81920) {
         _stream = Guard.AgainstNull(stream, nameof(stream));
         _progress = progress;
+        if (bufferSize <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(bufferSize), "Buffer size must be greater than 0.");
+        }
+
         _bufferSize = bufferSize;
     }
 


### PR DESCRIPTION
## Summary
- throw `ArgumentOutOfRangeException` when `ProgressStreamContent` receives a non-positive buffer size
- add unit tests for invalid buffer sizes

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c9849fee0832eb0a28d01917a8b18