### PR TITLE
fix(core): guard against null token info

### DIFF
--- a/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
+++ b/SectigoCertificateManager.Tests/ApiConfigLoaderTests.cs
@@ -120,6 +120,11 @@ public sealed class ApiConfigLoaderTests {
     }
 
     [Fact]
+    public void WriteToken_WithNullInfo_Throws() {
+        Assert.Throws<ArgumentNullException>(() => ApiConfigLoader.WriteToken(null!));
+    }
+
+    [Fact]
     public void Load_FromTokenCache() {
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempDir);

--- a/SectigoCertificateManager/ApiConfigLoader.cs
+++ b/SectigoCertificateManager/ApiConfigLoader.cs
@@ -60,6 +60,10 @@ public static class ApiConfigLoader {
     }
 
     public static void WriteToken(TokenInfo info, string? path = null) {
+        if (info is null) {
+            throw new ArgumentNullException(nameof(info));
+        }
+
         var tokenPath = GetTokenPath(path);
         var dir = Path.GetDirectoryName(tokenPath);
         if (!string.IsNullOrEmpty(dir)) {


### PR DESCRIPTION
## Summary
- validate token info before writing to cache
- cover null token case with unit test

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cbb3e703c832eaa418396315cc801