### PR TITLE
Persist refreshed tokens to configurable cache path

### DIFF
--- a/SectigoCertificateManager/ApiConfig.cs
+++ b/SectigoCertificateManager/ApiConfig.cs
@@ -19,6 +19,11 @@ using System.Threading.Tasks;
 /// <param name="token">Optional bearer token used for authentication.</param>
 /// <param name="tokenExpiresAt">Optional expiration time for <paramref name="token"/>.</param>
 /// <param name="refreshToken">Optional delegate used to refresh the token.</param>
+/// <param name="tokenRefreshThreshold">Optional threshold before expiration when the token should be refreshed.</param>
+/// <param name="concurrencyLimit">Optional concurrency limit for HTTP requests.</param>
+/// <param name="retryCount">Maximum number of retry attempts for transient failures.</param>
+/// <param name="retryInitialDelay">Initial delay used for exponential backoff when retrying.</param>
+/// <param name="tokenCachePath">Optional path to the token cache file.</param>
 public sealed class ApiConfig(
     string baseUrl,
     string username,
@@ -33,7 +38,8 @@ public sealed class ApiConfig(
     TimeSpan? tokenRefreshThreshold = null,
     int? concurrencyLimit = null,
     int retryCount = 5,
-    TimeSpan? retryInitialDelay = null) {
+    TimeSpan? retryInitialDelay = null,
+    string? tokenCachePath = null) {
     /// <summary>Gets the base URL of the API endpoint.</summary>
     public string BaseUrl { get; } = baseUrl;
 
@@ -75,4 +81,7 @@ public sealed class ApiConfig(
 
     /// <summary>Gets the initial delay used for exponential backoff when retrying.</summary>
     public TimeSpan RetryInitialDelay { get; } = retryInitialDelay ?? TimeSpan.FromSeconds(1);
+
+    /// <summary>Gets the path to the token cache file, if any.</summary>
+    public string? TokenCachePath { get; } = tokenCachePath;
 }

--- a/SectigoCertificateManager/ApiConfigBuilder.cs
+++ b/SectigoCertificateManager/ApiConfigBuilder.cs
@@ -26,6 +26,7 @@ public sealed class ApiConfigBuilder {
     private int _retryCount = 5;
     private TimeSpan _retryInitialDelay = TimeSpan.FromSeconds(1);
     private TimeSpan _tokenRefreshThreshold = TimeSpan.FromMinutes(1);
+    private string? _tokenCachePath;
 
     /// <summary>Sets the base URL for the API endpoint.</summary>
     /// <param name="baseUrl">The root URL of the Sectigo API.</param>
@@ -93,6 +94,16 @@ public sealed class ApiConfigBuilder {
         lock (_lock) {
             _tokenRefreshThreshold = threshold;
         }
+        return this;
+    }
+
+    /// <summary>Sets the path to the token cache file.</summary>
+    /// <param name="path">Full path to the cache file.</param>
+    public ApiConfigBuilder WithTokenCachePath(string path) {
+        lock (_lock) {
+            _tokenCachePath = path;
+        }
+
         return this;
     }
 
@@ -220,7 +231,8 @@ public sealed class ApiConfigBuilder {
                 _tokenRefreshThreshold,
                 _concurrencyLimit,
                 _retryCount,
-                _retryInitialDelay);
+                _retryInitialDelay,
+                _tokenCachePath);
         }
     }
 }

--- a/SectigoCertificateManager/ApiConfigLoader.cs
+++ b/SectigoCertificateManager/ApiConfigLoader.cs
@@ -96,17 +96,17 @@ public static class ApiConfigLoader {
         string? version = Environment.GetEnvironmentVariable("SECTIGO_API_VERSION");
 
         if (baseUrl is not null && token is not null && customerUri is not null) {
-            return new ApiConfig(baseUrl, string.Empty, string.Empty, customerUri, ApiVersionHelper.Parse(version), token: token);
+            return new ApiConfig(baseUrl, string.Empty, string.Empty, customerUri, ApiVersionHelper.Parse(version), token: token, tokenCachePath: tokenPath);
         }
 
         var cached = ReadToken(tokenPath);
 
         if (baseUrl is not null && cached is not null && customerUri is not null) {
-            return new ApiConfig(baseUrl, string.Empty, string.Empty, customerUri, ApiVersionHelper.Parse(version), token: cached.Token, tokenExpiresAt: cached.ExpiresAt);
+            return new ApiConfig(baseUrl, string.Empty, string.Empty, customerUri, ApiVersionHelper.Parse(version), token: cached.Token, tokenExpiresAt: cached.ExpiresAt, tokenCachePath: tokenPath);
         }
 
         if (baseUrl is not null && username is not null && password is not null && customerUri is not null) {
-            return new ApiConfig(baseUrl, username, password, customerUri, ApiVersionHelper.Parse(version));
+            return new ApiConfig(baseUrl, username, password, customerUri, ApiVersionHelper.Parse(version), tokenCachePath: tokenPath);
         }
 
         if (string.IsNullOrEmpty(path)) {
@@ -141,6 +141,7 @@ public static class ApiConfigLoader {
             model.CustomerUri,
             ApiVersionHelper.Parse(model.ApiVersion),
             token: tokenValue,
-            tokenExpiresAt: expires);
+            tokenExpiresAt: expires,
+            tokenCachePath: tokenPath);
     }
 }


### PR DESCRIPTION
## Summary
- expose configurable token cache path on ApiConfig
- persist refreshed tokens via ApiConfigLoader in SectigoClient
- add unit test ensuring refreshed tokens are written to cache

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689e4526b140832ea4dc1a8e836ab260