### PR TITLE
fix: throw on unreadable CSR stream

### DIFF
--- a/SectigoCertificateManager.Tests/RenewCertificateRequestTests.cs
+++ b/SectigoCertificateManager.Tests/RenewCertificateRequestTests.cs
@@ -16,6 +16,10 @@ public sealed class RenewCertificateRequestTests {
         public void Report(double value) => Value = value;
     }
 
+    private sealed class UnreadableStream : MemoryStream {
+        public override bool CanRead => false;
+    }
+
     /// <summary>Reads CSR from a stream.</summary>
     [Fact]
     public void SetCsr_FromStream_SetsProperty() {
@@ -50,5 +54,13 @@ public sealed class RenewCertificateRequestTests {
         request.SetCsr(stream);
 
         Assert.Equal(Base64Csr, request.Csr);
+    }
+
+    [Fact]
+    public void SetCsr_UnreadableStream_Throws() {
+        using var stream = new UnreadableStream();
+        var request = new RenewCertificateRequest();
+
+        Assert.Throws<ArgumentException>(() => request.SetCsr(stream));
     }
 }

--- a/SectigoCertificateManager/Requests/RenewCertificateRequest.cs
+++ b/SectigoCertificateManager/Requests/RenewCertificateRequest.cs
@@ -26,6 +26,10 @@ public sealed class RenewCertificateRequest {
     public void SetCsr(Stream stream, IProgress<double>? progress = null) {
         Guard.AgainstNull(stream, nameof(stream));
 
+        if (!stream.CanRead) {
+            throw new ArgumentException("Stream must be readable.", nameof(stream));
+        }
+
         if (stream.CanSeek) {
             stream.Seek(0, SeekOrigin.Begin);
         }


### PR DESCRIPTION
## Summary
- validate CSR stream readability before reading
- cover unreadable stream with new unit test

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689e4506ba2c832e8e5b6c99dd469c89