### PR TITLE
feat: refresh token ahead of expiration

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/TokenRefreshExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/TokenRefreshExample.cs
@@ -20,6 +20,7 @@ public static class TokenRefreshExample {
             .WithCustomerUri("<customer uri>")
             .WithToken("<initial token>")
             .WithTokenExpiration(DateTimeOffset.UtcNow.AddMinutes(30))
+            .WithTokenRefreshThreshold(TimeSpan.FromMinutes(1))
             .WithTokenRefresh(RefreshTokenAsync);
 
         var config = builder.Build();

--- a/SectigoCertificateManager/ApiConfig.cs
+++ b/SectigoCertificateManager/ApiConfig.cs
@@ -30,6 +30,7 @@ public sealed class ApiConfig(
     string? token = null,
     DateTimeOffset? tokenExpiresAt = null,
     Func<CancellationToken, Task<TokenInfo>>? refreshToken = null,
+    TimeSpan? tokenRefreshThreshold = null,
     int? concurrencyLimit = null,
     int retryCount = 5,
     TimeSpan? retryInitialDelay = null) {
@@ -62,6 +63,9 @@ public sealed class ApiConfig(
 
     /// <summary>Gets the delegate used to refresh the token, if any.</summary>
     public Func<CancellationToken, Task<TokenInfo>>? RefreshToken { get; } = refreshToken;
+
+    /// <summary>Gets the threshold before expiration when the token should be refreshed.</summary>
+    public TimeSpan TokenRefreshThreshold { get; } = tokenRefreshThreshold ?? TimeSpan.FromMinutes(1);
 
     /// <summary>Gets the optional concurrency limit for HTTP requests.</summary>
     public int? ConcurrencyLimit { get; } = concurrencyLimit;

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -25,6 +25,7 @@ public sealed class ApiConfigBuilder {
     private int? _concurrencyLimit;
     private int _retryCount = 5;
     private TimeSpan _retryInitialDelay = TimeSpan.FromSeconds(1);
+    private TimeSpan _tokenRefreshThreshold = TimeSpan.FromMinutes(1);
 
     /// <summary>Sets the base URL for the API endpoint.</summary>
     /// <param name="baseUrl">The root URL of the Sectigo API.</param>
@@ -78,6 +79,19 @@ public sealed class ApiConfigBuilder {
     public ApiConfigBuilder WithTokenRefresh(Func<CancellationToken, Task<TokenInfo>> refresh) {
         lock (_lock) {
             _refreshToken = refresh;
+        }
+        return this;
+    }
+
+    /// <summary>Sets the threshold before expiration when the token should be refreshed.</summary>
+    /// <param name="threshold">Time remaining before expiration to trigger a refresh.</param>
+    public ApiConfigBuilder WithTokenRefreshThreshold(TimeSpan threshold) {
+        if (threshold < TimeSpan.Zero) {
+            throw new ArgumentOutOfRangeException(nameof(threshold));
+        }
+
+        lock (_lock) {
+            _tokenRefreshThreshold = threshold;
         }
         return this;
     }
@@ -203,6 +217,7 @@ public sealed class ApiConfigBuilder {
                 _token,
                 _tokenExpiresAt,
                 _refreshToken,
+                _tokenRefreshThreshold,
                 _concurrencyLimit,
                 _retryCount,
                 _retryInitialDelay);


### PR DESCRIPTION
## Summary
- allow configuring token refresh threshold
- refresh token when nearing expiration
- test token refresh before expiry

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cdc28622c832ea8170a3530878b59