### PR TITLE
Harden certificate status, paging, and retry contracts

### DIFF
--- a/SectigoCertificateManager.Tests/AdminSslClientTests.cs
+++ b/SectigoCertificateManager.Tests/AdminSslClientTests.cs
@@ -18,6 +18,76 @@ namespace SectigoCertificateManager.Tests;
 /// Unit tests for <see cref="AdminSslClient"/>.
 /// </summary>
 public sealed class AdminSslClientTests {
+    private sealed class RetryHandler : HttpMessageHandler {
+        private readonly HttpResponseMessage _tokenResponse = new(HttpStatusCode.OK) {
+            Content = JsonContent.Create(new { access_token = "token", expires_in = 3600 })
+        };
+        private readonly HttpResponseMessage _retryResponse = new(HttpStatusCode.ServiceUnavailable) {
+            Content = JsonContent.Create(new { })
+        };
+        private readonly HttpResponseMessage _successResponse = new(HttpStatusCode.OK) {
+            Content = JsonContent.Create(new[] { new AdminSslIdentity { SslId = 7 } })
+        };
+
+        public int ApiRequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            if (request.RequestUri!.AbsoluteUri.Contains("protocol/openid-connect/token", StringComparison.Ordinal)) {
+                return Task.FromResult(_tokenResponse);
+            }
+
+            ApiRequestCount++;
+            if (ApiRequestCount == 1) {
+                return Task.FromResult(_retryResponse);
+            }
+
+            return Task.FromResult(_successResponse);
+        }
+
+        protected override void Dispose(bool disposing) {
+            if (disposing) {
+                _tokenResponse.Dispose();
+                _retryResponse.Dispose();
+                _successResponse.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class TokenRetryAfterHandler : HttpMessageHandler {
+        private readonly HttpResponseMessage _throttledTokenResponse = new((HttpStatusCode)429);
+        private readonly HttpResponseMessage _tokenResponse = new(HttpStatusCode.OK) {
+            Content = JsonContent.Create(new { access_token = "token", expires_in = 3600 })
+        };
+        private readonly HttpResponseMessage _apiResponse = new(HttpStatusCode.OK) {
+            Content = JsonContent.Create(Array.Empty<AdminSslIdentity>())
+        };
+
+        public TokenRetryAfterHandler(TimeSpan retryAfter) {
+            _throttledTokenResponse.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(retryAfter);
+        }
+
+        public int TokenRequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            if (request.RequestUri!.AbsoluteUri.Contains("protocol/openid-connect/token", StringComparison.Ordinal)) {
+                TokenRequestCount++;
+                return Task.FromResult(TokenRequestCount == 1 ? _throttledTokenResponse : _tokenResponse);
+            }
+
+            return Task.FromResult(_apiResponse);
+        }
+
+        protected override void Dispose(bool disposing) {
+            if (disposing) {
+                _throttledTokenResponse.Dispose();
+                _tokenResponse.Dispose();
+                _apiResponse.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+
     private sealed class TestHandler : HttpMessageHandler {
         private readonly string _tokenJson;
         private readonly HttpStatusCode _tokenStatus;
@@ -67,6 +137,76 @@ public sealed class AdminSslClientTests {
             }
             return apiResponse;
         }
+    }
+
+    [Fact]
+    public async Task ListAsync_RetriesTransientAdminApiFailure() {
+        var handler = new RetryHandler();
+        using var http = new HttpClient(handler);
+        var config = new AdminApiConfig(
+            "https://admin.enterprise.sectigo.com",
+            "https://auth.sso.sectigo.com/auth/realms/apiclients/protocol/openid-connect/token",
+            "id",
+            "secret") {
+            RetryCount = 2,
+            RetryInitialDelay = TimeSpan.Zero
+        };
+        using var client = new AdminSslClient(config, http);
+
+        IReadOnlyList<AdminSslIdentity> result = await client.ListAsync(5, 0);
+
+        Assert.Single(result);
+        Assert.Equal(2, handler.ApiRequestCount);
+    }
+
+    [Fact]
+    public async Task EnrollAsync_DoesNotRetryTransientMutationFailure() {
+        var handler = new RetryHandler();
+        using var http = new HttpClient(handler);
+        var config = new AdminApiConfig(
+            "https://admin.enterprise.sectigo.com",
+            "https://auth.sso.sectigo.com/auth/realms/apiclients/protocol/openid-connect/token",
+            "id",
+            "secret") {
+            RetryCount = 5,
+            RetryInitialDelay = TimeSpan.Zero
+        };
+        using var client = new AdminSslClient(config, http);
+
+        await Assert.ThrowsAsync<ApiException>(() => client.EnrollAsync(new AdminSslEnrollRequest {
+            OrgId = 5,
+            CertType = 123,
+            Term = 365,
+            Csr = "CSR-DATA"
+        }));
+
+        Assert.Equal(1, handler.ApiRequestCount);
+    }
+
+    [Fact]
+    public async Task TokenRequest_HonorsRetryAfter() {
+        var expected = TimeSpan.FromSeconds(17);
+        var handler = new TokenRetryAfterHandler(expected);
+        using var http = new HttpClient(handler);
+        var config = new AdminApiConfig(
+            "https://admin.enterprise.sectigo.com",
+            "https://auth.sso.sectigo.com/auth/realms/apiclients/protocol/openid-connect/token",
+            "id",
+            "secret") {
+            RetryCount = 2,
+            RetryInitialDelay = TimeSpan.Zero
+        };
+        using var client = new AdminSslClient(config, http);
+        TimeSpan? observed = null;
+        client.DelayAsync = (delay, _) => {
+            observed = delay;
+            return Task.CompletedTask;
+        };
+
+        await client.ListAsync(1, 0);
+
+        Assert.Equal(2, handler.TokenRequestCount);
+        Assert.Equal(expected, observed);
     }
 
     [Fact]
@@ -197,7 +337,7 @@ public sealed class AdminSslClientTests {
         Assert.NotNull(handler.LastRequest);
         Assert.Equal("https://admin.enterprise.sectigo.com/api/ssl/v2/import?orgId=15", handler.LastRequest!.RequestUri!.ToString());
         Assert.Equal(HttpMethod.Post, handler.LastRequest.Method);
-        Assert.IsType<MultipartFormDataContent>(handler.LastRequest.Content);
+        Assert.StartsWith("multipart/", handler.LastRequest.Content!.Headers.ContentType!.MediaType);
 
         Assert.NotNull(result);
         Assert.Equal(3, result!.ProcessedCount);

--- a/SectigoCertificateManager.Tests/CertificateServiceTests.cs
+++ b/SectigoCertificateManager.Tests/CertificateServiceTests.cs
@@ -291,6 +291,22 @@ public sealed class CertificateServiceTests {
     }
 
     [Fact]
+    public async Task ListAsync_Legacy_ForwardsOrganizationAndRequesterFilters() {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = JsonContent.Create<IReadOnlyList<Certificate>>(Array.Empty<Certificate>())
+        };
+        var stub = new LegacyStubClient(response);
+        var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
+
+        using var service = new CertificateService(config, stub);
+        _ = await service.ListAsync(25, 50, CertificateStatus.Issued, orgId: 7, requester: "owner@example.test");
+
+        Assert.Equal(
+            "v1/certificate?size=25&position=50&status=Issued&orgId=7&requester=owner%40example.test",
+            stub.LastRequest!.RequestUri!.ToString());
+    }
+
+    [Fact]
     public async Task GetAsync_Legacy_UsesCertificatesClient() {
         var certificate = new Certificate {
             Id = 2,

--- a/SectigoCertificateManager.Tests/CertificatesClientTests.cs
+++ b/SectigoCertificateManager.Tests/CertificatesClientTests.cs
@@ -46,12 +46,14 @@ public sealed class CertificatesClientTests {
     private sealed class TestHandler : HttpMessageHandler {
         private readonly HttpResponseMessage _response;
         public HttpRequestMessage? Request { get; private set; }
+        public HttpContent? RequestContent { get; private set; }
         public string? Body { get; private set; }
 
         public TestHandler(HttpResponseMessage response) => _response = response;
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
             Request = request;
+            RequestContent = request.Content;
             if (request.Content is not null) {
                 Body = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
             }
@@ -613,8 +615,8 @@ public sealed class CertificatesClientTests {
     }
 
     public static IEnumerable<object[]> StatusCases() {
-        foreach (CertificateStatus status in Enum.GetValues(typeof(CertificateStatus))) {
-            yield return new object[] { status.ToString(), status };
+        foreach (var name in Enum.GetNames(typeof(CertificateStatus))) {
+            yield return new object[] { name, (CertificateStatus)Enum.Parse(typeof(CertificateStatus), name) };
         }
     }
 
@@ -799,8 +801,9 @@ public sealed class CertificatesClientTests {
         Assert.NotNull(handler.Request);
         Assert.Equal(HttpMethod.Post, handler.Request!.Method);
         Assert.Equal("https://example.com/v1/certificate/import?orgId=10", handler.Request.RequestUri!.ToString());
-        Assert.NotNull(handler.Request.Content);
-        Assert.StartsWith("multipart/form-data", handler.Request.Content!.Headers.ContentType!.MediaType);
+        Assert.NotNull(handler.RequestContent);
+        Assert.StartsWith("multipart/form-data", handler.RequestContent!.Headers.ContentType!.MediaType);
+        Assert.True(stream.CanRead);
         Assert.NotNull(result);
         Assert.Equal(2, result!.ProcessedCount);
         Assert.Single(result.Errors);

--- a/SectigoCertificateManager.Tests/ModuleInitializerAttribute.cs
+++ b/SectigoCertificateManager.Tests/ModuleInitializerAttribute.cs
@@ -1,0 +1,10 @@
+#if NET472
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Makes module initializers available to the test assembly on .NET Framework.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+internal sealed class ModuleInitializerAttribute : Attribute {
+}
+#endif

--- a/SectigoCertificateManager.Tests/OrdersClientTests.cs
+++ b/SectigoCertificateManager.Tests/OrdersClientTests.cs
@@ -20,12 +20,14 @@ public sealed class OrdersClientTests {
     private sealed class TestHandler : HttpMessageHandler {
         private readonly HttpResponseMessage _response;
         public HttpRequestMessage? Request { get; private set; }
+        public HttpContent? RequestContent { get; private set; }
         public string? Body { get; private set; }
 
         public TestHandler(HttpResponseMessage response) => _response = response;
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
             Request = request;
+            RequestContent = request.Content;
             if (request.Content is not null) {
 #if NETSTANDARD2_0 || NET472
                 Body = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -72,7 +74,7 @@ public sealed class OrdersClientTests {
         Assert.NotNull(handler.Request);
         Assert.Equal(HttpMethod.Post, handler.Request!.Method);
         Assert.Equal("https://example.com/v1/order/5/cancel", handler.Request.RequestUri!.ToString());
-        await AssertContentDisposedAsync(handler.Request.Content);
+        await AssertContentDisposedAsync(handler.RequestContent);
     }
 
     [Theory]
@@ -115,7 +117,7 @@ public sealed class OrdersClientTests {
 
         Assert.NotNull(result);
         Assert.NotNull(handler.Request);
-        await AssertContentDisposedAsync(handler.Request!.Content);
+        await AssertContentDisposedAsync(handler.RequestContent);
     }
 
     [Fact]
@@ -138,7 +140,7 @@ public sealed class OrdersClientTests {
 
         Assert.NotNull(result);
         Assert.NotNull(handler.Request);
-        await AssertContentDisposedAsync(handler.Request!.Content);
+        await AssertContentDisposedAsync(handler.RequestContent);
     }
 
     [Fact]
@@ -161,7 +163,7 @@ public sealed class OrdersClientTests {
 
         Assert.NotNull(result);
         Assert.NotNull(handler.Request);
-        await AssertContentDisposedAsync(handler.Request!.Content);
+        await AssertContentDisposedAsync(handler.RequestContent);
     }
 
     [Fact]
@@ -418,7 +420,7 @@ public sealed class OrdersClientTests {
         Assert.NotNull(handler.Request);
         Assert.Equal(HttpMethod.Post, handler.Request!.Method);
         Assert.Equal("https://example.com/v1/order/bulk", handler.Request.RequestUri!.ToString());
-        Assert.Equal("text/csv", handler.Request.Content!.Headers.ContentType!.MediaType);
+        Assert.Equal("text/csv", handler.RequestContent!.Headers.ContentType!.MediaType);
     }
 
     [Fact]
@@ -475,7 +477,7 @@ public sealed class OrdersClientTests {
 
         Assert.NotNull(handler.Request);
         Assert.Equal("https://example.com/v1/order/bulk", handler.Request!.RequestUri!.ToString());
-        Assert.Equal("application/json", handler.Request.Content!.Headers.ContentType!.MediaType);
+        Assert.Equal("application/json", handler.RequestContent!.Headers.ContentType!.MediaType);
         Assert.StartsWith("[", handler.Body);
         Assert.Equal(2, result.Count);
     }
@@ -499,7 +501,6 @@ public sealed class OrdersClientTests {
 
         Assert.NotNull(handler.Request);
         Assert.Equal("https://example.com/v1/order/bulk", handler.Request!.RequestUri!.ToString());
-        Assert.StartsWith("multipart/", handler.Request.Content!.Headers.ContentType!.MediaType);
-        Assert.IsType<MultipartContent>(handler.Request.Content);
+        Assert.StartsWith("multipart/", handler.RequestContent!.Headers.ContentType!.MediaType);
     }
 }

--- a/SectigoCertificateManager.Tests/ProgressStreamContentTests.cs
+++ b/SectigoCertificateManager.Tests/ProgressStreamContentTests.cs
@@ -1,6 +1,8 @@
 using SectigoCertificateManager.Utilities;
 using System;
 using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SectigoCertificateManager.Tests;
@@ -9,6 +11,18 @@ namespace SectigoCertificateManager.Tests;
 /// Tests for <see cref="ProgressStreamContent"/>.
 /// </summary>
 public sealed class ProgressStreamContentTests {
+    [Fact]
+    public async Task ReadAsByteArrayAsync_UsesRemainingSeekableStreamLength() {
+        using var stream = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+        stream.Position = 2;
+        using var content = new ProgressStreamContent(stream);
+
+        byte[] uploaded = await content.ReadAsByteArrayAsync();
+
+        Assert.Equal(2, content.Headers.ContentLength);
+        Assert.Equal(new byte[] { 3, 4 }, uploaded);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]

--- a/SectigoCertificateManager.Tests/SectigoClientTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientTests.cs
@@ -551,8 +551,7 @@ public sealed class SectigoClientTests {
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
             _content.SerializationCountAtHandler = _content.SerializationCount;
-            var response = new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = request };
-            return Task.FromResult(response);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = request });
         }
     }
 

--- a/SectigoCertificateManager.Tests/SectigoClientTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientTests.cs
@@ -55,6 +55,20 @@ public sealed class SectigoClientTests {
     }
 
     [Fact]
+    public async Task Credentials_ClearInjectedAuthorizationHeader() {
+        var config = new ApiConfig("https://example.com/api/", "user", "pass", "cst1", ApiVersion.V25_4);
+        var handler = new TestHandler();
+        using var httpClient = new HttpClient(handler);
+        httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "stale");
+        using var client = new SectigoClient(config, httpClient);
+
+        await client.GetAsync("v1/test");
+
+        Assert.Null(httpClient.DefaultRequestHeaders.Authorization);
+        Assert.Equal("user", httpClient.DefaultRequestHeaders.GetValues("login").Single());
+    }
+
+    [Fact]
     public async Task UsesBaseUrlWithoutTrailingSlash() {
         var config = new ApiConfig("https://example.com/api", "user", "pass", "cst1", ApiVersion.V25_4);
         var handler = new TestHandler();
@@ -134,7 +148,7 @@ public sealed class SectigoClientTests {
     }
 
     [Fact]
-    public void DisposeDisposesHttpClient() {
+    public void DisposeDoesNotDisposeInjectedHttpClient() {
         var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
         var handler = new DisposableHandler();
         using var httpClient = new HttpClient(handler);
@@ -142,7 +156,7 @@ public sealed class SectigoClientTests {
 
         client.Dispose();
 
-        Assert.True(handler.Disposed);
+        Assert.False(handler.Disposed);
     }
 
     [Fact]
@@ -155,7 +169,7 @@ public sealed class SectigoClientTests {
         client.Dispose();
         client.Dispose();
 
-        Assert.True(handler.Disposed);
+        Assert.False(handler.Disposed);
     }
 
     [Fact]
@@ -171,7 +185,7 @@ public sealed class SectigoClientTests {
     }
 
     [Fact]
-    public async Task DisposeDuringRefresh_ThrowsObjectDisposedException() {
+    public async Task DisposeDuringRefresh_AllowsInFlightRequestToComplete() {
         var started = new TaskCompletionSource<object?>();
         var release = new TaskCompletionSource<TokenInfo>();
 
@@ -198,8 +212,9 @@ public sealed class SectigoClientTests {
         client.Dispose();
         release.SetResult(new TokenInfo("n", DateTimeOffset.UtcNow.AddMinutes(5)));
 
-        var ex = await Assert.ThrowsAnyAsync<Exception>(() => task);
-        Assert.True(ex is ObjectDisposedException || ex is IOException);
+        using var response = await task;
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => client.GetAsync("v1/test"));
     }
 
     [Fact]
@@ -316,6 +331,34 @@ public sealed class SectigoClientTests {
         var cached = ApiConfigLoader.ReadToken(path);
         Assert.NotNull(cached);
         Assert.Equal("new", cached!.Token);
+    }
+
+    [Fact]
+    public async Task PersistsTokenAfterRefreshUsingDefaultCacheResolution() {
+        string path = Environment.GetEnvironmentVariable("SECTIGO_TOKEN_CACHE_PATH")!;
+        if (File.Exists(path)) {
+            File.Delete(path);
+        }
+        var expired = DateTimeOffset.UtcNow.AddMinutes(-1);
+        Task<TokenInfo> Refresh(CancellationToken ct) => Task.FromResult(new TokenInfo("default-cache", DateTimeOffset.UtcNow.AddMinutes(30)));
+        var config = new ApiConfig(
+            "https://example.com/",
+            string.Empty,
+            string.Empty,
+            "c",
+            ApiVersion.V25_4,
+            token: "old",
+            tokenExpiresAt: expired,
+            refreshToken: Refresh);
+        var handler = new TestHandler();
+        using var httpClient = new HttpClient(handler);
+        using var client = new SectigoClient(config, httpClient);
+
+        await client.GetAsync("v1/test");
+
+        TokenInfo? cached = ApiConfigLoader.ReadToken();
+        Assert.NotNull(cached);
+        Assert.Equal("default-cache", cached!.Token);
     }
 
     private sealed class ThrottleHandler : HttpMessageHandler {
@@ -457,6 +500,81 @@ public sealed class SectigoClientTests {
         await Assert.ThrowsAnyAsync<Exception>(() => client.GetAsync("v1/test"));
 
         Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task PostAsync_DoesNotRetryAfterTransportFailure() {
+        var handler = new TransportFailureHandler();
+        using var httpClient = new HttpClient(handler);
+        var config = new ApiConfigBuilder()
+            .WithBaseUrl("https://example.com/")
+            .WithCredentials("u", "p")
+            .WithCustomerUri("c")
+            .WithRetryOptions(3, TimeSpan.Zero)
+            .Build();
+        using var client = new SectigoClient(config, httpClient) { DelayAsync = (_, _) => Task.CompletedTask };
+        using var content = new StringContent("mutation");
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.PostAsync("v1/orders", content));
+
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task PostAsync_DoesNotBufferStreamingContentBeforeSend() {
+        using var content = new TrackingStreamContent();
+        var handler = new ContentObservationHandler(content);
+        using var httpClient = new HttpClient(handler);
+        var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
+        using var client = new SectigoClient(config, httpClient);
+
+        using HttpResponseMessage response = await client.PostAsync("v1/import", content);
+
+        Assert.Equal(0, content.SerializationCountAtHandler);
+        Assert.Equal(0, content.SerializationCount);
+        Assert.False(content.Disposed);
+    }
+
+    private sealed class TransportFailureHandler : HttpMessageHandler {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            RequestCount++;
+            throw new HttpRequestException("transport failed after dispatch");
+        }
+    }
+
+    private sealed class ContentObservationHandler : HttpMessageHandler {
+        private readonly TrackingStreamContent _content;
+
+        public ContentObservationHandler(TrackingStreamContent content) => _content = content;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            _content.SerializationCountAtHandler = _content.SerializationCount;
+            var response = new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = request };
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class TrackingStreamContent : HttpContent {
+        public int SerializationCount { get; private set; }
+        public int SerializationCountAtHandler { get; set; }
+        public bool Disposed { get; private set; }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) {
+            SerializationCount++;
+            return stream.WriteAsync(new byte[] { 1 }, 0, 1);
+        }
+
+        protected override bool TryComputeLength(out long length) {
+            length = -1;
+            return false;
+        }
+
+        protected override void Dispose(bool disposing) {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
     }
      
     [Fact]

--- a/SectigoCertificateManager.Tests/SectigoClientTests.cs
+++ b/SectigoCertificateManager.Tests/SectigoClientTests.cs
@@ -523,13 +523,15 @@ public sealed class SectigoClientTests {
     [Fact]
     public async Task PostAsync_DoesNotBufferStreamingContentBeforeSend() {
         using var content = new TrackingStreamContent();
-        var handler = new ContentObservationHandler(content);
+        using var expectedResponse = new HttpResponseMessage(HttpStatusCode.OK);
+        var handler = new ContentObservationHandler(content, expectedResponse);
         using var httpClient = new HttpClient(handler);
         var config = new ApiConfig("https://example.com/", "u", "p", "c", ApiVersion.V25_4);
         using var client = new SectigoClient(config, httpClient);
 
         using HttpResponseMessage response = await client.PostAsync("v1/import", content);
 
+        Assert.Same(expectedResponse, response);
         Assert.Equal(0, content.SerializationCountAtHandler);
         Assert.Equal(0, content.SerializationCount);
         Assert.False(content.Disposed);
@@ -546,12 +548,17 @@ public sealed class SectigoClientTests {
 
     private sealed class ContentObservationHandler : HttpMessageHandler {
         private readonly TrackingStreamContent _content;
+        private readonly HttpResponseMessage _response;
 
-        public ContentObservationHandler(TrackingStreamContent content) => _content = content;
+        public ContentObservationHandler(TrackingStreamContent content, HttpResponseMessage response) {
+            _content = content;
+            _response = response;
+        }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
             _content.SerializationCountAtHandler = _content.SerializationCount;
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = request });
+            _response.RequestMessage = request;
+            return Task.FromResult(_response);
         }
     }
 

--- a/SectigoCertificateManager.Tests/StatusEnumsSpecTests.cs
+++ b/SectigoCertificateManager.Tests/StatusEnumsSpecTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using System.Text.Json;
 
 namespace SectigoCertificateManager.Tests;
 
@@ -15,22 +16,27 @@ public sealed class StatusEnumsSpecTests {
     }
 
     [Fact]
-    public void CertificateStatus_ValuesMatchSpec() {
-        Assert.Equal(0, (int)CertificateStatus.Any);
-        Assert.Equal(1, (int)CertificateStatus.Requested);
-        Assert.Equal(8, (int)CertificateStatus.Approved);
-        Assert.Equal(9, (int)CertificateStatus.Applied);
-        Assert.Equal(2, (int)CertificateStatus.Issued);
-        Assert.Equal(3, (int)CertificateStatus.Declined);
-        Assert.Equal(4, (int)CertificateStatus.Downloaded);
-        Assert.Equal(5, (int)CertificateStatus.Rejected);
-        Assert.Equal(6, (int)CertificateStatus.AwaitingApproval);
-        Assert.Equal(7, (int)CertificateStatus.Invalid);
-        Assert.Equal(8, (int)CertificateStatus.Replaced);
-        Assert.Equal(9, (int)CertificateStatus.Unmanaged);
-        Assert.Equal(10, (int)CertificateStatus.SAApproved);
-        Assert.Equal(11, (int)CertificateStatus.Init);
-        Assert.Equal(3, (int)CertificateStatus.Revoked);
-        Assert.Equal(4, (int)CertificateStatus.Expired);
+    public void CertificateStatus_ValuesAreUnique() {
+        var values = Enum.GetValues(typeof(CertificateStatus)).Cast<CertificateStatus>().Select(static status => (int)status).ToArray();
+
+        Assert.Equal(values.Length, values.Distinct().Count());
+    }
+
+    [Theory]
+    [InlineData(0, CertificateStatus.Any)]
+    [InlineData(1, CertificateStatus.Requested)]
+    [InlineData(2, CertificateStatus.Issued)]
+    [InlineData(3, CertificateStatus.Revoked)]
+    [InlineData(4, CertificateStatus.Expired)]
+    [InlineData(5, CertificateStatus.EnrolledPendingDownload)]
+    [InlineData(6, CertificateStatus.NotEnrolled)]
+    [InlineData(7, CertificateStatus.AwaitingApproval)]
+    [InlineData(8, CertificateStatus.Approved)]
+    [InlineData(9, CertificateStatus.Applied)]
+    [InlineData(10, CertificateStatus.Downloaded)]
+    [InlineData(11, CertificateStatus.External)]
+    public void CertificateStatus_LegacyNumericWireCodesRemainStable(int code, CertificateStatus expected) {
+        Assert.Equal(expected, JsonSerializer.Deserialize<CertificateStatus>(code.ToString()));
+        Assert.Equal(expected, JsonSerializer.Deserialize<CertificateStatus>($"\"{code}\""));
     }
 }

--- a/SectigoCertificateManager.Tests/TestEnvironment.cs
+++ b/SectigoCertificateManager.Tests/TestEnvironment.cs
@@ -1,0 +1,15 @@
+using System.Runtime.CompilerServices;
+
+namespace SectigoCertificateManager.Tests;
+
+internal static class TestEnvironment {
+    [ModuleInitializer]
+    internal static void Initialize() {
+        string tempRoot = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        string path = tempRoot
+            + Path.DirectorySeparatorChar + "SectigoCertificateManager.Tests"
+            + Path.DirectorySeparatorChar + Guid.NewGuid().ToString("N")
+            + Path.DirectorySeparatorChar + "token.json";
+        Environment.SetEnvironmentVariable("SECTIGO_TOKEN_CACHE_PATH", path);
+    }
+}

--- a/SectigoCertificateManager/AdminApi/AdminAcmePrivateClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminAcmePrivateClient.cs
@@ -53,7 +53,7 @@ public sealed class AdminAcmePrivateClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -81,7 +81,7 @@ public sealed class AdminAcmePrivateClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return LocationHeaderParser.ParseId(response);

--- a/SectigoCertificateManager/AdminApi/AdminAcmePublicClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminAcmePublicClient.cs
@@ -54,7 +54,7 @@ public sealed class AdminAcmePublicClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -79,7 +79,7 @@ public sealed class AdminAcmePublicClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/acme/v2/account/{id}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var account = await response.Content
@@ -107,7 +107,7 @@ public sealed class AdminAcmePublicClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return LocationHeaderParser.ParseId(response);
@@ -140,7 +140,7 @@ public sealed class AdminAcmePublicClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -177,7 +177,7 @@ public sealed class AdminAcmePublicClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content
@@ -214,7 +214,7 @@ public sealed class AdminAcmePublicClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content
@@ -253,7 +253,7 @@ public sealed class AdminAcmePublicClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -283,7 +283,7 @@ public sealed class AdminAcmePublicClient : AdminApiClientBase {
             $"api/acme/v2/account/{accountId}/client/{Uri.EscapeDataString(clientId)}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -313,7 +313,7 @@ public sealed class AdminAcmePublicClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, absolute);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var servers = await response.Content

--- a/SectigoCertificateManager/AdminApi/AdminAdminClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminAdminClient.cs
@@ -67,7 +67,7 @@ public sealed class AdminAdminClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -92,7 +92,7 @@ public sealed class AdminAdminClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/admin/v1/{id}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var details = await response.Content
@@ -117,7 +117,7 @@ public sealed class AdminAdminClient : AdminApiClientBase {
         };
         SetBearer(httpRequest, token);
 
-        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return LocationHeaderParser.ParseId(response);
@@ -143,7 +143,7 @@ public sealed class AdminAdminClient : AdminApiClientBase {
         };
         SetBearer(httpRequest, token);
 
-        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -167,7 +167,7 @@ public sealed class AdminAdminClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Delete, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -186,7 +186,7 @@ public sealed class AdminAdminClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Put, $"api/admin/v1/{id}/unlink");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -210,7 +210,7 @@ public sealed class AdminAdminClient : AdminApiClientBase {
         SetBearer(request, token);
         request.Headers.Add("password", currentPassword);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -224,7 +224,7 @@ public sealed class AdminAdminClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, "api/admin/v1/password");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var status = await response.Content
@@ -249,7 +249,7 @@ public sealed class AdminAdminClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -281,7 +281,7 @@ public sealed class AdminAdminClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -301,7 +301,7 @@ public sealed class AdminAdminClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, "api/admin/v1/idp");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content

--- a/SectigoCertificateManager/AdminApi/AdminApiClientBase.cs
+++ b/SectigoCertificateManager/AdminApi/AdminApiClientBase.cs
@@ -3,7 +3,11 @@ namespace SectigoCertificateManager.AdminApi;
 using SectigoCertificateManager.Utilities;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -21,6 +25,7 @@ public abstract class AdminApiClientBase : IDisposable {
     protected readonly HttpClient _httpClient;
     private readonly bool _ownsHttpClient;
     private readonly AdminTokenManager _tokenManager;
+    internal Func<TimeSpan, CancellationToken, Task>? DelayAsync { get; set; }
 
     /// <summary>
     /// Initializes a new Admin Operations API client base with the specified configuration and HTTP client.
@@ -44,7 +49,7 @@ public abstract class AdminApiClientBase : IDisposable {
             _httpClient.BaseAddress = new Uri(_config.BaseUrl);
         }
 
-        _tokenManager = new AdminTokenManager(_httpClient, _config);
+        _tokenManager = new AdminTokenManager(_httpClient, _config, DelayBeforeRetryAsync);
     }
 
     /// <summary>
@@ -66,11 +71,166 @@ public abstract class AdminApiClientBase : IDisposable {
         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
     }
 
+    /// <summary>
+    /// Sends an Admin API request with bounded retries for rate limiting, server failures,
+    /// transient transport errors, and timeouts that were not requested by the caller.
+    /// </summary>
+    protected async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken) =>
+        await SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>Sends a retryable Admin API request with an explicit response buffering policy.</summary>
+    protected async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        HttpCompletionOption completionOption,
+        CancellationToken cancellationToken) {
+        if (request is null) {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        if (!RequestSnapshot.CanReplaySafely(request.Method, request.Content)) {
+            return await _httpClient.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
+        }
+
+        var snapshot = await RequestSnapshot.CreateAsync(request).ConfigureAwait(false);
+        var attempts = Math.Max(1, _config.RetryCount);
+        var delay = _config.RetryInitialDelay < TimeSpan.Zero ? TimeSpan.Zero : _config.RetryInitialDelay;
+
+        for (var attempt = 0; ; attempt++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                using var currentRequest = snapshot.CreateRequest();
+                var response = await _httpClient.SendAsync(currentRequest, completionOption, cancellationToken).ConfigureAwait(false);
+                if (!IsRetryable(response.StatusCode) || attempt >= attempts - 1) {
+                    return response;
+                }
+
+                var wait = GetRetryDelay(response, delay);
+                response.Dispose();
+                await DelayBeforeRetryAsync(wait, cancellationToken).ConfigureAwait(false);
+            } catch (HttpRequestException) when (attempt < attempts - 1) {
+                await DelayBeforeRetryAsync(delay, cancellationToken).ConfigureAwait(false);
+            } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && attempt < attempts - 1) {
+                await DelayBeforeRetryAsync(delay, cancellationToken).ConfigureAwait(false);
+            }
+
+            delay = TimeSpan.FromTicks(Math.Min(TimeSpan.FromMinutes(1).Ticks, Math.Max(1, delay.Ticks * 2)));
+        }
+    }
+
+    private Task DelayBeforeRetryAsync(TimeSpan delay, CancellationToken cancellationToken) =>
+        DelayAsync is null ? Task.Delay(delay, cancellationToken) : DelayAsync(delay, cancellationToken);
+
+    private static bool IsRetryable(HttpStatusCode statusCode) {
+        var status = (int)statusCode;
+        return status == 429 || status >= 500 && status < 600 && statusCode != HttpStatusCode.NotImplemented;
+    }
+
+    internal static TimeSpan GetRetryDelay(HttpResponseMessage response, TimeSpan fallback) {
+        RetryConditionHeaderValue? retryAfter = response.Headers.RetryAfter;
+        if (retryAfter?.Delta is TimeSpan delta) {
+            return delta < TimeSpan.Zero ? TimeSpan.Zero : delta;
+        }
+
+        if (retryAfter?.Date is DateTimeOffset date) {
+            var delay = date - DateTimeOffset.UtcNow;
+            return delay < TimeSpan.Zero ? TimeSpan.Zero : delay;
+        }
+
+        return fallback;
+    }
+
     /// <inheritdoc />
     public void Dispose() {
         _tokenManager.Dispose();
         if (_ownsHttpClient) {
             _httpClient.Dispose();
+        }
+    }
+}
+
+internal sealed class RequestSnapshot {
+    private readonly HttpMethod _method;
+    private readonly Uri? _requestUri;
+    private readonly Version _version;
+    private readonly IReadOnlyList<KeyValuePair<string, IEnumerable<string>>> _headers;
+    private readonly byte[]? _content;
+    private readonly IReadOnlyList<KeyValuePair<string, IEnumerable<string>>> _contentHeaders;
+
+    private RequestSnapshot(
+        HttpMethod method,
+        Uri? requestUri,
+        Version version,
+        IReadOnlyList<KeyValuePair<string, IEnumerable<string>>> headers,
+        byte[]? content,
+        IReadOnlyList<KeyValuePair<string, IEnumerable<string>>> contentHeaders) {
+        _method = method;
+        _requestUri = requestUri;
+        _version = version;
+        _headers = headers;
+        _content = content;
+        _contentHeaders = contentHeaders;
+    }
+
+    public static async Task<RequestSnapshot> CreateAsync(HttpRequestMessage request) {
+        byte[]? content = null;
+        IReadOnlyList<KeyValuePair<string, IEnumerable<string>>> contentHeaders = Array.Empty<KeyValuePair<string, IEnumerable<string>>>();
+        if (request.Content is not null) {
+            content = await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+            contentHeaders = CopyHeaders(request.Content.Headers);
+        }
+
+        return new RequestSnapshot(
+            request.Method,
+            request.RequestUri,
+            request.Version,
+            CopyHeaders(request.Headers),
+            content,
+            contentHeaders);
+    }
+
+    /// <summary>
+    /// Returns whether a request can be buffered and replayed without duplicating a mutation
+    /// or consuming a streaming body before the network send.
+    /// </summary>
+    public static bool CanReplaySafely(HttpMethod method, HttpContent? content) {
+        bool idempotentMethod = method == HttpMethod.Get
+            || method == HttpMethod.Head
+            || method == HttpMethod.Options
+            || method == HttpMethod.Put
+            || method == HttpMethod.Delete;
+        if (!idempotentMethod) {
+            return false;
+        }
+
+        return content is null
+            || content is ByteArrayContent
+            || content is StringContent
+            || content is FormUrlEncodedContent
+            || content is JsonContent;
+    }
+
+    public HttpRequestMessage CreateRequest() {
+        var request = new HttpRequestMessage(_method, _requestUri) { Version = _version };
+        CopyHeadersTo(_headers, request.Headers);
+        if (_content is not null) {
+            request.Content = new ByteArrayContent(_content);
+            CopyHeadersTo(_contentHeaders, request.Content.Headers);
+        }
+
+        return request;
+    }
+
+    private static IReadOnlyList<KeyValuePair<string, IEnumerable<string>>> CopyHeaders(HttpHeaders headers) =>
+        headers.Select(static header =>
+            new KeyValuePair<string, IEnumerable<string>>(header.Key, header.Value.ToArray())).ToArray();
+
+    private static void CopyHeadersTo(
+        IReadOnlyList<KeyValuePair<string, IEnumerable<string>>> source,
+        HttpHeaders destination) {
+        foreach (var header in source) {
+            destination.TryAddWithoutValidation(header.Key, header.Value);
         }
     }
 }
@@ -85,14 +245,19 @@ internal sealed class AdminTokenManager : IDisposable {
 
     private readonly HttpClient _httpClient;
     private readonly AdminApiConfig _config;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
     private readonly SemaphoreSlim _lock = new(1, 1);
 
     private string _cachedToken = string.Empty;
     private DateTimeOffset _tokenExpiresAt;
 
-    public AdminTokenManager(HttpClient httpClient, AdminApiConfig config) {
+    public AdminTokenManager(
+        HttpClient httpClient,
+        AdminApiConfig config,
+        Func<TimeSpan, CancellationToken, Task> delayAsync) {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _config = config ?? throw new ArgumentNullException(nameof(config));
+        _delayAsync = delayAsync ?? throw new ArgumentNullException(nameof(delayAsync));
     }
 
     public async Task<string> GetTokenAsync(CancellationToken cancellationToken) {
@@ -106,15 +271,7 @@ internal sealed class AdminTokenManager : IDisposable {
                 return _cachedToken;
             }
 
-            using var content = new FormUrlEncodedContent(new Dictionary<string, string> {
-                ["grant_type"] = "client_credentials",
-                ["client_id"] = _config.ClientId,
-                ["client_secret"] = _config.ClientSecret
-            });
-
-            using var response = await _httpClient
-                .PostAsync(_config.TokenUrl, content, cancellationToken)
-                .ConfigureAwait(false);
+            using var response = await SendTokenRequestAsync(cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var model = await response.Content
@@ -133,6 +290,37 @@ internal sealed class AdminTokenManager : IDisposable {
             return _cachedToken;
         } finally {
             _lock.Release();
+        }
+    }
+
+    private async Task<HttpResponseMessage> SendTokenRequestAsync(CancellationToken cancellationToken) {
+        var attempts = Math.Max(1, _config.RetryCount);
+        var delay = _config.RetryInitialDelay < TimeSpan.Zero ? TimeSpan.Zero : _config.RetryInitialDelay;
+        for (var attempt = 0; ; attempt++) {
+            var wait = delay;
+            using var content = new FormUrlEncodedContent(new Dictionary<string, string> {
+                ["grant_type"] = "client_credentials",
+                ["client_id"] = _config.ClientId,
+                ["client_secret"] = _config.ClientSecret
+            });
+
+            try {
+                var response = await _httpClient.PostAsync(_config.TokenUrl, content, cancellationToken).ConfigureAwait(false);
+                var status = (int)response.StatusCode;
+                if ((status != 429 && (status < 500 || status >= 600 || response.StatusCode == HttpStatusCode.NotImplemented)) || attempt >= attempts - 1) {
+                    return response;
+                }
+
+                wait = AdminApiClientBase.GetRetryDelay(response, delay);
+                response.Dispose();
+            } catch (HttpRequestException ex) when (attempt < attempts - 1) {
+                Trace.TraceWarning("Admin token request attempt {0} of {1} failed: {2}", attempt + 1, attempts, ex.Message);
+            } catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested && attempt < attempts - 1) {
+                Trace.TraceWarning("Admin token request attempt {0} of {1} timed out: {2}", attempt + 1, attempts, ex.Message);
+            }
+
+            await _delayAsync(wait, cancellationToken).ConfigureAwait(false);
+            delay = TimeSpan.FromTicks(Math.Min(TimeSpan.FromMinutes(1).Ticks, Math.Max(1, delay.Ticks * 2)));
         }
     }
 

--- a/SectigoCertificateManager/AdminApi/AdminApiConfig.cs
+++ b/SectigoCertificateManager/AdminApi/AdminApiConfig.cs
@@ -37,6 +37,12 @@ public sealed class AdminApiConfig(
         ? throw new ArgumentNullException(nameof(clientSecret))
         : clientSecret;
 
+    /// <summary>Gets or initializes the total number of attempts for transient HTTP failures.</summary>
+    public int RetryCount { get; set; } = 5;
+
+    /// <summary>Gets or initializes the first exponential-backoff delay.</summary>
+    public TimeSpan RetryInitialDelay { get; set; } = TimeSpan.FromSeconds(1);
+
     private static string ValidateHttpsUrl(string url, string paramName) {
         if (string.IsNullOrWhiteSpace(url)) {
             throw new ArgumentNullException(paramName);

--- a/SectigoCertificateManager/AdminApi/AdminAzureClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminAzureClient.cs
@@ -46,7 +46,7 @@ public sealed class AdminAzureClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+        using var response = await SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
@@ -77,7 +77,7 @@ public sealed class AdminAzureClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/azure/v1/accounts/{id}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+        using var response = await SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
@@ -103,7 +103,7 @@ public sealed class AdminAzureClient : AdminApiClientBase {
         };
         SetBearer(httpRequest, token);
 
-        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         var location = response.Headers.Location;
@@ -128,7 +128,7 @@ public sealed class AdminAzureClient : AdminApiClientBase {
         };
         SetBearer(httpRequest, token);
 
-        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
 
@@ -142,7 +142,7 @@ public sealed class AdminAzureClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Delete, $"api/azure/v1/accounts/{id}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
     }
 
@@ -160,7 +160,7 @@ public sealed class AdminAzureClient : AdminApiClientBase {
         };
         SetBearer(httpRequest, token);
 
-        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         return await response.Content
@@ -178,7 +178,7 @@ public sealed class AdminAzureClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/azure/v1/accounts/{id}/check");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+        using var response = await SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
@@ -205,7 +205,7 @@ public sealed class AdminAzureClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+        using var response = await SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
@@ -224,7 +224,7 @@ public sealed class AdminAzureClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/azure/v1/accounts/{accountId}/resource-groups");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+        using var response = await SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 

--- a/SectigoCertificateManager/AdminApi/AdminCodeSigningClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminCodeSigningClient.cs
@@ -51,7 +51,7 @@ public sealed class AdminCodeSigningClient : AdminApiClientBase {
         };
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var results = await response.Content
@@ -106,7 +106,7 @@ public sealed class AdminCodeSigningClient : AdminApiClientBase {
         };
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 

--- a/SectigoCertificateManager/AdminApi/AdminCustomFieldsV2Client.cs
+++ b/SectigoCertificateManager/AdminApi/AdminCustomFieldsV2Client.cs
@@ -50,7 +50,7 @@ public sealed class AdminCustomFieldsV2Client : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path.ToString());
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var fields = await response.Content
@@ -77,7 +77,7 @@ public sealed class AdminCustomFieldsV2Client : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/customField/v2/{id}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -103,7 +103,7 @@ public sealed class AdminCustomFieldsV2Client : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return LocationHeaderParser.ParseId(response);
@@ -129,7 +129,7 @@ public sealed class AdminCustomFieldsV2Client : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var updated = await response.Content

--- a/SectigoCertificateManager/AdminApi/AdminDcvClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminDcvClient.cs
@@ -68,7 +68,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -99,7 +99,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var status = await response.Content
@@ -130,7 +130,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -155,7 +155,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -178,7 +178,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content
@@ -207,7 +207,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -234,7 +234,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -261,7 +261,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -288,7 +288,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -315,7 +315,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -342,7 +342,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -369,7 +369,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -399,7 +399,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -433,7 +433,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -465,7 +465,7 @@ public sealed class AdminDcvClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content

--- a/SectigoCertificateManager/AdminApi/AdminDeviceClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminDeviceClient.cs
@@ -52,7 +52,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var identities = await response.Content
@@ -79,7 +79,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/device/v1/{deviceCertId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var details = await response.Content
@@ -147,7 +147,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content
@@ -174,7 +174,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         using var message = new HttpRequestMessage(HttpMethod.Post, $"api/device/v1/renew/order/{deviceCertId}");
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content
@@ -201,7 +201,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
             $"api/device/v1/renew/serial/{Uri.EscapeDataString(serialNumber)}");
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content
@@ -243,7 +243,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -275,7 +275,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -299,7 +299,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var results = await response.Content
@@ -337,7 +337,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -376,7 +376,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -405,7 +405,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         };
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -434,7 +434,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         };
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -460,7 +460,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path.ToString());
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var types = await response.Content
@@ -481,7 +481,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, "api/device/v1/customFields");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var fields = await response.Content
@@ -508,7 +508,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/device/v1/{certId}/location");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var list = await response.Content
@@ -541,7 +541,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/device/v1/{certId}/location/{locationId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var location = await response.Content
@@ -575,7 +575,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return LocationHeaderParser.ParseId(response);
@@ -610,7 +610,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -637,7 +637,7 @@ public sealed class AdminDeviceClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Delete, $"api/device/v1/{certId}/location/{locationId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 

--- a/SectigoCertificateManager/AdminApi/AdminDnsConnectorClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminDnsConnectorClient.cs
@@ -65,7 +65,7 @@ public sealed class AdminDnsConnectorClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+        using var response = await SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
@@ -96,7 +96,7 @@ public sealed class AdminDnsConnectorClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/connector/v1/dns/{Uri.EscapeDataString(uuid)}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+        using var response = await SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
@@ -115,7 +115,7 @@ public sealed class AdminDnsConnectorClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/connector/v1/dns/{Uri.EscapeDataString(uuid)}/provider");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+        using var response = await SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 

--- a/SectigoCertificateManager/AdminApi/AdminDomainClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminDomainClient.cs
@@ -61,7 +61,7 @@ public sealed class AdminDomainClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -90,7 +90,7 @@ public sealed class AdminDomainClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return LocationHeaderParser.ParseId(response);
@@ -119,7 +119,7 @@ public sealed class AdminDomainClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -146,7 +146,7 @@ public sealed class AdminDomainClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -167,7 +167,7 @@ public sealed class AdminDomainClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Put, $"api/domain/v1/{domainId}/suspend");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -188,7 +188,7 @@ public sealed class AdminDomainClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Put, $"api/domain/v1/{domainId}/activate");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -215,7 +215,7 @@ public sealed class AdminDomainClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -248,7 +248,7 @@ public sealed class AdminDomainClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -281,7 +281,7 @@ public sealed class AdminDomainClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -302,7 +302,7 @@ public sealed class AdminDomainClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 

--- a/SectigoCertificateManager/AdminApi/AdminNotificationClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminNotificationClient.cs
@@ -69,7 +69,7 @@ public sealed class AdminNotificationClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, absolute);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         int? total = null;
@@ -100,7 +100,7 @@ public sealed class AdminNotificationClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, "api/notification/v1/types");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var types = await response.Content
@@ -133,7 +133,7 @@ public sealed class AdminNotificationClient : AdminApiClientBase {
         };
         SetBearer(httpRequest, token);
 
-        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -154,7 +154,7 @@ public sealed class AdminNotificationClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Delete, $"api/notification/v1/{notificationId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/SectigoCertificateManager/AdminApi/AdminOrganizationValidationsClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminOrganizationValidationsClient.cs
@@ -48,7 +48,7 @@ public sealed class AdminOrganizationValidationsClient : AdminApiClientBase {
             $"api/organization/v2/{organizationId}/validations");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -83,7 +83,7 @@ public sealed class AdminOrganizationValidationsClient : AdminApiClientBase {
             $"api/organization/v2/{organizationId}/validations/{validationId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var details = await response.Content
@@ -118,7 +118,7 @@ public sealed class AdminOrganizationValidationsClient : AdminApiClientBase {
             $"api/organization/v2/{organizationId}/validations/{validationId}/sync");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var details = await response.Content
@@ -153,7 +153,7 @@ public sealed class AdminOrganizationValidationsClient : AdminApiClientBase {
             $"api/organization/v2/{organizationId}/validations/{validationId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 

--- a/SectigoCertificateManager/AdminApi/AdminOrganizationsClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminOrganizationsClient.cs
@@ -40,7 +40,7 @@ public sealed class AdminOrganizationsClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, "api/organization/v1");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -67,7 +67,7 @@ public sealed class AdminOrganizationsClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/organization/v1/{organizationId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var details = await response.Content
@@ -94,7 +94,7 @@ public sealed class AdminOrganizationsClient : AdminApiClientBase {
             $"api/organization/v1/report-type/{Uri.EscapeDataString(reportType)}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -123,7 +123,7 @@ public sealed class AdminOrganizationsClient : AdminApiClientBase {
             $"api/organization/v1/managed-by/{Uri.EscapeDataString(role)}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content

--- a/SectigoCertificateManager/AdminApi/AdminSmimeClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminSmimeClient.cs
@@ -51,7 +51,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -78,7 +78,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/smime/v2/{certId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var details = await response.Content
@@ -145,7 +145,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content
@@ -208,7 +208,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -227,7 +227,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         using var message = new HttpRequestMessage(HttpMethod.Post, $"api/smime/v2/renew/order/{Uri.EscapeDataString(backendCertId)}");
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content
@@ -252,7 +252,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         using var message = new HttpRequestMessage(HttpMethod.Post, $"api/smime/v2/renew/serial/{Uri.EscapeDataString(serialNumber)}");
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content
@@ -282,7 +282,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -306,7 +306,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -330,7 +330,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -354,7 +354,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path);
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var types = await response.Content
@@ -375,7 +375,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, "api/smime/v2/customFields");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var fields = await response.Content
@@ -402,7 +402,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/smime/v2/{certId}/location");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var list = await response.Content
@@ -434,7 +434,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/smime/v2/{certId}/location/{locationId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var location = await response.Content
@@ -468,7 +468,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return LocationHeaderParser.ParseId(response);
@@ -502,7 +502,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -528,7 +528,7 @@ public sealed class AdminSmimeClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Delete, $"api/smime/v2/{certId}/location/{locationId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 

--- a/SectigoCertificateManager/AdminApi/AdminSslClient.cs
+++ b/SectigoCertificateManager/AdminApi/AdminSslClient.cs
@@ -79,7 +79,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, BuildListUri(size, position, status, orgId, requester, expiresBefore, expiresAfter));
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         int? totalCount = null;
@@ -116,7 +116,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/ssl/v2/{sslId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var details = await response.Content
@@ -157,7 +157,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -193,7 +193,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -224,7 +224,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -255,7 +255,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -298,7 +298,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -369,7 +369,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content
@@ -404,7 +404,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -428,7 +428,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -456,7 +456,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -496,7 +496,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return await response.Content
@@ -534,7 +534,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -570,7 +570,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -608,7 +608,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var result = await response.Content
@@ -635,7 +635,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/ssl/v2/{sslId}/dcv");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var items = await response.Content
@@ -662,7 +662,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Post, $"api/ssl/v2/{sslId}/dcv/recheck");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var info = await response.Content
@@ -689,7 +689,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/ssl/v2/{sslId}/location");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var list = await response.Content
@@ -721,7 +721,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"api/ssl/v2/{sslId}/location/{locationId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var location = await response.Content
@@ -755,7 +755,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         return LocationHeaderParser.ParseId(response);
@@ -789,7 +789,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         };
         SetBearer(message, token);
 
-        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(message, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -815,7 +815,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Delete, $"api/ssl/v2/{sslId}/location/{locationId}");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -841,7 +841,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, path.ToString());
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var types = await response.Content
@@ -862,7 +862,7 @@ public sealed class AdminSslClient : AdminApiClientBase {
         using var request = new HttpRequestMessage(HttpMethod.Get, "api/ssl/v2/customFields");
         SetBearer(request, token);
 
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
 
         var fields = await response.Content

--- a/SectigoCertificateManager/ApiConfigLoader.cs
+++ b/SectigoCertificateManager/ApiConfigLoader.cs
@@ -1,6 +1,7 @@
 namespace SectigoCertificateManager;
 
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Text.Json;
 
@@ -8,6 +9,7 @@ using System.Text.Json;
 /// Provides helpers for loading <see cref="ApiConfig"/> from environment variables or a JSON file.
 /// </summary>
 public static class ApiConfigLoader {
+    private static readonly ConcurrentDictionary<string, object> s_tokenPathLocks = new(StringComparer.OrdinalIgnoreCase);
     private sealed class TokenFileModel {
         public string Token { get; set; } = string.Empty;
         public DateTimeOffset ExpiresAt { get; set; }
@@ -52,16 +54,18 @@ public static class ApiConfigLoader {
     /// </summary>
     /// <param name="path">Optional custom token cache path; defaults to <c>~/.sectigo/token.json</c> or the <c>SECTIGO_TOKEN_CACHE_PATH</c> environment variable.</param>
     public static TokenInfo? ReadToken(string? path = null) {
-        var tokenPath = GetTokenPath(path);
-        if (!File.Exists(tokenPath)) {
-            return null;
-        }
+        var tokenPath = Path.GetFullPath(GetTokenPath(path));
+        lock (s_tokenPathLocks.GetOrAdd(tokenPath, static _ => new object())) {
+            if (!File.Exists(tokenPath)) {
+                return null;
+            }
 
-        using var stream = File.OpenRead(tokenPath);
-        using var reader = new StreamReader(stream);
-        var json = reader.ReadToEnd();
-        var model = JsonSerializer.Deserialize<TokenFileModel>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-        return model is null ? null : new TokenInfo(model.Token, model.ExpiresAt);
+            using var stream = new FileStream(tokenPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var reader = new StreamReader(stream);
+            var json = reader.ReadToEnd();
+            var model = JsonSerializer.Deserialize<TokenFileModel>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return model is null ? null : new TokenInfo(model.Token, model.ExpiresAt);
+        }
     }
 
     /// <summary>
@@ -74,16 +78,33 @@ public static class ApiConfigLoader {
             throw new ArgumentNullException(nameof(info));
         }
 
-        var tokenPath = GetTokenPath(path);
+        var tokenPath = Path.GetFullPath(GetTokenPath(path));
         var dir = Path.GetDirectoryName(tokenPath);
         if (!string.IsNullOrEmpty(dir)) {
             Directory.CreateDirectory(dir);
         }
 
         var json = JsonSerializer.Serialize(new TokenFileModel { Token = info.Token, ExpiresAt = info.ExpiresAt });
-        using (var stream = new FileStream(tokenPath, FileMode.Create, FileAccess.Write, FileShare.None)) {
-            using var writer = new StreamWriter(stream);
-            writer.Write(json);
+        lock (s_tokenPathLocks.GetOrAdd(tokenPath, static _ => new object())) {
+            var tempPath = tokenPath + "." + Guid.NewGuid().ToString("N") + ".tmp";
+            try {
+                using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
+                    using var writer = new StreamWriter(stream);
+                    writer.Write(json);
+                    writer.Flush();
+                    stream.Flush();
+                }
+
+                if (File.Exists(tokenPath)) {
+                    File.Replace(tempPath, tokenPath, destinationBackupFileName: null);
+                } else {
+                    File.Move(tempPath, tokenPath);
+                }
+            } finally {
+                if (File.Exists(tempPath)) {
+                    File.Delete(tempPath);
+                }
+            }
         }
 #if NET6_0_OR_GREATER
         if (!OperatingSystem.IsWindows()) {

--- a/SectigoCertificateManager/CertificateService.Lifecycle.cs
+++ b/SectigoCertificateManager/CertificateService.Lifecycle.cs
@@ -1,0 +1,375 @@
+namespace SectigoCertificateManager;
+
+using SectigoCertificateManager.Models;
+using SectigoCertificateManager.Requests;
+using SectigoCertificateManager.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Provides download, mutation, lifecycle, and mapping behavior for <see cref="CertificateService"/>.
+/// </summary>
+public sealed partial class CertificateService {
+    /// <summary>
+    /// Downloads an issued certificate and returns an <see cref="System.Security.Cryptography.X509Certificates.X509Certificate2"/> instance.
+    /// </summary>
+    /// <param name="certificateId">Identifier of the certificate.</param>
+    /// <param name="format">
+    /// Optional format parameter for Admin API downloads. When <c>null</c>, the API default (<c>base64</c>) is used.
+    /// Ignored for legacy API calls, which always request base64.
+    /// </param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<System.Security.Cryptography.X509Certificates.X509Certificate2> DownloadCertificateAsync(
+        int certificateId,
+        string? format = null,
+        CancellationToken cancellationToken = default) {
+        if (certificateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(certificateId));
+        }
+
+        if (_adminClient is not null) {
+            using var stream = await _adminClient
+                .CollectAsync(certificateId, format, cancellationToken)
+                .ConfigureAwait(false);
+            return Models.Certificate.FromBase64(stream);
+        }
+
+        if (_legacyClient is not null) {
+            return await _legacyClient
+                .DownloadAsync(certificateId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException("No underlying client is configured for CertificateService.");
+    }
+
+    /// <summary>
+    /// Creates a keystore download link for a certificate using the Admin API.
+    /// </summary>
+    /// <param name="certificateId">Identifier of the certificate.</param>
+    /// <param name="formatType">
+    /// Keystore format type as defined by the Admin API (for example, <c>key</c>, <c>p12</c>, <c>p12aes</c>, <c>jks</c>, <c>pem</c>).
+    /// </param>
+    /// <param name="passphrase">Optional passphrase used to protect the keystore.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>A keystore download link.</returns>
+    /// <remarks>
+    /// This operation is only supported when the service is configured with an Admin API configuration.
+    /// When configured with a legacy API configuration, a <see cref="NotSupportedException"/> is thrown.
+    /// </remarks>
+    public async Task<string> CreateKeystoreDownloadLinkAsync(
+        int certificateId,
+        string formatType,
+        string? passphrase = null,
+        CancellationToken cancellationToken = default) {
+        if (certificateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(certificateId));
+        }
+
+        if (string.IsNullOrWhiteSpace(formatType)) {
+            throw new ArgumentException("Format type cannot be null or empty.", nameof(formatType));
+        }
+
+        if (_adminClient is not null) {
+            return await _adminClient
+                .CreateKeystoreLinkAsync(certificateId, formatType, passphrase, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (_legacyClient is not null) {
+            throw new NotSupportedException("Keystore download is only supported when using the Admin Operations API configuration.");
+        }
+
+        throw new InvalidOperationException("No underlying client is configured for CertificateService.");
+    }
+
+    /// <summary>
+    /// Creates a keystore download link for a certificate using the Admin API.
+    /// </summary>
+    /// <param name="certificateId">Identifier of the certificate.</param>
+    /// <param name="formatType">Keystore format type.</param>
+    /// <param name="passphrase">Optional passphrase used to protect the keystore.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public Task<string> CreateKeystoreDownloadLinkAsync(
+        int certificateId,
+        KeystoreFormatType formatType,
+        string? passphrase = null,
+        CancellationToken cancellationToken = default) {
+        return CreateKeystoreDownloadLinkAsync(certificateId, MapKeystoreFormat(formatType), passphrase, cancellationToken);
+    }
+
+    private static DateTimeOffset? ParseDate(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        if (DateTimeOffset.TryParse(value, out var dto)) {
+            return dto;
+        }
+
+        return null;
+    }
+
+    private static string RemoveUsageSeparators(string value) {
+        // Normalize common spelling variations (for example, "Non-Repudiation" and "Non Repudiation")
+        // so they map to the same canonical token.
+        return value.Replace(" ", string.Empty).Replace("-", string.Empty);
+    }
+
+    private static string? NormalizeKeyUsage(IReadOnlyList<string>? values) {
+        if (values == null || values.Count == 0) {
+            return null;
+        }
+
+        var normalized = new List<string>(values.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string? raw in values) {
+            if (string.IsNullOrWhiteSpace(raw)) {
+                continue;
+            }
+
+            string token = raw.Trim();
+            string compact = RemoveUsageSeparators(token);
+
+            string label = compact.ToUpperInvariant() switch {
+                "DIGITALSIGNATURE" => "DigitalSignature",
+                "NONREPUDIATION" => "NonRepudiation",
+                "CONTENTCOMMITMENT" => "NonRepudiation",
+                "KEYENCIPHERMENT" => "KeyEncipherment",
+                "DATAENCIPHERMENT" => "DataEncipherment",
+                "KEYAGREEMENT" => "KeyAgreement",
+                "KEYCERTSIGN" => "CertificateSign",
+                "CERTIFICATESIGN" => "CertificateSign",
+                "CRLSIGN" => "CrlSign",
+                "ENCIPHERONLY" => "EncipherOnly",
+                "DECIPHERONLY" => "DecipherOnly",
+                _ => token
+            };
+
+            if (seen.Add(label)) {
+                normalized.Add(label);
+            }
+        }
+
+        return normalized.Count == 0 ? null : string.Join(", ", normalized);
+    }
+
+    private static string? NormalizeCommaList(IReadOnlyList<string>? values) {
+        if (values == null || values.Count == 0) {
+            return null;
+        }
+
+        var normalized = new List<string>(values.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string? raw in values) {
+            if (string.IsNullOrWhiteSpace(raw)) {
+                continue;
+            }
+
+            string token = raw.Trim();
+            if (seen.Add(token)) {
+                normalized.Add(token);
+            }
+        }
+
+        return normalized.Count == 0 ? null : string.Join(", ", normalized);
+    }
+
+    private static string? BuildUsagePurposes(IReadOnlyList<string>? apiPurposes, IReadOnlyList<string>? extendedKeyUsages) {
+        var purposes = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        static void AddPurpose(List<string> output, HashSet<string> seenSet, string purpose) {
+            if (seenSet.Add(purpose)) {
+                output.Add(purpose);
+            }
+        }
+
+        if (apiPurposes != null) {
+            foreach (string? raw in apiPurposes) {
+                if (string.IsNullOrWhiteSpace(raw)) {
+                    continue;
+                }
+
+                string token = raw.Trim();
+                if (TryMapPurposeFromEku(token, out string purpose)) {
+                    AddPurpose(purposes, seen, purpose);
+                } else {
+                    AddPurpose(purposes, seen, token);
+                }
+            }
+        }
+
+        if (extendedKeyUsages != null) {
+            foreach (string? raw in extendedKeyUsages) {
+                if (string.IsNullOrWhiteSpace(raw)) {
+                    continue;
+                }
+
+                if (TryMapPurposeFromEku(raw.Trim(), out string purpose)) {
+                    AddPurpose(purposes, seen, purpose);
+                }
+            }
+        }
+
+        return purposes.Count == 0 ? null : string.Join(", ", purposes);
+    }
+
+    private static bool TryMapPurposeFromEku(string ekuValue, out string purpose) {
+        if (s_usagePurposeByOid.TryGetValue(ekuValue, out purpose!)) {
+            return true;
+        }
+
+        string normalized = RemoveUsageSeparators(ekuValue);
+        purpose = normalized.ToUpperInvariant() switch {
+            "SERVERAUTHENTICATION" => "ServerAuth",
+            "CLIENTAUTHENTICATION" => "ClientAuth",
+            "CODESIGNING" => "CodeSigning",
+            "EMAILPROTECTION" => "EmailProtection",
+            "TIMESTAMPING" => "TimeStamping",
+            "OCSPSIGNING" => "OcspSigning",
+            "DOCUMENTSIGNING" => "DocumentSigning",
+            "ANYEXTENDEDKEYUSAGE" => "AnyEku",
+            _ => string.Empty
+        };
+
+        return !string.IsNullOrEmpty(purpose);
+    }
+
+    private static CertificateStatus ParseStatus(string? statusText) {
+        if (statusText == null) {
+            return CertificateStatus.Any;
+        }
+
+        if (statusText.Trim().Length == 0) {
+            return CertificateStatus.Any;
+        }
+
+        string normalized = statusText.Replace(" ", string.Empty);
+        return Enum.TryParse<CertificateStatus>(normalized, ignoreCase: true, out var status)
+            ? status
+            : CertificateStatus.Any;
+    }
+
+    private static RevocationReason MapRevocationReason(string? code) {
+        if (code == null) {
+            return RevocationReason.Unspecified;
+        }
+
+        var value = code.Trim();
+        if (value.Length == 0) {
+            return RevocationReason.Unspecified;
+        }
+
+        return value switch {
+            "0" => RevocationReason.Unspecified,
+            "1" => RevocationReason.KeyCompromise,
+            "2" => RevocationReason.CaCompromise,
+            "3" => RevocationReason.AffiliationChanged,
+            "4" => RevocationReason.Superseded,
+            "5" => RevocationReason.CessationOfOperation,
+            "6" => RevocationReason.CertificateHold,
+            "8" => RevocationReason.RemoveFromCrl,
+            "9" => RevocationReason.PrivilegeWithdrawn,
+            "10" => RevocationReason.AaCompromise,
+            _ => RevocationReason.Unspecified
+        };
+    }
+
+    private static string MapKeystoreFormat(KeystoreFormatType formatType) {
+        return formatType switch {
+            KeystoreFormatType.Key => "key",
+            KeystoreFormatType.P12 => "p12",
+            KeystoreFormatType.P12Aes => "p12aes",
+            KeystoreFormatType.Jks => "jks",
+            KeystoreFormatType.Pem => "pem",
+            _ => "p12"
+        };
+    }
+
+    private static string MapRevocationReasonToAdminCode(RevocationReason reason) {
+        return reason switch {
+            RevocationReason.KeyCompromise => "1",
+            RevocationReason.CaCompromise => "2",
+            RevocationReason.AffiliationChanged => "3",
+            RevocationReason.Superseded => "4",
+            RevocationReason.CessationOfOperation => "5",
+            RevocationReason.CertificateHold => "6",
+            RevocationReason.RemoveFromCrl => "8",
+            RevocationReason.PrivilegeWithdrawn => "9",
+            RevocationReason.AaCompromise => "10",
+            _ => "0"
+        };
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        (_ownedLegacyClient as IDisposable)?.Dispose();
+        _ownedAdminClient?.Dispose();
+    }
+
+    /// <summary>
+    /// Removes a certificate by identifier using the active API configuration.
+    /// </summary>
+    /// <param name="certificateId">Identifier of the certificate to remove.</param>
+    /// <param name="reasonCode">Optional revocation reason used when calling the Admin API.</param>
+    /// <param name="reason">Optional revocation reason text used when calling the Admin API.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task RemoveAsync(
+        int certificateId,
+        RevocationReason reasonCode = RevocationReason.Unspecified,
+        string? reason = null,
+        CancellationToken cancellationToken = default) {
+        if (certificateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(certificateId));
+        }
+
+        if (_adminClient is not null) {
+            var code = MapRevocationReasonToAdminCode(reasonCode);
+            await _adminClient.RevokeByIdAsync(certificateId, code, reason, cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        if (_legacyClient is not null) {
+            await _legacyClient.DeleteAsync(certificateId, cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        throw new InvalidOperationException("No underlying client is configured for CertificateService.");
+    }
+
+    /// <summary>
+    /// Renews a certificate by identifier and returns the new certificate identifier.
+    /// </summary>
+    /// <param name="certificateId">Identifier of the certificate to renew.</param>
+    /// <param name="request">Renewal request payload.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task<int> RenewByIdAsync(
+        int certificateId,
+        RenewCertificateRequest request,
+        CancellationToken cancellationToken = default) {
+        Guard.AgainstNull(request, nameof(request));
+
+        if (certificateId <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(certificateId));
+        }
+
+        if (_adminClient is not null) {
+            return await _adminClient
+                .RenewByIdAsync(certificateId, request, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (_legacyClient is not null) {
+            return await _legacyClient
+                .RenewAsync(certificateId, request, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException("No underlying client is configured for CertificateService.");
+    }
+}

--- a/SectigoCertificateManager/CertificateService.cs
+++ b/SectigoCertificateManager/CertificateService.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 /// <summary>
 /// Provides a unified facade for certificate operations across legacy and Admin APIs.
 /// </summary>
-public sealed class CertificateService : IDisposable {
+public sealed partial class CertificateService : IDisposable {
     private static readonly Dictionary<string, string> s_usagePurposeByOid = new(StringComparer.OrdinalIgnoreCase) {
         ["1.3.6.1.5.5.7.3.1"] = "ServerAuth",
         ["1.3.6.1.5.5.7.3.2"] = "ClientAuth",
@@ -72,7 +72,8 @@ public sealed class CertificateService : IDisposable {
             _ownedAdminClient = new AdminSslClient(config);
             _adminClient = _ownedAdminClient;
         } else {
-            _adminClient = new AdminSslClient(config, httpClient);
+            _ownedAdminClient = new AdminSslClient(config, httpClient);
+            _adminClient = _ownedAdminClient;
         }
     }
 
@@ -140,12 +141,17 @@ public sealed class CertificateService : IDisposable {
         }
 
         if (_legacyClient is not null) {
-            var request = new CertificateSearchRequest { Size = size, Position = position };
+            var request = new CertificateSearchRequest {
+                Size = size,
+                Position = position,
+                OrgId = orgId,
+                Requester = requester
+            };
             if (status != CertificateStatus.Any) {
                 request.Status = status;
             }
             var response = await _legacyClient
-                .SearchAsync(request, cancellationToken)
+                .SearchPageAsync(request, cancellationToken)
                 .ConfigureAwait(false);
             return response?.Certificates ?? Array.Empty<Certificate>();
         }
@@ -370,57 +376,28 @@ public sealed class CertificateService : IDisposable {
                 break;
             }
 
-            using var semaphore = new SemaphoreSlim(maxConcurrency);
-            var tasks = new List<Task<Certificate?>>(identities.Count);
-
-            foreach (var identity in identities) {
-                if (maxCertificatesToScan is int scanLimit && scanLimit > 0 && scanned >= scanLimit) {
-                    break;
-                }
-
-                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                scanned++;
-
-                var idCopy = identity;
-                var task = Task.Run(async () => {
-                    try {
-                        AdminSslCertificateDetails? details = null;
-                        string? detailError = null;
-                        try {
-                            details = await _adminClient
-                                .GetAsync(idCopy.SslId, cancellationToken)
-                                .ConfigureAwait(false);
-                        } catch (ApiException ex) {
-                            detailError = ex.Message;
-                        } catch (HttpRequestException ex) {
-                            detailError = ex.Message;
-                        }
-
-                        var certificate = details is not null ? MapDetails(details) : MapIdentity(idCopy);
-                        if (detailError is not null) {
-                            certificate.IsAdminDetailFallback = true;
-                            certificate.AdminDetailError = detailError;
-                        }
-
-                        if (!ShouldIncludeByExpiry(certificate.Expires, cutoff, now)) {
-                            return null;
-                        }
-
-                        return (Certificate?)certificate;
-                    } finally {
-                        int current = Interlocked.Increment(ref completed);
-                        progress?.Report(current);
-                        semaphore.Release();
-                    }
-                }, cancellationToken);
-
-                tasks.Add(task);
+            var pageLimit = identities.Count;
+            if (maxCertificatesToScan is int remainingScanLimit && remainingScanLimit > 0) {
+                pageLimit = Math.Min(pageLimit, remainingScanLimit - scanned);
             }
 
-            var pageResults = await Task.WhenAll(tasks).ConfigureAwait(false);
-            foreach (var certificate in pageResults) {
-                if (certificate is not null) {
-                    result.Add(certificate);
+            for (var start = 0; start < pageLimit; start += maxConcurrency) {
+                cancellationToken.ThrowIfCancellationRequested();
+                var count = Math.Min(maxConcurrency, pageLimit - start);
+                var tasks = new Task<Certificate?>[count];
+                for (var index = 0; index < count; index++) {
+                    var identity = identities[start + index];
+                    scanned++;
+                    tasks[index] = FetchExpiringCertificateAsync(identity, cutoff, now, cancellationToken);
+                }
+
+                var batch = await Task.WhenAll(tasks).ConfigureAwait(false);
+                foreach (var certificate in batch) {
+                    var current = Interlocked.Increment(ref completed);
+                    progress?.Report(current);
+                    if (certificate is not null) {
+                        result.Add(certificate);
+                    }
                 }
             }
 
@@ -432,6 +409,34 @@ public sealed class CertificateService : IDisposable {
         }
 
         return result;
+    }
+
+    private async Task<Certificate?> FetchExpiringCertificateAsync(
+        AdminSslIdentity identity,
+        DateTimeOffset cutoff,
+        DateTimeOffset now,
+        CancellationToken cancellationToken) {
+        AdminSslCertificateDetails? details = null;
+        string? detailError = null;
+        try {
+            details = await _adminClient!
+                .GetAsync(identity.SslId, cancellationToken)
+                .ConfigureAwait(false);
+        } catch (ApiException ex) {
+            detailError = ex.Message;
+        } catch (HttpRequestException ex) {
+            detailError = ex.Message;
+        } catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested) {
+            detailError = ex.Message;
+        }
+
+        var certificate = details is not null ? MapDetails(details) : MapIdentity(identity);
+        if (detailError is not null) {
+            certificate.IsAdminDetailFallback = true;
+            certificate.AdminDetailError = detailError;
+        }
+
+        return ShouldIncludeByExpiry(certificate.Expires, cutoff, now) ? certificate : null;
     }
 
     private static bool ShouldIncludeByExpiry(
@@ -692,364 +697,4 @@ public sealed class CertificateService : IDisposable {
         throw new InvalidOperationException("No underlying client is configured for CertificateService.");
     }
 
-    /// <summary>
-    /// Downloads an issued certificate and returns an <see cref="System.Security.Cryptography.X509Certificates.X509Certificate2"/> instance.
-    /// </summary>
-    /// <param name="certificateId">Identifier of the certificate.</param>
-    /// <param name="format">
-    /// Optional format parameter for Admin API downloads. When <c>null</c>, the API default (<c>base64</c>) is used.
-    /// Ignored for legacy API calls, which always request base64.
-    /// </param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    public async Task<System.Security.Cryptography.X509Certificates.X509Certificate2> DownloadCertificateAsync(
-        int certificateId,
-        string? format = null,
-        CancellationToken cancellationToken = default) {
-        if (certificateId <= 0) {
-            throw new ArgumentOutOfRangeException(nameof(certificateId));
-        }
-
-        if (_adminClient is not null) {
-            using var stream = await _adminClient
-                .CollectAsync(certificateId, format, cancellationToken)
-                .ConfigureAwait(false);
-            return Models.Certificate.FromBase64(stream);
-        }
-
-        if (_legacyClient is not null) {
-            return await _legacyClient
-                .DownloadAsync(certificateId, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        throw new InvalidOperationException("No underlying client is configured for CertificateService.");
-    }
-
-    /// <summary>
-    /// Creates a keystore download link for a certificate using the Admin API.
-    /// </summary>
-    /// <param name="certificateId">Identifier of the certificate.</param>
-    /// <param name="formatType">
-    /// Keystore format type as defined by the Admin API (for example, <c>key</c>, <c>p12</c>, <c>p12aes</c>, <c>jks</c>, <c>pem</c>).
-    /// </param>
-    /// <param name="passphrase">Optional passphrase used to protect the keystore.</param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>A keystore download link.</returns>
-    /// <remarks>
-    /// This operation is only supported when the service is configured with an Admin API configuration.
-    /// When configured with a legacy API configuration, a <see cref="NotSupportedException"/> is thrown.
-    /// </remarks>
-    public async Task<string> CreateKeystoreDownloadLinkAsync(
-        int certificateId,
-        string formatType,
-        string? passphrase = null,
-        CancellationToken cancellationToken = default) {
-        if (certificateId <= 0) {
-            throw new ArgumentOutOfRangeException(nameof(certificateId));
-        }
-
-        if (string.IsNullOrWhiteSpace(formatType)) {
-            throw new ArgumentException("Format type cannot be null or empty.", nameof(formatType));
-        }
-
-        if (_adminClient is not null) {
-            return await _adminClient
-                .CreateKeystoreLinkAsync(certificateId, formatType, passphrase, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        if (_legacyClient is not null) {
-            throw new NotSupportedException("Keystore download is only supported when using the Admin Operations API configuration.");
-        }
-
-        throw new InvalidOperationException("No underlying client is configured for CertificateService.");
-    }
-
-    /// <summary>
-    /// Creates a keystore download link for a certificate using the Admin API.
-    /// </summary>
-    /// <param name="certificateId">Identifier of the certificate.</param>
-    /// <param name="formatType">Keystore format type.</param>
-    /// <param name="passphrase">Optional passphrase used to protect the keystore.</param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    public Task<string> CreateKeystoreDownloadLinkAsync(
-        int certificateId,
-        KeystoreFormatType formatType,
-        string? passphrase = null,
-        CancellationToken cancellationToken = default) {
-        return CreateKeystoreDownloadLinkAsync(certificateId, MapKeystoreFormat(formatType), passphrase, cancellationToken);
-    }
-
-    private static DateTimeOffset? ParseDate(string? value) {
-        if (string.IsNullOrWhiteSpace(value)) {
-            return null;
-        }
-
-        if (DateTimeOffset.TryParse(value, out var dto)) {
-            return dto;
-        }
-
-        return null;
-    }
-
-    private static string RemoveUsageSeparators(string value) {
-        // Normalize common spelling variations (for example, "Non-Repudiation" and "Non Repudiation")
-        // so they map to the same canonical token.
-        return value.Replace(" ", string.Empty).Replace("-", string.Empty);
-    }
-
-    private static string? NormalizeKeyUsage(IReadOnlyList<string>? values) {
-        if (values == null || values.Count == 0) {
-            return null;
-        }
-
-        var normalized = new List<string>(values.Count);
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (string? raw in values) {
-            if (string.IsNullOrWhiteSpace(raw)) {
-                continue;
-            }
-
-            string token = raw.Trim();
-            string compact = RemoveUsageSeparators(token);
-
-            string label = compact.ToUpperInvariant() switch {
-                "DIGITALSIGNATURE" => "DigitalSignature",
-                "NONREPUDIATION" => "NonRepudiation",
-                "CONTENTCOMMITMENT" => "NonRepudiation",
-                "KEYENCIPHERMENT" => "KeyEncipherment",
-                "DATAENCIPHERMENT" => "DataEncipherment",
-                "KEYAGREEMENT" => "KeyAgreement",
-                "KEYCERTSIGN" => "CertificateSign",
-                "CERTIFICATESIGN" => "CertificateSign",
-                "CRLSIGN" => "CrlSign",
-                "ENCIPHERONLY" => "EncipherOnly",
-                "DECIPHERONLY" => "DecipherOnly",
-                _ => token
-            };
-
-            if (seen.Add(label)) {
-                normalized.Add(label);
-            }
-        }
-
-        return normalized.Count == 0 ? null : string.Join(", ", normalized);
-    }
-
-    private static string? NormalizeCommaList(IReadOnlyList<string>? values) {
-        if (values == null || values.Count == 0) {
-            return null;
-        }
-
-        var normalized = new List<string>(values.Count);
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (string? raw in values) {
-            if (string.IsNullOrWhiteSpace(raw)) {
-                continue;
-            }
-
-            string token = raw.Trim();
-            if (seen.Add(token)) {
-                normalized.Add(token);
-            }
-        }
-
-        return normalized.Count == 0 ? null : string.Join(", ", normalized);
-    }
-
-    private static string? BuildUsagePurposes(IReadOnlyList<string>? apiPurposes, IReadOnlyList<string>? extendedKeyUsages) {
-        var purposes = new List<string>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        static void AddPurpose(List<string> output, HashSet<string> seenSet, string purpose) {
-            if (seenSet.Add(purpose)) {
-                output.Add(purpose);
-            }
-        }
-
-        if (apiPurposes != null) {
-            foreach (string? raw in apiPurposes) {
-                if (string.IsNullOrWhiteSpace(raw)) {
-                    continue;
-                }
-
-                string token = raw.Trim();
-                if (TryMapPurposeFromEku(token, out string purpose)) {
-                    AddPurpose(purposes, seen, purpose);
-                } else {
-                    AddPurpose(purposes, seen, token);
-                }
-            }
-        }
-
-        if (extendedKeyUsages != null) {
-            foreach (string? raw in extendedKeyUsages) {
-                if (string.IsNullOrWhiteSpace(raw)) {
-                    continue;
-                }
-
-                if (TryMapPurposeFromEku(raw.Trim(), out string purpose)) {
-                    AddPurpose(purposes, seen, purpose);
-                }
-            }
-        }
-
-        return purposes.Count == 0 ? null : string.Join(", ", purposes);
-    }
-
-    private static bool TryMapPurposeFromEku(string ekuValue, out string purpose) {
-        if (s_usagePurposeByOid.TryGetValue(ekuValue, out purpose!)) {
-            return true;
-        }
-
-        string normalized = RemoveUsageSeparators(ekuValue);
-        purpose = normalized.ToUpperInvariant() switch {
-            "SERVERAUTHENTICATION" => "ServerAuth",
-            "CLIENTAUTHENTICATION" => "ClientAuth",
-            "CODESIGNING" => "CodeSigning",
-            "EMAILPROTECTION" => "EmailProtection",
-            "TIMESTAMPING" => "TimeStamping",
-            "OCSPSIGNING" => "OcspSigning",
-            "DOCUMENTSIGNING" => "DocumentSigning",
-            "ANYEXTENDEDKEYUSAGE" => "AnyEku",
-            _ => string.Empty
-        };
-
-        return !string.IsNullOrEmpty(purpose);
-    }
-
-    private static CertificateStatus ParseStatus(string? statusText) {
-        if (statusText == null) {
-            return CertificateStatus.Any;
-        }
-
-        if (statusText.Trim().Length == 0) {
-            return CertificateStatus.Any;
-        }
-
-        string normalized = statusText.Replace(" ", string.Empty);
-        return Enum.TryParse<CertificateStatus>(normalized, ignoreCase: true, out var status)
-            ? status
-            : CertificateStatus.Any;
-    }
-
-    private static RevocationReason MapRevocationReason(string? code) {
-        if (code == null) {
-            return RevocationReason.Unspecified;
-        }
-
-        var value = code.Trim();
-        if (value.Length == 0) {
-            return RevocationReason.Unspecified;
-        }
-
-        return value switch {
-            "0" => RevocationReason.Unspecified,
-            "1" => RevocationReason.KeyCompromise,
-            "2" => RevocationReason.CaCompromise,
-            "3" => RevocationReason.AffiliationChanged,
-            "4" => RevocationReason.Superseded,
-            "5" => RevocationReason.CessationOfOperation,
-            "6" => RevocationReason.CertificateHold,
-            "8" => RevocationReason.RemoveFromCrl,
-            "9" => RevocationReason.PrivilegeWithdrawn,
-            "10" => RevocationReason.AaCompromise,
-            _ => RevocationReason.Unspecified
-        };
-    }
-
-    private static string MapKeystoreFormat(KeystoreFormatType formatType) {
-        return formatType switch {
-            KeystoreFormatType.Key => "key",
-            KeystoreFormatType.P12 => "p12",
-            KeystoreFormatType.P12Aes => "p12aes",
-            KeystoreFormatType.Jks => "jks",
-            KeystoreFormatType.Pem => "pem",
-            _ => "p12"
-        };
-    }
-
-    private static string MapRevocationReasonToAdminCode(RevocationReason reason) {
-        return reason switch {
-            RevocationReason.KeyCompromise => "1",
-            RevocationReason.CaCompromise => "2",
-            RevocationReason.AffiliationChanged => "3",
-            RevocationReason.Superseded => "4",
-            RevocationReason.CessationOfOperation => "5",
-            RevocationReason.CertificateHold => "6",
-            RevocationReason.RemoveFromCrl => "8",
-            RevocationReason.PrivilegeWithdrawn => "9",
-            RevocationReason.AaCompromise => "10",
-            _ => "0"
-        };
-    }
-
-    /// <inheritdoc />
-    public void Dispose() {
-        (_ownedLegacyClient as IDisposable)?.Dispose();
-        _ownedAdminClient?.Dispose();
-    }
-
-    /// <summary>
-    /// Removes a certificate by identifier using the active API configuration.
-    /// </summary>
-    /// <param name="certificateId">Identifier of the certificate to remove.</param>
-    /// <param name="reasonCode">Optional revocation reason used when calling the Admin API.</param>
-    /// <param name="reason">Optional revocation reason text used when calling the Admin API.</param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    public async Task RemoveAsync(
-        int certificateId,
-        RevocationReason reasonCode = RevocationReason.Unspecified,
-        string? reason = null,
-        CancellationToken cancellationToken = default) {
-        if (certificateId <= 0) {
-            throw new ArgumentOutOfRangeException(nameof(certificateId));
-        }
-
-        if (_adminClient is not null) {
-            var code = MapRevocationReasonToAdminCode(reasonCode);
-            await _adminClient.RevokeByIdAsync(certificateId, code, reason, cancellationToken)
-                .ConfigureAwait(false);
-            return;
-        }
-
-        if (_legacyClient is not null) {
-            await _legacyClient.DeleteAsync(certificateId, cancellationToken)
-                .ConfigureAwait(false);
-            return;
-        }
-
-        throw new InvalidOperationException("No underlying client is configured for CertificateService.");
-    }
-
-    /// <summary>
-    /// Renews a certificate by identifier and returns the new certificate identifier.
-    /// </summary>
-    /// <param name="certificateId">Identifier of the certificate to renew.</param>
-    /// <param name="request">Renewal request payload.</param>
-    /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    public async Task<int> RenewByIdAsync(
-        int certificateId,
-        RenewCertificateRequest request,
-        CancellationToken cancellationToken = default) {
-        Guard.AgainstNull(request, nameof(request));
-
-        if (certificateId <= 0) {
-            throw new ArgumentOutOfRangeException(nameof(certificateId));
-        }
-
-        if (_adminClient is not null) {
-            return await _adminClient
-                .RenewByIdAsync(certificateId, request, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        if (_legacyClient is not null) {
-            return await _legacyClient
-                .RenewAsync(certificateId, request, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        throw new InvalidOperationException("No underlying client is configured for CertificateService.");
-    }
 }

--- a/SectigoCertificateManager/CertificateStatus.cs
+++ b/SectigoCertificateManager/CertificateStatus.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 /// <summary>
 /// Enumerates statuses for certificates.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(CertificateStatusJsonConverter))]
 public enum CertificateStatus {
     /// <summary>Any status.</summary>
     Any = 0,
@@ -14,44 +14,53 @@ public enum CertificateStatus {
     Requested = 1,
 
     /// <summary>The certificate has been approved.</summary>
-    Approved = 8,
+    Approved = 3,
 
     /// <summary>The certificate request was applied.</summary>
-    Applied = 9,
+    Applied = 4,
 
     /// <summary>The certificate has been issued.</summary>
     Issued = 2,
 
     /// <summary>The certificate request was declined.</summary>
-    Declined,
+    Declined = 5,
 
     /// <summary>The certificate was downloaded. Deprecated.</summary>
-    Downloaded,
+    Downloaded = 6,
 
     /// <summary>The certificate request was rejected.</summary>
-    Rejected,
+    Rejected = 7,
 
     /// <summary>The certificate awaits approval. Deprecated.</summary>
-    AwaitingApproval,
+    AwaitingApproval = 8,
 
     /// <summary>The certificate status is invalid.</summary>
-    Invalid,
+    Invalid = 9,
 
     /// <summary>The certificate was replaced.</summary>
-    Replaced,
+    Replaced = 10,
 
     /// <summary>Certificate is unmanaged. Deprecated.</summary>
-    Unmanaged,
+    Unmanaged = 11,
 
     /// <summary>The certificate was approved by system administrator.</summary>
-    SAApproved,
+    SAApproved = 12,
 
     /// <summary>The certificate request was initialized.</summary>
-    Init,
+    Init = 13,
 
     /// <summary>The certificate has been revoked.</summary>
-    Revoked = 3,
+    Revoked = 14,
 
     /// <summary>The certificate has expired.</summary>
-    Expired = 4
+    Expired = 15,
+
+    /// <summary>The certificate is enrolled and waiting to be downloaded.</summary>
+    EnrolledPendingDownload = 16,
+
+    /// <summary>The certificate subject has not been enrolled.</summary>
+    NotEnrolled = 17,
+
+    /// <summary>The certificate was registered as external. Deprecated.</summary>
+    External = 18
 }

--- a/SectigoCertificateManager/CertificateStatusJsonConverter.cs
+++ b/SectigoCertificateManager/CertificateStatusJsonConverter.cs
@@ -1,0 +1,53 @@
+namespace SectigoCertificateManager;
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Preserves legacy numeric wire codes while exposing unique status values to callers.
+/// </summary>
+public sealed class CertificateStatusJsonConverter : JsonConverter<CertificateStatus> {
+    /// <inheritdoc />
+    public override CertificateStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+        if (reader.TokenType == JsonTokenType.String) {
+            string? value = reader.GetString();
+            if (int.TryParse(value, out int numericCode)) {
+                return FromLegacyNumericCode(numericCode);
+            }
+
+            if (Enum.TryParse(value, ignoreCase: true, out CertificateStatus status)) {
+                return status;
+            }
+
+            throw new JsonException($"Unknown certificate status '{value}'.");
+        }
+
+        if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out int code)) {
+            return FromLegacyNumericCode(code);
+        }
+
+        throw new JsonException("Certificate status must be a string name or legacy numeric code.");
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, CertificateStatus value, JsonSerializerOptions options) {
+        writer.WriteStringValue(value.ToString());
+    }
+
+    private static CertificateStatus FromLegacyNumericCode(int code) => code switch {
+        0 => CertificateStatus.Any,
+        1 => CertificateStatus.Requested,
+        2 => CertificateStatus.Issued,
+        3 => CertificateStatus.Revoked,
+        4 => CertificateStatus.Expired,
+        5 => CertificateStatus.EnrolledPendingDownload,
+        6 => CertificateStatus.NotEnrolled,
+        7 => CertificateStatus.AwaitingApproval,
+        8 => CertificateStatus.Approved,
+        9 => CertificateStatus.Applied,
+        10 => CertificateStatus.Downloaded,
+        11 => CertificateStatus.External,
+        _ => throw new JsonException($"Unknown numeric certificate status '{code}'.")
+    };
+}

--- a/SectigoCertificateManager/Clients/CertificatesClient.Import.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Import.cs
@@ -26,8 +26,8 @@ public sealed partial class CertificatesClient : BaseClient {
         Guard.AgainstNull(stream, nameof(stream));
         Guard.AgainstNullOrEmpty(fileName, nameof(fileName), "File name cannot be null or empty.");
 
-        var content = new MultipartFormDataContent();
-        var fileContent = new StreamContent(stream);
+        using var content = new MultipartFormDataContent();
+        var fileContent = new ProgressStreamContent(stream);
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
         content.Add(fileContent, "file", fileName);
 

--- a/SectigoCertificateManager/Clients/CertificatesClient.Import.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Import.cs
@@ -31,7 +31,7 @@ public sealed partial class CertificatesClient : BaseClient {
         fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
         content.Add(fileContent, "file", fileName);
 
-        var response = await _client.PostAsync($"v1/certificate/import?orgId={orgId}", content, cancellationToken).ConfigureAwait(false);
+        using var response = await _client.PostAsync($"v1/certificate/import?orgId={orgId}", content, cancellationToken).ConfigureAwait(false);
         return await response.Content
             .ReadFromJsonAsyncSafe<ImportCertificateResponse>(s_json, cancellationToken)
             .ConfigureAwait(false);

--- a/SectigoCertificateManager/Clients/CertificatesClient.Search.cs
+++ b/SectigoCertificateManager/Clients/CertificatesClient.Search.cs
@@ -27,6 +27,28 @@ public sealed partial class CertificatesClient : BaseClient {
     }
 
     /// <summary>
+    /// Retrieves exactly one page of certificates using the requested size and position.
+    /// </summary>
+    /// <param name="request">Filter and page boundaries to send to the API.</param>
+    /// <param name="cancellationToken">Token used to cancel the request.</param>
+    /// <returns>The page response, or <c>null</c> when the page is empty.</returns>
+    public async Task<CertificateResponse?> SearchPageAsync(
+        CertificateSearchRequest request,
+        CancellationToken cancellationToken = default) {
+        Guard.AgainstNull(request, nameof(request));
+
+        var query = BuildQuery(request);
+        using var response = await _client.GetAsync($"v1/certificate{query}", cancellationToken).ConfigureAwait(false);
+        var page = await response.Content
+            .ReadFromJsonAsyncSafe<IReadOnlyList<Certificate>>(s_json, cancellationToken)
+            .ConfigureAwait(false);
+
+        return page is null || page.Count == 0
+            ? null
+            : new CertificateResponse { Certificates = page };
+    }
+
+    /// <summary>
     /// Streams all certificates visible to the caller.
     /// </summary>
     /// <param name="pageSize">Number of certificates to request per page.</param>
@@ -126,13 +148,8 @@ public sealed partial class CertificatesClient : BaseClient {
         var position = request.Position ?? 0;
 
         try {
-            var query = BuildQuery(request);
-            IReadOnlyList<Certificate>? page;
-            using (var response = await _client.GetAsync($"v1/certificate{query}", cancellationToken).ConfigureAwait(false)) {
-                page = await response.Content
-                    .ReadFromJsonAsyncSafe<IReadOnlyList<Certificate>>(s_json, cancellationToken)
-                    .ConfigureAwait(false);
-            }
+            var response = await SearchPageAsync(request, cancellationToken).ConfigureAwait(false);
+            IReadOnlyList<Certificate>? page = response?.Certificates;
             if (page is null || page.Count == 0) {
                 yield break;
             }
@@ -150,11 +167,8 @@ public sealed partial class CertificatesClient : BaseClient {
 
             while (true) {
                 request.Position = position;
-                query = BuildQuery(request);
-                using var response = await _client.GetAsync($"v1/certificate{query}", cancellationToken).ConfigureAwait(false);
-                page = await response.Content
-                    .ReadFromJsonAsyncSafe<IReadOnlyList<Certificate>>(s_json, cancellationToken)
-                    .ConfigureAwait(false);
+                response = await SearchPageAsync(request, cancellationToken).ConfigureAwait(false);
+                page = response?.Certificates;
                 if (page is null || page.Count == 0) {
                     yield break;
                 }

--- a/SectigoCertificateManager/SectigoCertificateManager.csproj
+++ b/SectigoCertificateManager/SectigoCertificateManager.csproj
@@ -9,9 +9,9 @@
     </Description>
     <AssemblyName>SectigoCertificateManager</AssemblyName>
     <AssemblyTitle>SectigoCertificateManager</AssemblyTitle>
-    <VersionPrefix>0.2.0</VersionPrefix>
-    <AssemblyVersion>0.2.0</AssemblyVersion>
-    <FileVersion>0.2.0</FileVersion>
+    <VersionPrefix>0.3.0</VersionPrefix>
+    <AssemblyVersion>0.3.0</AssemblyVersion>
+    <FileVersion>0.3.0</FileVersion>
     <TargetFrameworks>net472;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/SectigoCertificateManager/SectigoClient.cs
+++ b/SectigoCertificateManager/SectigoClient.cs
@@ -8,12 +8,15 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using SectigoCertificateManager.AdminApi;
+using SectigoCertificateManager.Utilities;
 
 /// <summary>
 /// Provides a basic HTTP client wrapper for communicating with the Sectigo API.
 /// </summary>
 public sealed class SectigoClient : ISectigoClient, IDisposable {
     private readonly HttpClient _client;
+    private readonly bool _ownsHttpClient;
     private readonly Func<CancellationToken, Task<TokenInfo>>? _refreshToken;
     private readonly SemaphoreSlim _refreshLock = new(1, 1);
     private readonly SemaphoreSlim? _throttle;
@@ -56,6 +59,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
 
             config.ConfigureHandler?.Invoke(handler);
             httpClient = new HttpClient(handler);
+            _ownsHttpClient = true;
         }
 
         _client = httpClient;
@@ -89,9 +93,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
             await _throttle.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
         try {
-            var response = await SendWithRetryAsync(ct => _client.GetAsync(requestUri, ct), cancellationToken).ConfigureAwait(false);
-            await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
-            return response;
+            return await SendCheckedAsync(HttpMethod.Get, requestUri, content: null, cancellationToken).ConfigureAwait(false);
         } finally {
             _throttle?.Release();
         }
@@ -110,9 +112,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
             await _throttle.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
         try {
-            var response = await SendWithRetryAsync(ct => _client.PostAsync(requestUri, content, ct), cancellationToken).ConfigureAwait(false);
-            await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
-            return response;
+            return await SendCheckedAsync(HttpMethod.Post, requestUri, content, cancellationToken).ConfigureAwait(false);
         } finally {
             _throttle?.Release();
         }
@@ -131,9 +131,7 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
             await _throttle.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
         try {
-            var response = await SendWithRetryAsync(ct => _client.PutAsync(requestUri, content, ct), cancellationToken).ConfigureAwait(false);
-            await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
-            return response;
+            return await SendCheckedAsync(HttpMethod.Put, requestUri, content, cancellationToken).ConfigureAwait(false);
         } finally {
             _throttle?.Release();
         }
@@ -151,21 +149,79 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
             await _throttle.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
         try {
-            var response = await SendWithRetryAsync(ct => _client.DeleteAsync(requestUri, ct), cancellationToken).ConfigureAwait(false);
-            await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
-            return response;
+            return await SendCheckedAsync(HttpMethod.Delete, requestUri, content: null, cancellationToken).ConfigureAwait(false);
         } finally {
             _throttle?.Release();
         }
     }
 
+    private async Task<HttpResponseMessage> SendCheckedAsync(
+        HttpMethod method,
+        string requestUri,
+        HttpContent? content,
+        CancellationToken cancellationToken) {
+        if (!RequestSnapshot.CanReplaySafely(method, content)) {
+            return await SendCheckedOnceAsync(method, requestUri, content, cancellationToken).ConfigureAwait(false);
+        }
+
+        var snapshot = await CreateSnapshotAsync(method, requestUri, content).ConfigureAwait(false);
+        return await SendCheckedAsync(snapshot, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<HttpResponseMessage> SendCheckedAsync(
+        RequestSnapshot snapshot,
+        CancellationToken cancellationToken) {
+        var response = await SendWithRetryAsync(snapshot, cancellationToken).ConfigureAwait(false);
+        try {
+            await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+            return response;
+        } catch {
+            response.Dispose();
+            throw;
+        }
+    }
+
+    private async Task<HttpResponseMessage> SendCheckedOnceAsync(
+        HttpMethod method,
+        string requestUri,
+        HttpContent? content,
+        CancellationToken cancellationToken) {
+        using var request = new HttpRequestMessage(method, requestUri) {
+            Content = content is null ? null : new NonDisposingHttpContent(content)
+        };
+        HttpResponseMessage response = await _client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        try {
+            await ApiErrorHandler.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+            return response;
+        } catch {
+            response.Dispose();
+            throw;
+        }
+    }
+
     private async Task<HttpResponseMessage> SendWithRetryAsync(
-        Func<CancellationToken, Task<HttpResponseMessage>> send,
+        RequestSnapshot snapshot,
         CancellationToken cancellationToken) {
         var attempt = 0;
         var delay = _retryInitialDelay;
         while (true) {
-            var response = await send(cancellationToken).ConfigureAwait(false);
+            HttpResponseMessage response;
+            try {
+                using var request = snapshot.CreateRequest();
+                response = await _client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            } catch (HttpRequestException) when (attempt < _retryCount - 1) {
+                await DelayBeforeRetryAsync(delay, cancellationToken).ConfigureAwait(false);
+                attempt++;
+                delay = TimeSpan.FromSeconds(delay.TotalSeconds * 2);
+                continue;
+            } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && attempt < _retryCount - 1) {
+                await DelayBeforeRetryAsync(delay, cancellationToken).ConfigureAwait(false);
+                attempt++;
+                delay = TimeSpan.FromSeconds(delay.TotalSeconds * 2);
+                continue;
+            }
+
             var status = (int)response.StatusCode;
             var retryable = status == 429 || (status >= 500 && status < 600 && response.StatusCode != HttpStatusCode.NotImplemented);
             if (!retryable || attempt >= _retryCount - 1) {
@@ -187,25 +243,41 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
 
             response.Dispose();
 
-            if (DelayAsync is null) {
-                await Task.Delay(wait, cancellationToken).ConfigureAwait(false);
-            } else {
-                await DelayAsync(wait, cancellationToken).ConfigureAwait(false);
-            }
+            await DelayBeforeRetryAsync(wait, cancellationToken).ConfigureAwait(false);
 
             attempt++;
             delay = TimeSpan.FromSeconds(delay.TotalSeconds * 2);
         }
     }
 
+    private Task DelayBeforeRetryAsync(TimeSpan delay, CancellationToken cancellationToken) =>
+        DelayAsync is null ? Task.Delay(delay, cancellationToken) : DelayAsync(delay, cancellationToken);
+
+    private static async Task<RequestSnapshot> CreateSnapshotAsync(
+        HttpMethod method,
+        string requestUri,
+        HttpContent? content) {
+        using var request = new HttpRequestMessage(method, requestUri);
+        request.Content = content;
+        var snapshot = await RequestSnapshot.CreateAsync(request).ConfigureAwait(false);
+        request.Content = null;
+        return snapshot;
+    }
+
     private void ConfigureHeaders(ApiConfig cfg) {
-        _client.DefaultRequestHeaders.Clear();
-        _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        if (!_client.DefaultRequestHeaders.Accept.Any(static value =>
+            string.Equals(value.MediaType, "application/json", StringComparison.OrdinalIgnoreCase))) {
+            _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        }
+        _client.DefaultRequestHeaders.Remove("customerUri");
+        _client.DefaultRequestHeaders.Remove("login");
+        _client.DefaultRequestHeaders.Remove("password");
         _client.DefaultRequestHeaders.Add("customerUri", cfg.CustomerUri);
 
         if (cfg.Token is not null && cfg.Token.Length > 0) {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", cfg.Token);
         } else {
+            _client.DefaultRequestHeaders.Authorization = null;
             _client.DefaultRequestHeaders.Add("login", cfg.Username);
             _client.DefaultRequestHeaders.Add("password", cfg.Password);
         }
@@ -248,7 +320,9 @@ public sealed class SectigoClient : ISectigoClient, IDisposable {
             return;
         }
 
-        _client.Dispose();
+        if (_ownsHttpClient) {
+            _client.Dispose();
+        }
         _refreshLock.Dispose();
         _throttle?.Dispose();
         _disposed = true;

--- a/SectigoCertificateManager/Utilities/NonDisposingHttpContent.cs
+++ b/SectigoCertificateManager/Utilities/NonDisposingHttpContent.cs
@@ -1,0 +1,42 @@
+namespace SectigoCertificateManager.Utilities;
+
+using System.Net;
+using System.Net.Http;
+
+/// <summary>
+/// Delegates HTTP serialization without taking ownership of the wrapped content.
+/// </summary>
+internal sealed class NonDisposingHttpContent : HttpContent {
+    private readonly HttpContent _inner;
+
+    /// <summary>
+    /// Initializes a wrapper that preserves the caller's ownership of <paramref name="inner"/>.
+    /// </summary>
+    public NonDisposingHttpContent(HttpContent inner) {
+        _inner = Guard.AgainstNull(inner, nameof(inner));
+        foreach (var header in inner.Headers) {
+            Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+    }
+
+#if NET5_0_OR_GREATER
+    protected override Task SerializeToStreamAsync(
+        Stream stream,
+        TransportContext? context,
+        CancellationToken cancellationToken) =>
+        _inner.CopyToAsync(stream, context, cancellationToken);
+#endif
+
+    protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+        _inner.CopyToAsync(stream);
+
+    protected override bool TryComputeLength(out long length) {
+        if (_inner.Headers.ContentLength is long contentLength) {
+            length = contentLength;
+            return true;
+        }
+
+        length = 0;
+        return false;
+    }
+}

--- a/SectigoCertificateManager/Utilities/ProgressStreamContent.cs
+++ b/SectigoCertificateManager/Utilities/ProgressStreamContent.cs
@@ -46,7 +46,7 @@ internal sealed class ProgressStreamContent : HttpContent {
 
     private async Task TransferToAsync(Stream target, CancellationToken cancellationToken) {
         var buffer = new byte[_bufferSize];
-        long total = _stream.CanSeek ? _stream.Length : -1;
+        long total = _stream.CanSeek ? _stream.Length - _stream.Position : -1;
         long uploaded = 0;
         int read;
         while (true) {
@@ -76,7 +76,7 @@ internal sealed class ProgressStreamContent : HttpContent {
 
     protected override bool TryComputeLength(out long length) {
         if (_stream.CanSeek) {
-            length = _stream.Length;
+            length = _stream.Length - _stream.Position;
             return true;
         }
 


### PR DESCRIPTION
## Summary

- expose unique CertificateStatus values while preserving the documented SCM 25.5 numeric wire table, including numeric strings
- represent enrolled-pending-download, not-enrolled, awaiting-approval, downloaded, and external legacy states without aliasing unrelated enum values
- preserve legacy paging and organization/requester filters
- retry only replay-safe, idempotent Admin and legacy requests
- send mutation POSTs and streaming/multipart uploads once without pre-buffering
- preserve caller ownership of low-level HttpContent and upload streams across net472 and current .NET
- honor Retry-After for API and token throttling
- clear stale authorization when username/password authentication is selected
- make token-cache updates atomic and persist refreshes through explicit, environment, or default cache paths
- bound expiring-certificate detail concurrency and split the certificate facade by responsibility
- update the package to 0.3.0

## Compatibility

CertificateStatus has unique underlying values, while JSON names, documented legacy numeric tokens, and numeric strings remain compatible. Unknown numeric codes are rejected rather than cast to an unrelated status.

Non-idempotent operations are not replayed after ambiguous transport failures. Content created by higher-level clients is disposed, while caller-provided low-level content and streams remain caller-owned.

## Validation

The complete suite passes on .NET 8 and .NET Framework 4.7.2. The package targets net472, netstandard2.0, and .NET 8, 9, and 10.