### PR TITLE
feat(api): include status code and body snippet in error messages

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/ApiErrorHandlingExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/ApiErrorHandlingExample.cs
@@ -1,0 +1,27 @@
+using SectigoCertificateManager;
+using System;
+using System.Threading.Tasks;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates handling API error responses and enhanced messages.
+/// </summary>
+public static class ApiErrorHandlingExample {
+    /// <summary>Runs the example showing enhanced error messages.</summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .Build();
+
+        using var client = new SectigoClient(config);
+
+        try {
+            await client.GetAsync("v1/nonexistent");
+        } catch (ApiException ex) {
+            Console.WriteLine(ex.Message);
+        }
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -17,3 +17,4 @@ HttpClientPropertyExample.Run();
 GuardExample.Run();
 CombineCertKeyToPfxExample.Run();
 await StreamCertificatesBytesExample.RunAsync();
+await ApiErrorHandlingExample.RunAsync();


### PR DESCRIPTION
## Summary
- include HTTP status code and truncated response body in API error messages
- add unit tests for enhanced error handling
- add example demonstrating improved error messages

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cbb2c2a28832eb05e6683256945ec