### PR TITLE
Enable case-insensitive JSON deserialization in BaseClient

### DIFF
--- a/SectigoCertificateManager.Tests/SerializationTests.cs
+++ b/SectigoCertificateManager.Tests/SerializationTests.cs
@@ -1,5 +1,10 @@
+using SectigoCertificateManager;
+using SectigoCertificateManager.Clients;
 using SectigoCertificateManager.Models;
+using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SectigoCertificateManager.Tests;
@@ -12,22 +17,14 @@ public sealed class SerializationTests {
     [Fact]
     public void Deserialize_Certificate_Succeeds() {
         const string json = "{\"id\":1}";
-        var options = new JsonSerializerOptions {
-            PropertyNameCaseInsensitive = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-        };
-        var obj = JsonSerializer.Deserialize<Certificate>(json, options);
+        var obj = JsonSerializer.Deserialize<Certificate>(json, TestClient.JsonOptions);
         Assert.NotNull(obj);
     }
 
     [Fact]
     public void Deserialize_Profile_Succeeds() {
         const string json = "{\"id\":1}";
-        var options = new JsonSerializerOptions {
-            PropertyNameCaseInsensitive = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-        };
-        var obj = JsonSerializer.Deserialize<Profile>(json, options);
+        var obj = JsonSerializer.Deserialize<Profile>(json, TestClient.JsonOptions);
         Assert.NotNull(obj);
     }
 
@@ -48,6 +45,50 @@ public sealed class SerializationTests {
             var json = JsonSerializer.Serialize(status, options);
             var result = JsonSerializer.Deserialize<OrderStatus>(json, options);
             Assert.Equal(status, result);
+        }
+    }
+
+    [Fact]
+    public void BaseClient_JsonOptions_HandleCamelCasePayload() {
+        const string json = "{\"id\":2}";
+        var result = JsonSerializer.Deserialize<Certificate>(json, TestClient.JsonOptions);
+
+        Assert.NotNull(result);
+        Assert.True(TestClient.JsonOptions.PropertyNameCaseInsensitive);
+    }
+
+    private sealed class TestClient : BaseClient {
+        private TestClient()
+            : base(StubSectigoClient.Instance) {
+        }
+
+        public static JsonSerializerOptions JsonOptions => s_json;
+    }
+
+    private sealed class StubSectigoClient : ISectigoClient {
+        private static readonly HttpClient s_httpClient = new();
+
+        private StubSectigoClient() {
+        }
+
+        public static StubSectigoClient Instance { get; } = new();
+
+        public HttpClient HttpClient => s_httpClient;
+
+        public Task<HttpResponseMessage> GetAsync(string requestUri, CancellationToken cancellationToken = default) {
+            throw new NotSupportedException();
+        }
+
+        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default) {
+            throw new NotSupportedException();
+        }
+
+        public Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content, CancellationToken cancellationToken = default) {
+            throw new NotSupportedException();
+        }
+
+        public Task<HttpResponseMessage> DeleteAsync(string requestUri, CancellationToken cancellationToken = default) {
+            throw new NotSupportedException();
         }
     }
 }

--- a/SectigoCertificateManager/Clients/BaseClient.cs
+++ b/SectigoCertificateManager/Clients/BaseClient.cs
@@ -17,7 +17,8 @@ public abstract class BaseClient {
     /// JSON options with camel case naming policy.
     /// </summary>
     protected static readonly JsonSerializerOptions s_json = new() {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
     };
 
     /// <summary>


### PR DESCRIPTION
## Summary
- enable case-insensitive JSON deserialization for all clients by updating BaseClient defaults
- adjust serialization tests to use the shared options and add coverage confirming camelCase payloads deserialize

## Testing
- dotnet test SectigoCertificateManager.sln

------
https://chatgpt.com/codex/tasks/task_e_68e2c13b9b50832e81736396a7fbbc55