### PR TITLE
refactor(clients): split CertificatesClient into focused partial classes

### DIFF
--- a/SectigoCertificateManager/Clients/CertificatesClient.Core.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Core.cs
@@ -5,73 +5,18 @@ using SectigoCertificateManager.Requests;
 using SectigoCertificateManager.Responses;
 using SectigoCertificateManager.Utilities;
 using System.Globalization;
-using System.IO;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Text.Json;
 
 /// <summary>
 /// Provides access to certificate related endpoints.
 /// </summary>
 public sealed partial class CertificatesClient : BaseClient {
-
     /// <summary>
     /// Initializes a new instance of the <see cref="CertificatesClient"/> class.
     /// </summary>
     /// <param name="client">HTTP client wrapper.</param>
     public CertificatesClient(ISectigoClient client) : base(client) {
-    }
-
-    /// <summary>
-    /// Retrieves a certificate by identifier.
-    /// </summary>
-    /// <param name="certificateId">Identifier of the certificate to retrieve.</param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    public async Task<Certificate?> GetAsync(int certificateId, CancellationToken cancellationToken = default) {
-        if (certificateId <= 0) {
-            throw new ArgumentOutOfRangeException(nameof(certificateId));
-        }
-
-        var response = await _client.GetAsync($"v1/certificate/{certificateId}", cancellationToken).ConfigureAwait(false);
-        return await response.Content
-            .ReadFromJsonAsyncSafe<Certificate>(s_json, cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Retrieves the status of a certificate by identifier.
-    /// </summary>
-    /// <param name="certificateId">Identifier of the certificate.</param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    public async Task<CertificateStatus?> GetStatusAsync(int certificateId, CancellationToken cancellationToken = default) {
-        if (certificateId <= 0) {
-            throw new ArgumentOutOfRangeException(nameof(certificateId));
-        }
-
-        var response = await _client.GetAsync($"v1/certificate/{certificateId}/status", cancellationToken).ConfigureAwait(false);
-        var result = await response.Content
-            .ReadFromJsonAsyncSafe<StatusResponse>(s_json, cancellationToken)
-            .ConfigureAwait(false);
-        return result?.Status;
-    }
-
-    /// <summary>
-    /// Retrieves revocation details for a certificate by identifier.
-    /// </summary>
-    /// <param name="certificateId">Identifier of the certificate.</param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    public async Task<CertificateRevocation?> GetRevocationAsync(int certificateId, CancellationToken cancellationToken = default) {
-        if (certificateId <= 0) {
-            throw new ArgumentOutOfRangeException(nameof(certificateId));
-        }
-
-        var response = await _client.GetAsync($"v1/certificate/{certificateId}/revocation", cancellationToken).ConfigureAwait(false);
-        return await response.Content
-            .ReadFromJsonAsyncSafe<CertificateRevocation>(s_json, cancellationToken)
-            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -105,40 +50,6 @@ public sealed partial class CertificatesClient : BaseClient {
     }
 
     /// <summary>
-    /// Renews a certificate by identifier.
-    /// </summary>
-    /// <param name="certificateId">Identifier of the certificate to renew.</param>
-    /// <param name="request">Payload describing renewal parameters.</param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>The identifier of the newly issued certificate.</returns>
-    public async Task<int> RenewAsync(int certificateId, RenewCertificateRequest request, CancellationToken cancellationToken = default) {
-        Guard.AgainstNull(request, nameof(request));
-
-        var response = await _client.PostAsync($"v1/certificate/renewById/{certificateId}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
-        var result = await response.Content
-            .ReadFromJsonAsyncSafe<RenewCertificateResponse>(s_json, cancellationToken)
-            .ConfigureAwait(false);
-        return result?.SslId ?? 0;
-    }
-
-    /// <summary>
-    /// Renews a certificate by order number.
-    /// </summary>
-    /// <param name="orderNumber">Order number used to identify the certificate.</param>
-    /// <param name="request">Payload describing renewal parameters.</param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>The identifier of the newly issued certificate.</returns>
-    public async Task<int> RenewByOrderNumberAsync(long orderNumber, RenewCertificateRequest request, CancellationToken cancellationToken = default) {
-        Guard.AgainstNull(request, nameof(request));
-
-        var response = await _client.PostAsync($"v1/certificate/renew/{orderNumber}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
-        var result = await response.Content
-            .ReadFromJsonAsyncSafe<RenewCertificateResponse>(s_json, cancellationToken)
-            .ConfigureAwait(false);
-        return result?.SslId ?? 0;
-    }
-
-    /// <summary>
     /// Deletes a certificate by identifier.
     /// </summary>
     /// <param name="certificateId">Identifier of the certificate to delete.</param>
@@ -167,35 +78,6 @@ public sealed partial class CertificatesClient : BaseClient {
             .ConfigureAwait(false);
         return await response.Content
             .ReadFromJsonAsyncSafe<ValidateCertificateResponse>(s_json, cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Imports certificates using a zip archive.
-    /// </summary>
-    /// <param name="orgId">Identifier of the organization.</param>
-    /// <param name="stream">Zip archive containing certificates.</param>
-    /// <param name="fileName">File name to use for the upload.</param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    public async Task<ImportCertificateResponse?> ImportAsync(
-        int orgId,
-        Stream stream,
-        string fileName,
-        CancellationToken cancellationToken = default) {
-        if (orgId <= 0) {
-            throw new ArgumentOutOfRangeException(nameof(orgId));
-        }
-        Guard.AgainstNull(stream, nameof(stream));
-        Guard.AgainstNullOrEmpty(fileName, nameof(fileName), "File name cannot be null or empty.");
-
-        var content = new MultipartFormDataContent();
-        var fileContent = new StreamContent(stream);
-        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
-        content.Add(fileContent, "file", fileName);
-
-        var response = await _client.PostAsync($"v1/certificate/import?orgId={orgId}", content, cancellationToken).ConfigureAwait(false);
-        return await response.Content
-            .ReadFromJsonAsyncSafe<ImportCertificateResponse>(s_json, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -280,10 +162,5 @@ public sealed partial class CertificatesClient : BaseClient {
         AppendDate("dateTo", request.DateTo);
 
         return builder.ToString();
-    }
-
-    private sealed class StatusResponse {
-        /// <summary>Gets or sets the certificate status.</summary>
-        public CertificateStatus Status { get; set; }
     }
 }

--- a/SectigoCertificateManager/Clients/CertificatesClient.Import.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Import.cs
@@ -1,0 +1,39 @@
+namespace SectigoCertificateManager.Clients;
+
+using SectigoCertificateManager.Responses;
+using SectigoCertificateManager.Utilities;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+public sealed partial class CertificatesClient : BaseClient {
+    /// <summary>
+    /// Imports certificates using a zip archive.
+    /// </summary>
+    /// <param name="orgId">Identifier of the organization.</param>
+    /// <param name="stream">Zip archive containing certificates.</param>
+    /// <param name="fileName">File name to use for the upload.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<ImportCertificateResponse?> ImportAsync(
+        int orgId,
+        Stream stream,
+        string fileName,
+        CancellationToken cancellationToken = default) {
+        if (orgId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(orgId));
+        }
+        Guard.AgainstNull(stream, nameof(stream));
+        Guard.AgainstNullOrEmpty(fileName, nameof(fileName), "File name cannot be null or empty.");
+
+        var content = new MultipartFormDataContent();
+        var fileContent = new StreamContent(stream);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
+        content.Add(fileContent, "file", fileName);
+
+        var response = await _client.PostAsync($"v1/certificate/import?orgId={orgId}", content, cancellationToken).ConfigureAwait(false);
+        return await response.Content
+            .ReadFromJsonAsyncSafe<ImportCertificateResponse>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/SectigoCertificateManager/Clients/CertificatesClient.Renewal.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Renewal.cs
@@ -1,0 +1,42 @@
+namespace SectigoCertificateManager.Clients;
+
+using SectigoCertificateManager.Requests;
+using SectigoCertificateManager.Responses;
+using SectigoCertificateManager.Utilities;
+using System.Net.Http.Json;
+
+public sealed partial class CertificatesClient : BaseClient {
+    /// <summary>
+    /// Renews a certificate by identifier.
+    /// </summary>
+    /// <param name="certificateId">Identifier of the certificate to renew.</param>
+    /// <param name="request">Payload describing renewal parameters.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The identifier of the newly issued certificate.</returns>
+    public async Task<int> RenewAsync(int certificateId, RenewCertificateRequest request, CancellationToken cancellationToken = default) {
+        Guard.AgainstNull(request, nameof(request));
+
+        var response = await _client.PostAsync($"v1/certificate/renewById/{certificateId}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        var result = await response.Content
+            .ReadFromJsonAsyncSafe<RenewCertificateResponse>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+        return result?.SslId ?? 0;
+    }
+
+    /// <summary>
+    /// Renews a certificate by order number.
+    /// </summary>
+    /// <param name="orderNumber">Order number used to identify the certificate.</param>
+    /// <param name="request">Payload describing renewal parameters.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The identifier of the newly issued certificate.</returns>
+    public async Task<int> RenewByOrderNumberAsync(long orderNumber, RenewCertificateRequest request, CancellationToken cancellationToken = default) {
+        Guard.AgainstNull(request, nameof(request));
+
+        var response = await _client.PostAsync($"v1/certificate/renew/{orderNumber}", JsonContent.Create(request, options: s_json), cancellationToken).ConfigureAwait(false);
+        var result = await response.Content
+            .ReadFromJsonAsyncSafe<RenewCertificateResponse>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+        return result?.SslId ?? 0;
+    }
+}

--- a/SectigoCertificateManager/Clients/CertificatesClient.Retrieval.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Retrieval.cs
@@ -1,0 +1,62 @@
+namespace SectigoCertificateManager.Clients;
+
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Responses;
+using SectigoCertificateManager.Utilities;
+using System.Net.Http.Json;
+
+public sealed partial class CertificatesClient : BaseClient {
+    /// <summary>
+    /// Retrieves a certificate by identifier.
+    /// </summary>
+    /// <param name="certificateId">Identifier of the certificate to retrieve.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<Certificate?> GetAsync(int certificateId, CancellationToken cancellationToken = default) {
+        if (certificateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(certificateId));
+        }
+
+        var response = await _client.GetAsync($"v1/certificate/{certificateId}", cancellationToken).ConfigureAwait(false);
+        return await response.Content
+            .ReadFromJsonAsyncSafe<Certificate>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Retrieves the status of a certificate by identifier.
+    /// </summary>
+    /// <param name="certificateId">Identifier of the certificate.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<CertificateStatus?> GetStatusAsync(int certificateId, CancellationToken cancellationToken = default) {
+        if (certificateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(certificateId));
+        }
+
+        var response = await _client.GetAsync($"v1/certificate/{certificateId}/status", cancellationToken).ConfigureAwait(false);
+        var result = await response.Content
+            .ReadFromJsonAsyncSafe<StatusResponse>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+        return result?.Status;
+    }
+
+    /// <summary>
+    /// Retrieves revocation details for a certificate by identifier.
+    /// </summary>
+    /// <param name="certificateId">Identifier of the certificate.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<CertificateRevocation?> GetRevocationAsync(int certificateId, CancellationToken cancellationToken = default) {
+        if (certificateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(certificateId));
+        }
+
+        var response = await _client.GetAsync($"v1/certificate/{certificateId}/revocation", cancellationToken).ConfigureAwait(false);
+        return await response.Content
+            .ReadFromJsonAsyncSafe<CertificateRevocation>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private sealed class StatusResponse {
+        /// <summary>Gets or sets the certificate status.</summary>
+        public CertificateStatus Status { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- extract certificate retrieval operations into `CertificatesClient.Retrieval`
- add dedicated renewal and import partials
- keep `CertificatesClient.Core` focused on issuance, revocation and helpers

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cbb311968832eb5c0bd9d11b1eb0f