### PR TITLE
fix(client): dispose throttle semaphore

### DIFF
--- a/SectigoCertificateManager/SectigoClient.cs
+++ b/SectigoCertificateManager/SectigoClient.cs
@@ -247,6 +247,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
 
         _client.Dispose();
         _refreshLock.Dispose();
+        _throttle?.Dispose();
         _disposed = true;
     }
 }


### PR DESCRIPTION
## Summary
- ensure SectigoClient disposes throttle semaphore
- verify semaphore disposal via new unit test

## Testing
- `dotnet test --framework net472`
- `dotnet test --framework netstandard2.0`
- `dotnet build SectigoCertificateManager/SectigoCertificateManager.csproj -f netstandard2.0`
- `dotnet test --framework net8.0`
- `dotnet test --framework net9.0`


------
https://chatgpt.com/codex/tasks/task_e_689e0ad4f99c832eac83ef95f35392e8