### PR TITLE
ci: migrate to hosted runners and add macOS/Linux testing

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,6 @@ on:
   workflow_dispatch:
 
 env:
-  DOTNET_VERSION: '9.x'
   BUILD_CONFIGURATION: 'Debug'
 
 jobs:
@@ -29,7 +28,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            9.0.x
+            8.0.x
 
       - name: Restore dependencies
         run: dotnet restore SectigoCertificateManager.sln
@@ -65,7 +66,14 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            9.0.x
+            8.0.x
+
+      - name: Install Mono
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mono-complete
 
       - name: Restore dependencies
         run: dotnet restore SectigoCertificateManager.sln
@@ -101,7 +109,12 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            9.0.x
+            8.0.x
+
+      - name: Install Mono
+        run: brew install mono
 
       - name: Restore dependencies
         run: dotnet restore SectigoCertificateManager.sln

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -14,7 +14,6 @@ on:
   workflow_dispatch:
 
 env:
-  DOTNET_VERSION: '8.x'
   BUILD_CONFIGURATION: 'Debug'
 
 jobs:
@@ -28,6 +27,13 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            8.0.x
 
       - name: Setup PowerShell modules
         run: |
@@ -78,7 +84,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            9.0.x
+            8.0.x
 
       - name: Install PowerShell modules
         shell: powershell
@@ -117,7 +125,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            9.0.x
+            8.0.x
 
       - name: Install PowerShell modules
         shell: pwsh
@@ -156,7 +166,14 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            9.0.x
+            8.0.x
+
+      - name: Install Mono
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mono-complete
 
       - name: Install PowerShell modules
         shell: pwsh
@@ -195,7 +212,12 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            9.0.x
+            8.0.x
+
+      - name: Install Mono
+        run: brew install mono
 
       - name: Install PowerShell modules
         shell: pwsh


### PR DESCRIPTION
## Summary
- run .NET tests on GitHub-hosted Windows, Linux, and macOS runners
- run PowerShell tests on hosted Windows, Linux, and macOS runners
- limit each job to 10 minutes

## Testing
- `dotnet test SectigoCertificateManager.Tests/SectigoCertificateManager.Tests.csproj --configuration Debug -l "console;verbosity=detailed"`
- `pwsh -Command "Import-Module Pester; Invoke-Pester -Script Module/Tests -Output Detailed"` *(fails: CommandNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_689c9adc0534832eabd7f0db58465f1b