### PR TITLE
fix: Normalize SAN handling in certificate request builder

### DIFF
--- a/SectigoCertificateManager/Requests/IssueCertificateRequestBuilder.cs
+++ b/SectigoCertificateManager/Requests/IssueCertificateRequestBuilder.cs
@@ -11,7 +11,7 @@ using SectigoCertificateManager.Utilities;
 public sealed class IssueCertificateRequestBuilder {
     private readonly IssueCertificateRequest _request = new();
     private readonly IReadOnlyList<int> _allowedTerms;
-    private readonly HashSet<string> _subjectAlternativeNames = new();
+    private readonly HashSet<string> _subjectAlternativeNames = new(StringComparer.OrdinalIgnoreCase);
     private readonly object _lock = new();
 
     /// <summary>
@@ -56,7 +56,14 @@ public sealed class IssueCertificateRequestBuilder {
             _subjectAlternativeNames.Clear();
             if (sans is not null) {
                 foreach (var san in sans) {
-                    _subjectAlternativeNames.Add(san);
+                    if (string.IsNullOrWhiteSpace(san)) {
+                        continue;
+                    }
+
+                    var trimmedSan = san.Trim();
+                    if (trimmedSan.Length > 0) {
+                        _subjectAlternativeNames.Add(trimmedSan);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure the certificate request builder stores subject alternative names using case-insensitive comparison and ignores blank entries
- extend the IssueCertificateRequest tests to cover trimming, case-insensitive deduplication, and blank filtering for SANs

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e2c14a955c832eb0e9834c52706b48