### PR TITLE
Ensure ApiErrorHandler disposes error responses

### DIFF
--- a/SectigoCertificateManager/ApiErrorHandler.cs
+++ b/SectigoCertificateManager/ApiErrorHandler.cs
@@ -1,16 +1,59 @@
-namespace SectigoCertificateManager;
-
-using System;
-using System.Net;
-using System.Net.Http;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
-
-/// <summary>
-/// Handles API error responses.
-/// </summary>
-internal static class ApiErrorHandler {
+        if (response.IsSuccessStatusCode) {
+            return;
+        }
+
+        try {
+            const int maxBodyLength = 200;
+#if NET5_0_OR_GREATER
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+            var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+            var snippet = body.Length > maxBodyLength
+                ? body.Substring(0, maxBodyLength) + "..."
+                : body;
+
+            ApiError? error = null;
+            try {
+                error = JsonSerializer.Deserialize<ApiError>(body, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            } catch (Exception ex) when (ex is JsonException or NotSupportedException) {
+                var parseMessage = $"StatusCode: {(int)response.StatusCode} ({response.StatusCode})";
+                if (!string.IsNullOrWhiteSpace(snippet)) {
+                    parseMessage += $", Body: {snippet}";
+                }
+                parseMessage += $", Error: Failed to parse ApiError from response: {ex.Message}";
+                throw new ApiException(new ApiError {
+                    Code = ApiErrorCode.UnknownError,
+                    Description = parseMessage
+                });
+            }
+
+            error ??= new ApiError {
+                Code = (ApiErrorCode)(int)response.StatusCode,
+                Description = response.ReasonPhrase ?? "Request failed"
+            };
+
+            var message = $"StatusCode: {(int)response.StatusCode} ({response.StatusCode})";
+            if (!string.IsNullOrWhiteSpace(snippet)) {
+                message += $", Body: {snippet}";
+            }
+            if (!string.IsNullOrWhiteSpace(error.Description)) {
+                message += $", Error: {error.Description}";
+            }
+
+            error.Description = message;
+
+            throw response.StatusCode switch {
+                HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => new AuthenticationException(error),
+                HttpStatusCode.BadRequest => new ValidationException(error),
+                _ => new ApiException(error)
+            };
+        } finally {
+            response.Dispose();
+        }
+    }
+}
+
     /// <summary>
     /// Throws an exception if the response indicates an error.
     /// </summary>


### PR DESCRIPTION
## Summary
- dispose the API error HttpResponseMessage before propagating exceptions
- add tracking response tests that verify disposal occurs for deserialization failures and API error payloads

## Testing
- dotnet test SectigoCertificateManager.sln

------
https://chatgpt.com/codex/tasks/task_e_68d6330f4400832e8268a5c495a00989