### PR TITLE
feat(client): refresh tokens before expiry

### DIFF
--- a/SectigoCertificateManager/ApiConfig.cs
+++ b/SectigoCertificateManager/ApiConfig.cs
@@ -19,6 +19,10 @@ using System.Threading.Tasks;
 /// <param name="token">Optional bearer token used for authentication.</param>
 /// <param name="tokenExpiresAt">Optional expiration time for <paramref name="token"/>.</param>
 /// <param name="refreshToken">Optional delegate used to refresh the token.</param>
+/// <param name="tokenRefreshThreshold">
+/// Optional buffer period before token expiration after which a refresh should occur.
+/// Defaults to one minute if not specified.
+/// </param>
 public sealed class ApiConfig(
     string baseUrl,
     string username,
@@ -30,7 +34,8 @@ public sealed class ApiConfig(
     string? token = null,
     DateTimeOffset? tokenExpiresAt = null,
     Func<CancellationToken, Task<TokenInfo>>? refreshToken = null,
-    int? concurrencyLimit = null) {
+    int? concurrencyLimit = null,
+    TimeSpan? tokenRefreshThreshold = null) {
     /// <summary>Gets the base URL of the API endpoint.</summary>
     public string BaseUrl { get; } = baseUrl;
 
@@ -63,4 +68,9 @@ public sealed class ApiConfig(
 
     /// <summary>Gets the optional concurrency limit for HTTP requests.</summary>
     public int? ConcurrencyLimit { get; } = concurrencyLimit;
+
+    /// <summary>
+    /// Gets the buffer period before token expiration that triggers a refresh.
+    /// </summary>
+    public TimeSpan TokenRefreshThreshold { get; } = tokenRefreshThreshold ?? TimeSpan.FromMinutes(1);
 }

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -23,6 +23,7 @@ public sealed class ApiConfigBuilder {
     private X509Certificate2? _clientCertificate;
     private Action<HttpClientHandler>? _configureHandler;
     private int? _concurrencyLimit;
+    private TimeSpan? _tokenRefreshThreshold;
 
     /// <summary>Sets the base URL for the API endpoint.</summary>
     /// <param name="baseUrl">The root URL of the Sectigo API.</param>
@@ -151,6 +152,19 @@ public sealed class ApiConfigBuilder {
         return this;
     }
 
+    /// <summary>Sets the buffer period before token expiration that triggers a refresh.</summary>
+    /// <param name="threshold">Duration before expiration to refresh the token.</param>
+    public ApiConfigBuilder WithTokenRefreshThreshold(TimeSpan threshold) {
+        if (threshold < TimeSpan.Zero) {
+            throw new ArgumentOutOfRangeException(nameof(threshold));
+        }
+
+        lock (_lock) {
+            _tokenRefreshThreshold = threshold;
+        }
+        return this;
+    }
+
     /// <summary>Builds a new <see cref="ApiConfig"/> instance using configured values.</summary>
     public ApiConfig Build() {
         lock (_lock) {
@@ -181,7 +195,8 @@ public sealed class ApiConfigBuilder {
                 _token,
                 _tokenExpiresAt,
                 _refreshToken,
-                _concurrencyLimit);
+                _concurrencyLimit,
+                _tokenRefreshThreshold);
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow configuring a token refresh threshold in `ApiConfig` and builder
- refresh tokens when expiry is within the threshold
- add tests covering pre-expiry refresh

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689c98540ec0832e8855ec93325421ae