### PR TITLE
feat(certificates): ✨ add PFX download support

### DIFF
--- a/SectigoCertificateManager.Examples/Examples/DownloadPfxExample.cs
+++ b/SectigoCertificateManager.Examples/Examples/DownloadPfxExample.cs
@@ -1,0 +1,28 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
+
+namespace SectigoCertificateManager.Examples.Examples;
+
+/// <summary>
+/// Demonstrates downloading an issued certificate as a password-protected PFX.
+/// </summary>
+public static class DownloadPfxExample {
+    /// <summary>
+    /// Executes the example that downloads a PFX containing the private key.
+    /// </summary>
+    public static async Task RunAsync() {
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://cert-manager.com/api")
+            .WithCredentials("<username>", "<password>")
+            .WithCustomerUri("<customer uri>")
+            .WithApiVersion(ApiVersion.V25_6)
+            .Build();
+
+        var client = new SectigoClient(config);
+        var certificates = new CertificatesClient(client);
+
+        Console.WriteLine("Downloading PFX certificate...");
+        using var cert = await certificates.DownloadPfxAsync(12345, "secret");
+        Console.WriteLine($"Thumbprint: {cert.Thumbprint}");
+    }
+}

--- a/SectigoCertificateManager.Examples/Program.cs
+++ b/SectigoCertificateManager.Examples/Program.cs
@@ -4,6 +4,7 @@ await BasicApiExample.RunAsync();
 await SearchCertificatesExample.RunAsync();
 await DownloadCertificateExample.RunAsync();
 await DownloadCertificateObjectExample.RunAsync();
+await DownloadPfxExample.RunAsync();
 await DeleteCertificateExample.RunAsync();
 await UploadOrdersExample.RunAsync();
 await GetCertificateRevocationExample.RunAsync();

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Globalization;
 using System.Threading;
@@ -76,6 +77,20 @@ public sealed class CertificatesClientTests {
     }
 
     private const string Base64Cert = "MIIC/zCCAeegAwIBAgIULTQw6ATwfRI/1hVSQooJNHPEit8wDQYJKoZIhvcNAQELBQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yNTA3MDQxMzE2NDRaFw0yNTA3MDUxMzE2NDRaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDiO8kIwsJLCi3d8bX31IIISKSoA24iCcfV7m+uMm8CMdJlY2NGf8ThiF3suG2lHQCxESQacUrPFMN/J3cM7L+5R8p24CCnrmAP2WhMuO2IwFhgfjo4PsmnmCGNx5fDAPI+lnSS6pnHfZfAPw3dbPT2/cgbeil0q2ByFR6C2YXU+mFdOg7cJJ1f2GXbUL3QYRBuaDYCHRrDAym4e/8DkKjjaroDxw1BPD6sjvzrDdEDusJANDCp8K6Cr99nvG+YCLjueN+xvUXHbsp9gUfLI39X73p+M9zGcYGAeYyD/i+VM/+Kde5CEfS34eOKfRIJX6DHAbVu1SrJPNFFvQV0keb/AgMBAAGjUzBRMB0GA1UdDgQWBBQ8PwJEkQsHvU7i5i45XLLyJUi4eTAfBgNVHSMEGDAWgBQ8PwJEkQsHvU7i5i45XLLyJUi4eTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAjWADB2IC5xBHKOROcXZDa8mp3DaasUwL5mWjG7Ppr4LHrY1uCEojstJCg6s2FLBjGTs+0DTQ5UiBqSVJDK1GVhYG02xJSPoXNS4wNTp4a56NtbkDT96lO0BrH91lclMNXHU9NpMUFea0tt7h5tUeVtZ2CVK0nuy5MOifMdURVyhWsFgQVemmTNTYisVD5sNRvBJEq0M+3+JSjFYvRZVqfRSM3z1K4XcZJfhxv7Gq1ebb93R1QunIdGC0HiFnBZxpxhDCbcVOpbdbQOJ22dLSe5/4f+1V+D/bPCZJx5kF0yvM0jEhuQNxNV3H/DasvBhH/24JIjpe+WfKPw0jx7vR6";
+
+    private static X509Certificate2 CreateCertificate() {
+        using var key = RSA.Create(2048);
+#if NET472
+        var request = new CertificateRequest(
+            new X500DistinguishedName("CN=Test"),
+            key,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+#else
+        var request = new CertificateRequest("CN=Test", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+#endif
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+    }
 
     /// <summary>Parses search results.</summary>
     [Fact]
@@ -794,6 +809,49 @@ public sealed class CertificatesClientTests {
         Assert.NotNull(handler.Request);
         Assert.Equal("https://example.com/ssl/v1/collect/5?format=base64", handler.Request!.RequestUri!.ToString());
         Assert.Equal("51A908D14C9C984231B7E2F6C37ABB1368A57F1F", cert.Thumbprint);
+    }
+
+    [Fact]
+    public async Task DownloadPfxAsync_ReturnsCertificate() {
+        using var original = CreateCertificate();
+        var bytes = original.Export(X509ContentType.Pfx);
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new ByteArrayContent(bytes)
+        };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var certificates = new CertificatesClient(client);
+
+        using var cert = await certificates.DownloadPfxAsync(5);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("https://example.com/ssl/v1/collect/5?format=pfx", handler.Request!.RequestUri!.ToString());
+        Assert.True(cert.HasPrivateKey);
+        Assert.Equal(original.Thumbprint, cert.Thumbprint);
+    }
+
+    [Fact]
+    public async Task DownloadPfxAsync_WithPassword_ReturnsCertificate() {
+        using var original = CreateCertificate();
+        var bytes = original.Export(X509ContentType.Pfx, "p@ss");
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new ByteArrayContent(bytes)
+        };
+
+        var handler = new TestHandler(response);
+        using var httpClient = new HttpClient(handler);
+        var client = new SectigoClient(new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4), httpClient);
+        var certificates = new CertificatesClient(client);
+
+        using var cert = await certificates.DownloadPfxAsync(5, "p@ss");
+
+        Assert.NotNull(handler.Request);
+        var expectedUrl = $"https://example.com/ssl/v1/collect/5?format=pfx&password={Uri.EscapeDataString("p@ss")}";
+        Assert.Equal(expectedUrl, handler.Request!.RequestUri!.ToString());
+        Assert.True(cert.HasPrivateKey);
+        Assert.Equal(original.Thumbprint, cert.Thumbprint);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- implement `DownloadPfxAsync` to fetch PFX blobs with optional password
- add unit tests for PFX download and password handling
- document PFX download usage with example

## Testing
- `dotnet build /clp:ErrorsOnly`
- `dotnet test --no-build -f net8.0` *(fails: The argument /workspace/...Tests.dll is invalid)*
- `dotnet test --no-build -f net9.0` *(fails: The argument /workspace/...Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_689e45142938832ebf68764e953bbca7