### PR TITLE
fix: deduplicate SANs in certificate request builder

### DIFF
--- a/SectigoCertificateManager.Tests/IssueCertificateRequestTests.cs
+++ b/SectigoCertificateManager.Tests/IssueCertificateRequestTests.cs
@@ -35,4 +35,17 @@ public sealed class IssueCertificateRequestTests {
         Assert.Equal(5, request.ProfileId);
         Assert.Equal(12, request.Term);
     }
+
+    [Fact]
+    public void Builder_WithSubjectAlternativeNames_CollapsesDuplicates() {
+        var builder = new IssueCertificateRequestBuilder(new[] { 12 });
+        var request = builder
+            .WithSubjectAlternativeNames(new[] { "a.example.com", "a.example.com", "b.example.com" })
+            .WithTerm(12)
+            .Build();
+
+        Assert.Equal(2, request.SubjectAlternativeNames.Count);
+        Assert.Contains("a.example.com", request.SubjectAlternativeNames);
+        Assert.Contains("b.example.com", request.SubjectAlternativeNames);
+    }
 }

--- a/SectigoCertificateManager/Requests/IssueCertificateRequestBuilder.cs
+++ b/SectigoCertificateManager/Requests/IssueCertificateRequestBuilder.cs
@@ -11,6 +11,7 @@ using SectigoCertificateManager.Utilities;
 public sealed class IssueCertificateRequestBuilder {
     private readonly IssueCertificateRequest _request = new();
     private readonly IReadOnlyList<int> _allowedTerms;
+    private readonly HashSet<string> _subjectAlternativeNames = new();
     private readonly object _lock = new();
 
     /// <summary>
@@ -52,7 +53,12 @@ public sealed class IssueCertificateRequestBuilder {
     /// <summary>Sets subject alternative names.</summary>
     public IssueCertificateRequestBuilder WithSubjectAlternativeNames(IEnumerable<string> sans) {
         lock (_lock) {
-            _request.SubjectAlternativeNames = sans?.ToArray() ?? Array.Empty<string>();
+            _subjectAlternativeNames.Clear();
+            if (sans is not null) {
+                foreach (var san in sans) {
+                    _subjectAlternativeNames.Add(san);
+                }
+            }
         }
         return this;
     }
@@ -64,7 +70,7 @@ public sealed class IssueCertificateRequestBuilder {
                 CommonName = _request.CommonName,
                 ProfileId = _request.ProfileId,
                 Term = _request.Term,
-                SubjectAlternativeNames = _request.SubjectAlternativeNames.ToArray()
+                SubjectAlternativeNames = _subjectAlternativeNames.ToArray()
             };
         }
     }


### PR DESCRIPTION
## Summary
- store Subject Alternative Names as a set to prevent duplicates
- test that builder collapses duplicate SAN inputs

## Testing
- `dotnet test`
- `dotnet test --framework net8.0 --no-build`


------
https://chatgpt.com/codex/tasks/task_e_689c984f39f8832e80aaaeeb09059fb1