### PR TITLE
fix(certificates): handle working-directory downloads

### DIFF
--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -360,6 +360,38 @@ public sealed class CertificatesClientTests {
         }
     }
 
+    [Fact]
+    public async Task DownloadAsync_WritesFileToWorkingDirectory() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new StringContent("DATA")
+        };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var certificates = new CertificatesClient(client);
+
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        var originalDir = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(dir);
+        var fileName = Path.GetRandomFileName();
+        try {
+            await certificates.DownloadAsync(1, fileName);
+            Assert.NotNull(handler.Request);
+            Assert.Equal("https://example.com/ssl/v1/collect/1?format=base64", handler.Request!.RequestUri!.ToString());
+            var fullPath = Path.Combine(dir, fileName);
+            Assert.True(File.Exists(fullPath));
+            Assert.Equal("DATA", File.ReadAllText(fullPath));
+            Assert.Empty(Directory.GetDirectories(dir));
+        } finally {
+            Directory.SetCurrentDirectory(originalDir);
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData(null)]

--- a/SectigoCertificateManager/Clients/CertificatesClient.Download.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Download.cs
@@ -90,7 +90,10 @@ public sealed partial class CertificatesClient : BaseClient {
         var response = await _client.GetAsync(url, cancellationToken).ConfigureAwait(false);
         var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         using (stream) {
-            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory)) {
+                Directory.CreateDirectory(directory);
+            }
             using var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
             var buffer = new byte[65536];
             long total = response.Content.Headers.ContentLength ?? (stream.CanSeek ? stream.Length : -1);


### PR DESCRIPTION
## Summary
- prevent `DownloadAsync` from creating directories when saving to working directory
- test saving certificates to working directory

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689e0adcc95c832e9e35983deaaf1e17