### PR TITLE
Remove placeholder class and add error-handling example

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/ErrorHandlingExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/ErrorHandlingExample.cs
@@ -1,0 +1,28 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates handling API errors.
+/// </summary>
+public static class ErrorHandlingExample {
+    /// <summary>
+    /// Executes the example showing how to catch <see cref="ApiException"/>.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .Build();
+
+        try {
+            using var client = new SectigoClient(config);
+            var certificates = new CertificatesClient(client);
+            await certificates.GetAsync(-1);
+        } catch (ApiException ex) {
+            Console.WriteLine($"API error ({ex.ErrorCode}): {ex.Message}");
+        }
+    }
+}

--- a/SectigoCertificateManager/Class1.cs
+++ b/SectigoCertificateManager/Class1.cs
@@ -1,9 +1,0 @@
-﻿namespace SectigoCertificateManager;
-
-/// <summary>
-/// Example class used for testing purposes.
-/// </summary>
-public class Class1 {
-    /// <summary>Gets the name of the class.</summary>
-    public string Name => nameof(Class1);
-}


### PR DESCRIPTION
## Summary
- remove placeholder `Class1` from main library
- add `ErrorHandlingExample` to demonstrate basic API error handling

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c983fa1e4832ea21ff5bf7b5799e8