### PR TITLE
feat(client): add configurable 5xx retry logic

### DIFF
--- a/SectigoCertificateManager.Tests/ApiErrorHandlerTests.cs
+++ b/SectigoCertificateManager.Tests/ApiErrorHandlerTests.cs
@@ -24,7 +24,7 @@ public sealed class ApiErrorHandlerTests {
     }
 
     private static SectigoClient CreateClient(HttpResponseMessage response) {
-        var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
+        var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4, concurrencyLimit: null, retryCount: 1);
         var handler = new RespondingHandler(response);
         return new SectigoClient(config, new HttpClient(handler));
     }

--- a/SectigoCertificateManager/ApiConfig.cs
+++ b/SectigoCertificateManager/ApiConfig.cs
@@ -30,7 +30,9 @@ public sealed class ApiConfig(
     string? token = null,
     DateTimeOffset? tokenExpiresAt = null,
     Func<CancellationToken, Task<TokenInfo>>? refreshToken = null,
-    int? concurrencyLimit = null) {
+    int? concurrencyLimit = null,
+    int retryCount = 5,
+    TimeSpan? retryInitialDelay = null) {
     /// <summary>Gets the base URL of the API endpoint.</summary>
     public string BaseUrl { get; } = baseUrl;
 
@@ -63,4 +65,10 @@ public sealed class ApiConfig(
 
     /// <summary>Gets the optional concurrency limit for HTTP requests.</summary>
     public int? ConcurrencyLimit { get; } = concurrencyLimit;
+
+    /// <summary>Gets the maximum number of retry attempts for transient failures.</summary>
+    public int RetryCount { get; } = retryCount;
+
+    /// <summary>Gets the initial delay used for exponential backoff when retrying.</summary>
+    public TimeSpan RetryInitialDelay { get; } = retryInitialDelay ?? TimeSpan.FromSeconds(1);
 }


### PR DESCRIPTION
## Summary
- add retry configuration options to `ApiConfig` and builder
- retry transient 5xx responses with exponential backoff in `SectigoClient`
- cover retry logic with new unit tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cbb5292b4832e9080fcc67c272d1c